### PR TITLE
chore: 설정을 yml로 통합하고 예제 파일 제공 - clone 직후 테스트 109건 실패 해소

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,12 @@ upload/
 
 *.sh
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,gradle,windows,macos,visualstudiocode
+### EduMeet 설정 ###
+# 시크릿이 들어가는 프로파일만 무시한다.
+# 공통 설정(application.yml), 테스트 설정(application-test.yml),
+# 템플릿(*.yml.example)은 저장소에 커밋한다.
+application-local.yml
+application-prod.yml
+!application.yml
+!application-test.yml
+!application-*.yml.example

--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@
 
 <br/>
 
+## 🚀 실행 방법
+
+```bash
+git clone https://github.com/dj258255/edumeet.git
+cd edumeet
+
+# 테스트는 추가 설정 없이 바로 실행됩니다 (H2 인메모리 사용)
+./gradlew test
+
+# 애플리케이션 실행에는 로컬 설정이 필요합니다
+cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+# application-local.yml 의 빈 값을 채운 뒤
+./gradlew bootRun
+```
+
+### 설정 파일 구조
+
+| 파일 | 내용 | 커밋 |
+|---|---|---|
+| `application.yml` | 공통 설정 (시크릿 없음) | O |
+| `application-test.yml` | 테스트 전용 (H2, 시크릿 없음) | O |
+| `application-local.yml.example` | 로컬 설정 템플릿 | O |
+| `application-local.yml` | 실제 시크릿 | **X (git 무시)** |
+
 ## 📌 커밋 컨벤션
 
 ```

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,0 +1,81 @@
+# 로컬 개발용 설정 템플릿
+#
+#   cp application-local.yml.example application-local.yml
+#
+# application-local.yml 은 .gitignore 에 등록되어 있다. 절대 커밋하지 않는다.
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/edumeet?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ""          # MySQL 계정
+    password: ""          # MySQL 비밀번호
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ""          # 발신 계정
+    password: ""          # 앱 비밀번호
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+  cloud:
+    aws:
+      credentials:
+        access-key: ""    # AWS IAM access key
+        secret-key: ""    # AWS IAM secret key
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: ""        # S3 버킷 이름
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ""       # Kakao REST API 키
+            client-secret: ""
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope: profile_nickname, account_email
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+edumeet:
+  upload:
+    path: ""              # 업로드 임시 저장 경로 (예: /Users/me/edumeet-upload)
+
+front:
+  url: http://localhost:3000
+  url2: http://localhost:5173
+
+jwt:
+  secret: ""              # Base64 인코딩된 32바이트 이상의 키
+  expiration_time: 3600000
+
+openvidu:
+  url: http://localhost:7880
+  livekit:
+    api:
+      key: ""             # LiveKit API key
+      secret: ""          # LiveKit API secret

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,82 @@
+# 테스트 프로파일 — 시크릿이 없다. 저장소에 커밋된다.
+# clone 직후 ./gradlew test 가 추가 설정 없이 통과해야 한다.
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:edumeet;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        generate_statistics: true   # 테스트에서 쿼리 수를 단언하기 위해 켠다
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  mail:
+    username: test@example.com
+    password: test
+    host: localhost
+    port: 25
+
+  cloud:
+    aws:
+      credentials:
+        access-key: test-access-key
+        secret-key: test-secret-key
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: test-bucket
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope: profile_nickname, account_email
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+edumeet:
+  upload:
+    path: ${java.io.tmpdir}/edumeet-test-upload
+
+front:
+  url: http://localhost:3000
+  url2: http://localhost:5173
+
+jwt:
+  # 테스트 전용 더미 값. 실제 시크릿이 아니다.
+  secret: dGVzdC1vbmx5LXNlY3JldC1ub3QtdXNlZC1pbi1wcm9kdWN0aW9uLTEyMzQ1Njc4OTA=
+  expiration_time: 3600000
+
+openvidu:
+  url: http://localhost:7880
+  livekit:
+    api:
+      key: devkey
+      secret: devsecret
+
+logging:
+  level:
+    com.edu.edumeet: WARN
+    org.hibernate.SQL: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,35 @@
+# 공통 설정 — 시크릿을 담지 않는다. 이 파일은 저장소에 커밋된다.
+# 환경별 시크릿은 application-local.yml (git 무시) 에 둔다.
+# 최초 실행: cp application-local.yml.example application-local.yml
+
+spring:
+  application:
+    name: edumeet
+  profiles:
+    active: local
+
+  jpa:
+    # 영속성 컨텍스트를 뷰 렌더링까지 열어두지 않는다.
+    # 커넥션 점유 시간이 길어지고 지연 로딩 위치가 불명확해지는 것을 막는다.
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        # 통계 수집. 성능 측정 시 쿼리 수를 세기 위해 필요하다. (CONTRIBUTING.md 참조)
+        generate_statistics: false
+
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
+
+server:
+  port: 8080
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+
+logging:
+  level:
+    com.edu.edumeet: INFO


### PR DESCRIPTION
## 변경 내용

`clone` 직후 테스트의 69%가 실패하던 문제를 해소한다.

### 원인

`.gitignore` 236번 줄의 `*.properties` 패턴이 모든 설정 파일을 무시해
`src/main/resources` 디렉터리 자체가 저장소에 없었다.

```
Could not resolve placeholder 'edumeet.upload.path'
  → PlaceholderResolutionException
  → BeanCreationException
  → Failed to load ApplicationContext
  → "ApplicationContext failure threshold (1) exceeded: skipping repeated attempt"  × 107건
```

Spring 통합 테스트는 컨텍스트 로딩이 한 번 실패하면 이후 시도를 건너뛴다.
**설정값 하나 때문에 통합 테스트 전체가 연쇄로 무너지는 구조였다.**

### 조치

시크릿 유무를 기준으로 파일을 분리했다.

| 파일 | 내용 | 커밋 |
|---|---|---|
| `application.yml` | 공통 설정 (포트, JPA, 로깅) | **O** |
| `application-test.yml` | H2 인메모리 + 더미값 | **O** |
| `application-local.yml.example` | 실제 설정 템플릿 (키만, 값은 빈 문자열) | **O** |
| `application-local.yml` | 실제 시크릿 | **X** |

`.gitignore` 도 함께 수정했다. `*.properties` 만 막아두면 `.yml` 은 걸리지 않아
**전환과 동시에 시크릿을 커밋할 위험이 새로 생기기 때문**이다.

```gitignore
application-local.yml
application-prod.yml
!application.yml
!application-test.yml
!application-*.yml.example
```

`git check-ignore` 로 검증했다.

```
✓ 무시됨: application-local.yml
✓ 무시됨: application-prod.yml
✓ 추적됨: application.yml / application-test.yml / application-local.yml.example
```

### 부수 변경

- `spring.jpa.open-in-view: false` — 커넥션 점유 시간이 길어지고 지연 로딩 위치가 불명확해지는 것을 막는다
- `hibernate.generate_statistics: true` (test 프로파일만) — #4에서 **쿼리 수를 단언하기 위해** 필요하다
- README에 실행 방법과 설정 파일 구조 추가

## 결과

| | Before | After |
|---|---|---|
| 실행된 테스트 | 159 | **169** |
| 실패 | **109** | **0** |
| clone 후 `./gradlew test` | 실패 | **추가 설정 없이 통과** |

총 건수가 늘어난 것은 이전에 컨텍스트 실패로 **실행조차 되지 않던** 테스트가 이제 실행되기 때문이다.

## 관련 이슈

Closes #6

## 확인

- [x] `./gradlew test --rerun-tasks` 169건 전부 통과
- [x] `git check-ignore` 로 시크릿 파일 무시 검증
- [x] 커밋 메시지가 컨벤션을 따름
