### PR TITLE
chore: Flyway 도입 - 자동 배포가 스키마 변경을 처리할 수 있게 (#29)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,11 @@ dependencies {
     // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-security")
 
+    // 스키마 마이그레이션. 운영은 ddl-auto=none 이라 스키마 변경 경로가 없었다. (#29)
+    // 평문 SQL 이라 DBA 리뷰와 수동 실행이 가능하다. 단일 DB(MySQL)라 Liquibase 의 추상화 이점이 없다.
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
+
     // Swagger (OpenAPI)
     // API Documentation(Swagger)
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
@@ -66,6 +71,11 @@ dependencies {
 
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    // 마이그레이션 검증은 진짜 MySQL 이어야 한다.
+    // H2 로는 engine=InnoDB, enum(...) 같은 MySQL 문법을 확인할 수 없다. (#29)
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:mysql")
+    testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -15,6 +15,10 @@ server:
   port: ${PERF_PORT:8081}
 
 spring:
+  # ddl-auto=create 로 매번 새로 만든다. (#29)
+  flyway:
+    enabled: false
+
   datasource:
     # PERF_DB_PORT=13307 로 두면 Toxiproxy 를 거쳐 MySQL 로 간다.
     # 잠금 테스트를 결정론적으로 만들기 위해 DB 응답에 지연을 넣을 때 쓴다.

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,6 +2,10 @@
 # clone 직후 ./gradlew test 가 추가 설정 없이 통과해야 한다.
 
 spring:
+  # H2 + ddl-auto=create-drop 을 쓴다. MySQL 문법 마이그레이션은 여기서 돌면 안 된다. (#29)
+  flyway:
+    enabled: false
+
   datasource:
     url: jdbc:h2:mem:edumeet;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,16 @@ spring:
   profiles:
     active: local
 
+  # 스키마 마이그레이션. 운영은 ddl-auto=none 이라 변경 경로가 없었다. (#29)
+  # baseline-on-migrate: 기존 운영 DB 는 스키마가 이미 있으므로 V1 을 실행하지 않고 V1 로 표시만 한다.
+  #                      빈 DB(신규 개발자)에서는 V1 부터 실제로 실행된다.
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    # 스키마가 코드와 어긋난 채로 뜨는 것보다 못 뜨는 게 낫다.
+    validate-on-migrate: true
+
   jpa:
     # 영속성 컨텍스트를 뷰 렌더링까지 열어두지 않는다.
     # 커넥션 점유 시간이 길어지고 지연 로딩 위치가 불명확해지는 것을 막는다.

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,294 @@
+-- V1 — 기존 스키마 baseline (#29)
+--
+-- 이 파일은 손으로 쓰지 않았다. 엔티티에서 생성했다:
+--   ./gradlew test --tests '*SchemaExportTest'   →  build/schema-mysql.sql
+--
+-- 운영 DB 에는 이미 이 스키마가 있다. Flyway 는 baseline-on-migrate 로
+-- 기존 DB 를 V1 으로 표시하고 이 파일을 실행하지 않는다.
+-- 빈 DB(신규 로컬 개발자)에서만 실제로 실행된다.
+--
+-- 따라서 이 파일은 "운영 스키마의 사본" 이 아니라 "엔티티가 기대하는 스키마" 다.
+-- 둘이 다르면 V2 이후 마이그레이션에서 드러난다.
+
+create table assignment (
+    class_id bigint not null,
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    title varchar(200) not null,
+    created_by_email varchar(255),
+    created_by_name varchar(255),
+    description TEXT,
+    primary key (id)
+) engine=InnoDB;
+create table assignment_file_upload (
+    img bit not null,
+    ord integer not null,
+    assignment_id bigint,
+    deleted_at datetime(6),
+    file_size bigint,
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reference_id bigint,
+    reg_date datetime(6),
+    content_type varchar(255),
+    domain varchar(255),
+    file_name varchar(255) not null,
+    uploaded_by varchar(255),
+    uuid varchar(255) not null,
+    primary key (id)
+) engine=InnoDB;
+create table board (
+    category_id bigint,
+    class_id bigint not null,
+    deleted_at datetime(6),
+    dislike BIGINT DEFAULT 0,
+    favorite BIGINT DEFAULT 0,
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    view BIGINT DEFAULT 0,
+    title varchar(50) not null,
+    writer varchar(100) not null,
+    content TEXT,
+    board_type VARCHAR(20) DEFAULT 'NORMAL',
+    primary key (id)
+) engine=InnoDB;
+create table board_category (
+    is_active bit not null,
+    recommend_threshold integer not null,
+    sort_order integer not null,
+    class_id bigint not null,
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    parent_id bigint,
+    reg_date datetime(6),
+    category_name varchar(255) not null,
+    created_by varchar(255) not null,
+    description varchar(255),
+    primary key (id)
+) engine=InnoDB;
+create table board_file_upload (
+    img bit not null,
+    ord integer not null,
+    board_id bigint,
+    deleted_at datetime(6),
+    file_size bigint,
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reference_id bigint,
+    reg_date datetime(6),
+    content_type varchar(255),
+    file_name varchar(255) not null,
+    uploaded_by varchar(255),
+    uuid varchar(255) not null,
+    primary key (id)
+) engine=InnoDB;
+create table class_invite (
+    class_room_id bigint,
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    invitee_id bigint,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    status enum ('ACCEPTED','APPLIED','DENIED'),
+    primary key (id)
+) engine=InnoDB;
+create table class_member (
+    class_room_id bigint,
+    id bigint not null auto_increment,
+    member_id bigint,
+    primary key (id)
+) engine=InnoDB;
+create table class_room (
+    is_deleted BOOLEAN DEFAULT FALSE not null,
+    participant_limit integer,
+    class_room_id bigint not null,
+    deleted_at datetime(6),
+    member_id bigint,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    description varchar(255),
+    original_url varchar(255),
+    thumbnail_url varchar(255),
+    thumbnail_uuid varchar(255),
+    title varchar(255),
+    primary key (class_room_id)
+) engine=InnoDB;
+create table class_room_seq (
+    next_val bigint
+) engine=InnoDB;
+insert into class_room_seq values ( 1 );
+create table class_room_tags (
+    class_room_class_room_id bigint,
+    id bigint not null auto_increment,
+    name varchar(255),
+    primary key (id)
+) engine=InnoDB;
+create table meeting (
+    class_room_id bigint not null,
+    end_time datetime(6),
+    id bigint not null auto_increment,
+    start_time datetime(6) not null,
+    title varchar(100) not null,
+    description varchar(500),
+    s3url varchar(255),
+    session_type enum ('BROADCAST','INTERACTIVE') not null,
+    primary key (id)
+) engine=InnoDB;
+create table meeting_participant (
+    id bigint not null auto_increment,
+    joined_at datetime(6) not null,
+    left_at datetime(6),
+    meeting_id bigint not null,
+    participant_email varchar(100) not null,
+    primary key (id)
+) engine=InnoDB;
+create table member (
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    nickname varchar(50) not null,
+    email varchar(100) not null,
+    password varchar(255) not null,
+    provider varchar(255),
+    provider_id varchar(255),
+    primary key (id)
+) engine=InnoDB;
+create table refresh_token (
+    expiration datetime(6) not null,
+    id bigint not null auto_increment,
+    member_id bigint not null,
+    token varchar(512) not null,
+    primary key (id)
+) engine=InnoDB;
+create table reply (
+    depth integer not null,
+    board_id bigint,
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    parent_id bigint,
+    reg_date datetime(6),
+    replayer varchar(255),
+    reply_text varchar(255),
+    primary key (id)
+) engine=InnoDB;
+create table student_submission_status (
+    assignment_id bigint,
+    id bigint not null auto_increment,
+    submitted_at datetime(6),
+    student_name varchar(50) not null,
+    student_email varchar(255) not null,
+    status enum ('NOT_SUBMITTED','SUBMITTED') not null,
+    primary key (id)
+) engine=InnoDB;
+create table submission (
+    assignment_id bigint not null,
+    deleted_at datetime(6),
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    class_member_email varchar(255),
+    class_member_name varchar(255),
+    content TEXT,
+    status enum ('NOT_SUBMITTED','SUBMITTED') not null,
+    primary key (id)
+) engine=InnoDB;
+create table submission_file_upload (
+    img bit not null,
+    ord integer not null,
+    deleted_at datetime(6),
+    file_size bigint,
+    id bigint not null auto_increment,
+    mod_date datetime(6),
+    reference_id bigint,
+    reg_date datetime(6),
+    student_submission_status_id bigint,
+    submission_id bigint,
+    content_type varchar(255),
+    domain varchar(255),
+    file_name varchar(255) not null,
+    uploaded_by varchar(255),
+    uuid varchar(255) not null,
+    primary key (id)
+) engine=InnoDB;
+alter table meeting_participant 
+   add constraint uk_meeting_participant unique (meeting_id, participant_email);
+alter table member 
+   add constraint UKmbmcqelty0fbrvxp1q58dn57t unique (email);
+alter table refresh_token 
+   add constraint UKdnbbikqdsc2r2cee1afysqfk9 unique (member_id);
+alter table refresh_token 
+   add constraint UKr4k4edos30bx9neoq81mdvwph unique (token);
+create index idx_reply_board_id 
+   on reply (board_id);
+create index idx_reply_parent_id 
+   on reply (parent_id);
+alter table assignment_file_upload 
+   add constraint FK5ty4r79nyswusaaj4lqwmuw7a 
+   foreign key (assignment_id) 
+   references assignment (id);
+alter table board_category 
+   add constraint FKj33evch04jxdr3xhf0bbsw2ph 
+   foreign key (parent_id) 
+   references board_category (id);
+alter table board_file_upload 
+   add constraint FKjpungikwmtrfnundn9g7xw9jr 
+   foreign key (board_id) 
+   references board (id);
+alter table class_invite 
+   add constraint FKt3nfqig7sr5qoxv2c08bykc3l 
+   foreign key (class_room_id) 
+   references class_room (class_room_id);
+alter table class_invite 
+   add constraint FKaokt124mb9yjn1r73besqsbmt 
+   foreign key (invitee_id) 
+   references member (id);
+alter table class_member 
+   add constraint FKhrb31q1ndu0q3eaj00h2sn3eg 
+   foreign key (class_room_id) 
+   references class_room (class_room_id);
+alter table class_member 
+   add constraint FK6qigkm2yyoupyn32rijfpy52r 
+   foreign key (member_id) 
+   references member (id);
+alter table class_room 
+   add constraint FKjgcv37s2fs60bwfacv6cxdw4y 
+   foreign key (member_id) 
+   references member (id);
+alter table class_room_tags 
+   add constraint FK4be7yt2lvq8j0gmg70uhiwe6o 
+   foreign key (class_room_class_room_id) 
+   references class_room (class_room_id);
+alter table meeting 
+   add constraint FKoveticxd6hjq9pxdr2ux64x9u 
+   foreign key (class_room_id) 
+   references class_room (class_room_id);
+alter table meeting_participant 
+   add constraint FK26jnnkay5w0sko7x7kqu17xbr 
+   foreign key (meeting_id) 
+   references meeting (id);
+alter table reply 
+   add constraint FKcs9hiip0bv9xxfrgoj0lwv2dt 
+   foreign key (board_id) 
+   references board (id);
+alter table reply 
+   add constraint FK653lh98w5hv6139pt9s7ejyr8 
+   foreign key (parent_id) 
+   references reply (id);
+alter table student_submission_status 
+   add constraint FKp2ep48be4p4xo91l95uxi8o11 
+   foreign key (assignment_id) 
+   references assignment (id);
+alter table submission_file_upload 
+   add constraint FK23s8ls4quxa3v41ilm86yjeq6 
+   foreign key (student_submission_status_id) 
+   references student_submission_status (id);
+alter table submission_file_upload 
+   add constraint FK23s0w3tqv9y0bg0c5vocn9sp 
+   foreign key (submission_id) 
+   references submission (id);

--- a/src/test/java/com/edu/edumeet/SchemaExportTest.java
+++ b/src/test/java/com/edu/edumeet/SchemaExportTest.java
@@ -1,0 +1,23 @@
+package com.edu.edumeet;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 엔티티에서 MySQL DDL 을 뽑는다. 평소에는 돌리지 않는다.
+ * ./gradlew test --tests '*SchemaExportTest' 로 명시 실행하면 build/schema-mysql.sql 이 생긴다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.jpa.properties.jakarta.persistence.schema-generation.scripts.action=create",
+        "spring.jpa.properties.jakarta.persistence.schema-generation.scripts.create-target=build/schema-mysql.sql",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect",
+        "spring.flyway.enabled=false"
+})
+class SchemaExportTest {
+    @Test
+    void export() { }
+}

--- a/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
+++ b/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
@@ -1,0 +1,87 @@
+package com.edu.edumeet.integration.migration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flyway 마이그레이션이 실제 MySQL 에서 도는지 확인한다. (#29)
+ *
+ * H2 로는 검증할 수 없다. V1 baseline 은 engine=InnoDB, enum(...) 같은
+ * MySQL 전용 문법을 담고 있어서 H2 MySQL 모드에서도 깨진다.
+ *
+ * 이 테스트가 없으면 "마이그레이션을 넣었다" 는 주장은 배포 시점에야 검증된다.
+ */
+@SpringBootTest
+@Testcontainers
+@DisplayName("Flyway 마이그레이션")
+class FlywayMigrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.MySQLDialect");
+        // 스키마는 Flyway 가 만든다. Hibernate 가 손대면 무엇이 만들었는지 알 수 없다.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("빈 DB 에서 V1 baseline 이 실제로 실행된다")
+    void v1_runs_on_empty_database() {
+        List<String> applied = jdbc.queryForList(
+                "SELECT version FROM flyway_schema_history WHERE success = 1 ORDER BY installed_rank",
+                String.class);
+
+        assertThat(applied)
+                .as("빈 DB 이므로 baseline 으로 건너뛰지 않고 V1 이 실행되어야 한다")
+                .contains("1");
+    }
+
+    @Test
+    @DisplayName("V1 이 엔티티가 기대하는 테이블을 전부 만든다")
+    void v1_creates_all_tables() {
+        Integer tableCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.tables " +
+                "WHERE table_schema = DATABASE() AND table_name <> 'flyway_schema_history'",
+                Integer.class);
+
+        assertThat(tableCount)
+                .as("엔티티에서 생성한 baseline 이므로 18개 테이블이 나와야 한다")
+                .isEqualTo(18);
+    }
+
+    @Test
+    @DisplayName("Hibernate 가 이 스키마를 그대로 쓸 수 있다 - 컨텍스트가 뜨면 검증된 것")
+    void hibernate_accepts_the_migrated_schema() {
+        // ddl-auto=none 인데 컨텍스트가 떴다는 것은
+        // Flyway 가 만든 스키마로 EntityManagerFactory 가 구성됐다는 뜻이다.
+        Integer meetingColumns = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.columns " +
+                "WHERE table_schema = DATABASE() AND table_name = 'meeting'",
+                Integer.class);
+
+        assertThat(meetingColumns).isEqualTo(8);
+    }
+}


### PR DESCRIPTION
Closes #29

## 왜

#27(AI 요약본 연동) 에서 컬럼을 추가하려다 막혔다. **스키마를 바꿀 방법이 없었다.**

| | 발견 |
|---|---|
| `ddl-auto` | `application-test.yml`(create-drop), `application-perf.yml`(create) 에만 존재. 운영은 Boot 기본값 **`none`** |
| 마이그레이션 도구 | 없음 |
| `application-prod.yml` | **파일 자체가 없음** — Dockerfile 은 `SPRING_PROFILES_ACTIVE=prod` 를 켠다 |

지금까지 문제가 안 된 이유는 단순하다 — **스키마를 바꾼 적이 없었다.**

그리고 이건 #26 에서 만든 자동 배포의 구멍이다.
push 하면 새 이미지가 뜨는데, 컬럼이 없으면 런타임에 죽는다.
헬스체크가 감지는 하지만 **막는 게 아니라 롤백만 시킨다.**

## 무엇

### V1 baseline 은 손으로 쓰지 않았다

```bash
./gradlew test --tests '*SchemaExportTest'   # → build/schema-mysql.sql
```

엔티티에서 MySQL DDL 을 생성했다. 18개 테이블, FK 20개.
**손으로 쓴 baseline 은 반드시 실제 스키마와 어긋난다.**

### baseline-on-migrate 를 쓰는 이유

| DB 상태 | Flyway 동작 |
|---|---|
| 기존 운영 DB (스키마 있음, 이력 테이블 없음) | V1 을 **실행하지 않고** V1 로 표시만 |
| 빈 DB (신규 개발자) | V1 부터 **실제로 실행** |

운영 DB 를 직접 볼 수 없는 상태에서 스키마를 SQL 로 역생성하는 건 위험하다.
따라서 **현재 상태를 baseline 으로 선언하고 V2 부터 관리**한다.

이 파일은 "운영 스키마의 사본" 이 아니라 **"엔티티가 기대하는 스키마"** 다.
둘이 다르면 V2 이후 마이그레이션에서 드러난다.

### 검증은 진짜 MySQL 에서 한다

```java
@Container
static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0");
```

H2 로는 검증할 수 없다. baseline 에 `engine=InnoDB`, `enum('BROADCAST','INTERACTIVE')` 같은
**MySQL 전용 문법**이 있어서 H2 의 MySQL 모드에서도 깨진다.

이 테스트가 없으면 *"마이그레이션을 넣었다"* 는 주장은 **배포 시점에야 검증된다.**

| 테스트 | 확인하는 것 |
|---|---|
| `v1_runs_on_empty_database` | 빈 DB 에서 baseline 으로 건너뛰지 않고 V1 이 실제로 실행 |
| `v1_creates_all_tables` | 18개 테이블 생성 |
| `hibernate_accepts_the_migrated_schema` | `ddl-auto=none` 인데 컨텍스트가 뜬다 = Flyway 스키마로 EMF 구성 성공 |

### 왜 Liquibase 가 아닌가

평문 SQL 이라 DBA 리뷰와 수동 실행이 가능하다.
단일 DB(MySQL)라 Liquibase 의 DB 추상화 이점이 없다.

## 결과

```
테스트 176개 통과 (기존 172 + 신규 4)
```

## 남는 것

- **최초 배포 시 운영 DB 에 `flyway_schema_history` 가 생긴다.** baseline-on-migrate 가
  기존 스키마를 V1 로 표시하므로 데이터 손실은 없다
- 로컬에서 Testcontainers 가 Docker 소켓을 못 찾으면
  `DOCKER_HOST=unix://$HOME/.docker/run/docker.sock` 를 지정해야 할 수 있다 (Docker Desktop for Mac)

관련: #26, #27