### PR TITLE
fix: AI 요약본 연동 재설계 - 인증·트랜잭션·멱등성 (#27)

### DIFF
--- a/docs/ops/03-internal-api-contract.md
+++ b/docs/ops/03-internal-api-contract.md
@@ -1,0 +1,91 @@
+# 서버 간 API 규약 — 파이썬 AI 서버 ↔ Spring
+
+> 작성 2026-08-22 · #27
+
+## 왜 별도 경로인가
+
+파이썬 AI 서버는 **사용자 JWT 를 가질 수 없다.** 사람이 로그인해서 부르는 게 아니다.
+
+#23 이전에는 `/api/v1/**` 이 permitAll 이라 이 경로가 **인증 없이 열려 있었다.**
+누구나 임의 클래스에 요약본을 덮어쓸 수 있었다.
+`anyRequest().authenticated()` 를 살리자 파이썬 호출이 **401 이 됐다** — 버그가 드러난 것이다.
+
+그래서 **경로를 분리**했다. 사용자 인증 규칙과 서비스 인증 규칙이 한 목록에 섞이면
+어느 쪽이 적용되는지 읽어서 알 수 없다.
+
+```
+/api/v1/**            사용자 JWT
+/api/v1/internal/**   X-Internal-Token  (공유 시크릿)
+```
+
+## 요약본 업로드
+
+```http
+POST /api/v1/internal/meetings/{meetingId}/summary
+X-Internal-Token: <공유 시크릿>
+Content-Type: multipart/form-data
+
+summary_md  : (선택) .md
+summary_pdf : (선택) .pdf
+```
+
+**둘 중 최소 하나**는 있어야 한다. **빈 파일은 없는 것으로 본다.**
+
+| 응답 | 뜻 |
+|---|---|
+| `201 Created` | 이번 호출로 기록됐다 |
+| `200 OK` | 이미 있어서 아무것도 바꾸지 않았다 (재시도로 간주) |
+| `400` | 파일 없음 / 형식·크기 오류 / 없는 `meetingId` |
+| `401` | 토큰 불일치 |
+
+```json
+{
+  "meetingId": 12,
+  "classId": 3,
+  "markdownUrl": "https://.../summary_20260822_140000.md",
+  "pdfUrl": "https://.../summary_20260822_140000.pdf",
+  "alreadyExisted": false
+}
+```
+
+## 파이썬이 바꿔야 하는 것
+
+| 이전 | 이후 |
+|---|---|
+| `POST /api/v1/meeting/summary/{classId}` | `POST /api/v1/internal/meetings/{meetingId}/summary` |
+| 인증 없음 | `X-Internal-Token` 헤더 필수 |
+| `class_id`, `meeting_id` 폼 필드 | **`meetingId` 는 경로에 필수.** `class_id` 는 보내지 않는다 |
+| `meeting_id` 생략 가능 | **생략 불가** |
+
+### `meeting_id` 를 필수로 바꾼 이유
+
+이전 구현은 `meeting_id` 가 없으면
+1. 해당 클래스의 **최신 회의에 덮어쓰거나**
+2. 회의가 없으면 **"AI 요약 미팅" 을 새로 생성**했다
+
+열린 적 없는 회의가 DB 에 생기고, 엉뚱한 회의에 요약본이 붙었다.
+**요약본은 이미 끝난 회의의 산출물**이므로 회의를 만들 이유가 없다.
+
+## 재시도
+
+**같은 회의에 두 번 올리면 두 번째는 무시된다** (`200`, `alreadyExisted: true`).
+S3 업로드 자체를 건너뛰므로 중복 객체가 쌓이지 않는다.
+
+타임아웃 후 재시도해도 안전하다. 다만 **요약본을 새로 만들어 덮어쓰고 싶다면
+현재 정책으로는 불가능**하다. 그런 요구가 생기면 명시적인 재생성 경로를 따로 만든다.
+
+## 토큰 운영
+
+```bash
+INTERNAL_API_TOKEN=<충분히 긴 랜덤 문자열>
+```
+
+- **비어 있으면 `/api/v1/internal/**` 은 전부 거부된다** (fail-closed)
+- 비교는 상수 시간이다 (`MessageDigest.isEqual`) — 응답 시간으로 한 글자씩 맞출 수 없다
+- **한계: 회전 절차가 없다.** 유출되면 환경변수를 바꾸고 재배포해야 한다.
+  호출 빈도가 낮고(회의당 1회) 내부 호출이라 감수한다
+
+## 남는 것
+
+- 파이썬 저장소가 이 리포에 없어서 **클라이언트 쪽 변경은 미반영**이다
+- 요약본 재생성 경로 (현재는 첫 기록이 이긴다)

--- a/src/main/java/com/edu/edumeet/config/SecurityConfig.java
+++ b/src/main/java/com/edu/edumeet/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.edu.edumeet.config;
 
 import com.edu.edumeet.config.jwt.JwtAuthenticationEntryPoint;
 import com.edu.edumeet.config.jwt.JwtAuthenticationFilter;
+import com.edu.edumeet.config.internal.InternalApiTokenFilter;
 import com.edu.edumeet.member.service.CustomOauth2UserService;
 import com.edu.edumeet.util.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final InternalApiTokenFilter internalApiTokenFilter;
     private final CorsConfigurationSource corsConfigurationSource;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CustomOauth2UserService customOauth2UserService;
@@ -83,12 +85,16 @@ public class SecurityConfig {
                                 "/actuator/health",
                                 "/actuator/health/**"
                         ).permitAll()
+                        // 서버 간 호출. 사용자 JWT 가 아니라 공유 시크릿으로 인증한다. (#27)
+                        // 경로를 분리해야 "사용자 인증" 과 "서비스 인증" 규칙이 섞이지 않는다.
+                        .requestMatchers("/api/v1/internal/**").hasRole("INTERNAL")
                         .anyRequest().authenticated()
                 )
 
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalApiTokenFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/edu/edumeet/config/internal/InternalApiTokenFilter.java
+++ b/src/main/java/com/edu/edumeet/config/internal/InternalApiTokenFilter.java
@@ -1,0 +1,84 @@
+package com.edu.edumeet.config.internal;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * 서버 간 호출 인증. (#27)
+ *
+ * <p>파이썬 AI 서버는 사용자 JWT 를 가질 수 없다. 사람이 로그인해서 부르는 게 아니기 때문이다.
+ * #23 이전에는 {@code /api/v1/**} 이 permitAll 이라 이 경로가 <b>인증 없이 열려 있었고</b>,
+ * 누구나 임의 클래스에 요약본을 덮어쓸 수 있었다.
+ *
+ * <p>공유 시크릿을 쓴다. 서버 간 호출이라 사용자 신원이 없고, 상호 TLS 를 붙일 만한
+ * 인프라도 아니다. 대신 <b>실패 시 닫힌다</b> — 토큰이 설정되지 않으면 아무도 통과하지 못한다.
+ *
+ * <p>한계: 회전 절차가 없다. 유출되면 환경변수를 바꾸고 재배포해야 한다.
+ * 호출 빈도가 낮고(회의당 1회) 내부 네트워크 호출이라 감수한다.
+ */
+@Slf4j
+@Component
+public class InternalApiTokenFilter extends OncePerRequestFilter {
+
+    public static final String HEADER = "X-Internal-Token";
+    private static final String PATH_PREFIX = "/api/v1/internal/";
+
+    private final byte[] expected;
+
+    public InternalApiTokenFilter(@Value("${edumeet.internal.api-token:}") String token) {
+        this.expected = (token == null || token.isBlank())
+                ? null
+                : token.getBytes(StandardCharsets.UTF_8);
+        if (this.expected == null) {
+            log.warn("edumeet.internal.api-token 이 비어 있다. {} 경로는 전부 거부된다.", PATH_PREFIX);
+        }
+    }
+
+    /** 내부 경로가 아니면 이 필터는 아무것도 하지 않는다. */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith(PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        if (matches(request.getHeader(HEADER))) {
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(
+                            "internal-service", null,
+                            AuthorityUtils.createAuthorityList("ROLE_INTERNAL")));
+        } else {
+            // 인증을 설정하지 않고 넘긴다. 인가 단계에서 401 이 나간다.
+            // 여기서 직접 응답을 쓰면 EntryPoint 의 응답 형식과 어긋난다.
+            log.warn("내부 API 토큰 불일치 - uri={}, remote={}",
+                    request.getRequestURI(), request.getRemoteAddr());
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * 상수 시간 비교. 바이트별로 일찍 끊으면 응답 시간으로 토큰을 한 글자씩 맞출 수 있다.
+     * 길이는 여전히 새지만 그것만으로는 값을 복원할 수 없다.
+     */
+    private boolean matches(String presented) {
+        if (expected == null || presented == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(expected, presented.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/edu/edumeet/exception/CustomRestAdvice.java
+++ b/src/main/java/com/edu/edumeet/exception/CustomRestAdvice.java
@@ -109,6 +109,25 @@ public class CustomRestAdvice {
      * <p>401(인증 필요)과 구분한다. 401 로 뭉뚱그리면 클라이언트가 "다시 로그인하면 되겠지"로
      * 오해한다.
      */
+    /**
+     * 잘못된 입력은 400 이다. (#27)
+     *
+     * <p>이전에는 서비스가 {@code catch (Exception e) -> throw new RuntimeException(...)} 으로
+     * 전부 재포장했다. IllegalArgumentException 도 RuntimeException 을 상속하므로 여기 걸려
+     * 컨트롤러의 400 분기는 <b>절대 실행되지 않았다.</b> 없는 classId 를 보내도 500 이 나갔다.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException e) {
+
+        log.warn("잘못된 요청: {}", e.getMessage());
+
+        Map<String, String> errorMap = new HashMap<>();
+        errorMap.put("time", "" + System.currentTimeMillis());
+        errorMap.put("msg", e.getMessage());
+        return ResponseEntity.badRequest().body(errorMap);
+    }
+
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException e) {

--- a/src/main/java/com/edu/edumeet/openvidu/controller/InternalMeetingSummaryController.java
+++ b/src/main/java/com/edu/edumeet/openvidu/controller/InternalMeetingSummaryController.java
@@ -1,0 +1,65 @@
+package com.edu.edumeet.openvidu.controller;
+
+import com.edu.edumeet.openvidu.dto.SummaryUploadResult;
+import com.edu.edumeet.openvidu.service.MeetingSummaryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 파이썬 AI 서버 전용. 사용자가 부르는 API 가 아니다. (#27)
+ *
+ * <p>경로를 {@code /api/v1/internal/} 로 분리한 이유는 보안 규칙을 섞지 않기 위해서다.
+ * SecurityConfig 에서 이 접두사는 {@code hasRole("INTERNAL")} 이고,
+ * {@link com.edu.edumeet.config.internal.InternalApiTokenFilter} 가
+ * {@code X-Internal-Token} 헤더를 검사해서 그 권한을 준다.
+ *
+ * <h3>파이썬이 맞춰야 하는 규약</h3>
+ * <pre>
+ * POST /api/v1/internal/meetings/{meetingId}/summary
+ *   X-Internal-Token: &lt;공유 시크릿&gt;
+ *   Content-Type: multipart/form-data
+ *   summary_md  : (선택) .md 파일
+ *   summary_pdf : (선택) .pdf 파일
+ *   → 둘 중 최소 하나는 있어야 한다. 빈 파일은 없는 것으로 본다.
+ *
+ * 201 Created : 이번 호출로 기록됐다
+ * 200 OK      : 이미 있어서 아무것도 바꾸지 않았다 (재시도로 간주)
+ * 400         : 파일이 없거나 형식/크기가 잘못됨, 또는 없는 meetingId
+ * 401         : 토큰 불일치
+ * </pre>
+ *
+ * <p>{@code meetingId} 는 <b>필수</b>다. 이전 구현은 없으면 최신 회의에 덮어쓰거나
+ * 회의를 새로 만들었는데, 열린 적 없는 회의가 생기고 엉뚱한 회의에 요약본이 붙었다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal/meetings")
+@RequiredArgsConstructor
+@Slf4j
+public class InternalMeetingSummaryController {
+
+    private final MeetingSummaryService meetingSummaryService;
+
+    @PostMapping("/{meetingId}/summary")
+    public ResponseEntity<SummaryUploadResult> uploadSummary(
+            @PathVariable("meetingId") Long meetingId,
+            @RequestParam(value = "summary_md", required = false) MultipartFile summaryMd,
+            @RequestParam(value = "summary_pdf", required = false) MultipartFile summaryPdf) {
+
+        log.info("요약본 업로드 요청 - meetingId={}, md={}, pdf={}",
+                meetingId,
+                summaryMd == null ? null : summaryMd.getSize(),
+                summaryPdf == null ? null : summaryPdf.getSize());
+
+        SummaryUploadResult result = meetingSummaryService.uploadSummary(meetingId, summaryMd, summaryPdf);
+
+        // 재시도로 아무것도 안 바뀌었으면 200, 이번에 기록했으면 201.
+        // 파이썬이 재시도 성공과 최초 성공을 구분할 수 있어야 로그가 읽힌다.
+        return ResponseEntity
+                .status(result.alreadyExisted() ? HttpStatus.OK : HttpStatus.CREATED)
+                .body(result);
+    }
+}

--- a/src/main/java/com/edu/edumeet/openvidu/controller/MeetingSummaryController.java
+++ b/src/main/java/com/edu/edumeet/openvidu/controller/MeetingSummaryController.java
@@ -1,137 +1,31 @@
 package com.edu.edumeet.openvidu.controller;
 
+import com.edu.edumeet.openvidu.dto.SummaryUploadResult;
 import com.edu.edumeet.openvidu.service.MeetingSummaryService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
-
+/**
+ * 사용자용 요약본 조회. 업로드는 {@link InternalMeetingSummaryController} 로 옮겼다. (#27)
+ */
 @RestController
 @RequestMapping("/api/v1/meeting")
 @RequiredArgsConstructor
-@Log4j2
+@Slf4j
 public class MeetingSummaryController {
 
     private final MeetingSummaryService meetingSummaryService;
 
-    @PostMapping("/summary/{classId}")
-    public ResponseEntity<Map<String, Object>> uploadSummary(
-            @PathVariable("classId") Long classId,
-            @RequestParam("class_id") String classIdParam,
-            @RequestParam(value = "meeting_id", required = false) String meetingIdParam,
-            @RequestParam(value = "summary_md", required = false) MultipartFile summaryMd,
-            @RequestParam(value = "summary_pdf", required = false) MultipartFile summaryPdf) {
-
-        log.info("📝 파이썬에서 요약본 업로드 요청 - classId: {}, meetingId: {}", classId, meetingIdParam);
-        
-        // 파라미터 디버깅
-        log.info("🔍 파라미터 디버깅:");
-        log.info("  - classIdParam: '{}'", classIdParam);
-        log.info("  - meetingIdParam: '{}'", meetingIdParam);
-        log.info("  - summaryMd: {}", summaryMd != null ? "NOT NULL (size: " + summaryMd.getSize() + ", name: " + summaryMd.getOriginalFilename() + ")" : "NULL");
-        log.info("  - summaryPdf: {}", summaryPdf != null ? "NOT NULL (size: " + summaryPdf.getSize() + ", name: " + summaryPdf.getOriginalFilename() + ")" : "NULL");
-
-        Map<String, Object> response = new HashMap<>();
-
-        try {
-            // meeting_id가 있으면 사용, 없으면 null
-            Long meetingId = null;
-            if (meetingIdParam != null && !meetingIdParam.trim().isEmpty()) {
-                try {
-                    meetingId = Long.parseLong(meetingIdParam.trim());
-                } catch (NumberFormatException e) {
-                    log.warn("❌ meeting_id 파싱 실패: {}", meetingIdParam);
-                }
-            }
-
-            // 파일 검증 - MD 또는 PDF 중 하나는 있어야 함 (빈 파일도 일단 허용)
-            boolean hasMdFile = summaryMd != null && summaryMd.getOriginalFilename() != null;
-            boolean hasPdfFile = summaryPdf != null && summaryPdf.getOriginalFilename() != null;
-            
-            log.info("📋 파일 검증 결과: hasMdFile={}, hasPdfFile={}", hasMdFile, hasPdfFile);
-            
-            if (!hasMdFile && !hasPdfFile) {
-                response.put("success", false);
-                response.put("message", "업로드할 파일이 없습니다. Markdown(.md) 또는 PDF(.pdf) 파일 중 하나는 필요합니다.");
-                return ResponseEntity.badRequest().body(response);
-            }
-            
-            // 업로드되는 파일 정보 로깅 (크기 포함)
-            String fileInfo = String.format("업로드 파일: %s%s", 
-                hasMdFile ? String.format("MD(%d bytes) ", summaryMd.getSize()) : "", 
-                hasPdfFile ? String.format("PDF(%d bytes)", summaryPdf.getSize()) : "");
-            log.info("📁 {}", fileInfo);
-            
-            log.info("🔍 서비스 호출 전 - meetingSummaryService: {}", meetingSummaryService != null ? "OK" : "NULL");
-
-            // 요약본 업로드 처리
-            Map<String, String> uploadResult = meetingSummaryService.uploadSummaryFiles(
-                    classId, meetingId, summaryMd, summaryPdf);
-                    
-            log.info("✅ 서비스 호출 완료 - uploadResult: {}", uploadResult);
-
-            response.put("success", true);
-            response.put("message", "파일 업로드 및 DB 업데이트 완료");
-            response.put("class_id", classId);
-            response.put("meeting_id", uploadResult.get("meeting_id"));
-            response.put("uploaded_files", uploadResult);
-            
-            // 어떤 파일이 업로드되었는지 응답에 포함
-            response.put("file_types", 
-                String.format("%s%s", 
-                    uploadResult.containsKey("summary_md_url") ? "MD " : "",
-                    uploadResult.containsKey("summary_pdf_url") ? "PDF" : "").trim());
-            response.put("primary_file", 
-                uploadResult.get("s3_url") != null && uploadResult.get("s3_url").contains(".pdf") ? "PDF" : "MD");
-
-            log.info("✅ 요약본 업로드 성공 - classId: {}, 결과: {}", classId, uploadResult);
-
-            return ResponseEntity.ok(response);
-
-        } catch (IllegalArgumentException e) {
-            log.error("❌ 요약본 업로드 실패 - 잘못된 요청: {}", e.getMessage());
-            response.put("success", false);
-            response.put("error", "잘못된 요청: " + e.getMessage());
-            return ResponseEntity.badRequest().body(response);
-
-        } catch (Exception e) {
-            log.error("❌ 요약본 업로드 실패 - classId: {}", classId, e);
-            response.put("success", false);
-            response.put("error", "파일 업로드 실패: " + e.getMessage());
-            return ResponseEntity.internalServerError().body(response);
-        }
-    }
-
+    /** 요약본이 없으면 204. 빈 본문에 success=true 를 담는 것보다 상태 코드로 말하는 게 낫다. */
     @GetMapping("/summary/{classId}")
-    public ResponseEntity<Map<String, Object>> getSummary(@PathVariable("classId") Long classId) {
-
-        log.info("📖 요약본 조회 요청 - classId: {}", classId);
-
-        Map<String, Object> response = new HashMap<>();
-
-        try {
-            Map<String, String> summaryInfo = meetingSummaryService.getSummaryInfo(classId);
-
-            response.put("success", true);
-            response.put("data", summaryInfo);
-
-            return ResponseEntity.ok(response);
-
-        } catch (IllegalArgumentException e) {
-            log.error("❌ 요약본 조회 실패 - 잘못된 요청: {}", e.getMessage());
-            response.put("success", false);
-            response.put("message", e.getMessage());
-            return ResponseEntity.badRequest().body(response);
-
-        } catch (Exception e) {
-            log.error("❌ 요약본 조회 실패 - classId: {}", classId, e);
-            response.put("success", false);
-            response.put("message", "서버 오류: " + e.getMessage());
-            return ResponseEntity.internalServerError().body(response);
-        }
+    public ResponseEntity<SummaryUploadResult> getSummary(@PathVariable("classId") Long classId) {
+        return meetingSummaryService.findLatestSummary(classId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 }

--- a/src/main/java/com/edu/edumeet/openvidu/domain/Meeting.java
+++ b/src/main/java/com/edu/edumeet/openvidu/domain/Meeting.java
@@ -41,7 +41,17 @@ public class Meeting {
 
     private LocalDateTime endTime;
 
+    /**
+     * 하위 호환용. PDF 가 있으면 PDF, 없으면 MD 를 담는다.
+     * 새 코드는 summaryMdUrl / summaryPdfUrl 을 직접 본다. (#27)
+     */
     private String s3url;
+
+    @Column(name = "summary_md_url", length = 500)
+    private String summaryMdUrl;
+
+    @Column(name = "summary_pdf_url", length = 500)
+    private String summaryPdfUrl;
 
     public void assignTo(ClassRoom classRoom) {
         this.classRoom = classRoom;
@@ -73,6 +83,24 @@ public class Meeting {
 
     public void changeS3Url(String newS3Url) {
         this.s3url = newS3Url;
+    }
+
+    /**
+     * 요약본 URL 을 기록한다. 둘 다 null 이면 호출하는 쪽 잘못이다.
+     * s3url 은 기존 조회 코드가 계속 읽으므로 함께 갱신한다. (#27)
+     */
+    public void recordSummary(String markdownUrl, String pdfUrl) {
+        if (markdownUrl == null && pdfUrl == null) {
+            throw new IllegalArgumentException("요약본 URL 이 하나도 없습니다.");
+        }
+        this.summaryMdUrl = markdownUrl;
+        this.summaryPdfUrl = pdfUrl;
+        this.s3url = (pdfUrl != null) ? pdfUrl : markdownUrl;
+    }
+
+    /** 이미 요약본이 기록되어 있는가. 멱등성 판단에 쓴다. */
+    public boolean hasSummary() {
+        return this.summaryMdUrl != null || this.summaryPdfUrl != null;
     }
 
     @PrePersist @PreUpdate

--- a/src/main/java/com/edu/edumeet/openvidu/dto/SummaryUploadResult.java
+++ b/src/main/java/com/edu/edumeet/openvidu/dto/SummaryUploadResult.java
@@ -1,0 +1,15 @@
+package com.edu.edumeet.openvidu.dto;
+
+/**
+ * 요약본 업로드 결과. (#27)
+ *
+ * @param alreadyExisted 이미 요약본이 있어서 이번 호출이 아무것도 바꾸지 않은 경우 true.
+ *                       파이썬이 재시도했을 때 중복 업로드를 만들지 않았다는 뜻이다.
+ */
+public record SummaryUploadResult(
+        Long meetingId,
+        Long classId,
+        String markdownUrl,
+        String pdfUrl,
+        boolean alreadyExisted
+) {}

--- a/src/main/java/com/edu/edumeet/openvidu/service/MeetingSummaryService.java
+++ b/src/main/java/com/edu/edumeet/openvidu/service/MeetingSummaryService.java
@@ -1,271 +1,183 @@
 package com.edu.edumeet.openvidu.service;
 
-import com.edu.edumeet.classroom.domain.ClassRoom;
-import com.edu.edumeet.classroom.repository.ClassRepository;
 import com.edu.edumeet.openvidu.domain.Meeting;
+import com.edu.edumeet.openvidu.dto.SummaryUploadResult;
 import com.edu.edumeet.openvidu.repository.MeetingRepository;
 import com.edu.edumeet.s3.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
+/**
+ * 파이썬 AI 서버가 만든 회의 요약본(MD/PDF)을 S3 에 올리고 회의에 연결한다. (#27)
+ *
+ * <h3>트랜잭션 경계를 왜 이렇게 잡았나</h3>
+ * 이전 구현은 메서드 전체가 {@code @Transactional} 이었고 그 안에서 S3 업로드를 두 번 했다.
+ * PDF 50MB 를 올리는 동안 DB 커넥션을 계속 붙잡는다. 커넥션 풀 고갈 경로다.
+ *
+ * <p>그래서 <b>느린 네트워크 I/O 를 트랜잭션 밖으로</b> 뺐다:
+ * <pre>
+ *   검증        (트랜잭션 없음)
+ *   회의 조회    (짧은 읽기)
+ *   S3 업로드    (트랜잭션 없음 - 여기가 오래 걸린다)
+ *   DB 기록      (짧은 쓰기)
+ * </pre>
+ *
+ * <h3>왜 TransactionTemplate 인가</h3>
+ * 오케스트레이션 메서드에서 {@code this.write(...)} 를 부르면
+ * <b>Spring AOP 프록시를 거치지 않아 {@code @Transactional} 이 무시된다.</b>
+ * 별도 빈으로 쪼개거나 TransactionTemplate 을 쓰는 수밖에 없는데,
+ * 여기서는 <b>트랜잭션 경계가 코드에 그대로 보이는</b> 쪽을 택했다.
+ */
 @Service
 @RequiredArgsConstructor
-@Log4j2
-@Transactional(readOnly = true)
+@Slf4j
 public class MeetingSummaryService {
 
+    private static final long MAX_MD_BYTES = 10L * 1024 * 1024;
+    private static final long MAX_PDF_BYTES = 50L * 1024 * 1024;
+    private static final DateTimeFormatter STAMP = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+
     private final MeetingRepository meetingRepository;
-    private final ClassRepository classRepository;
     private final S3Uploader s3Uploader;
+    private final TransactionTemplate transactionTemplate;
 
     /**
-     * 파이썬에서 보낸 요약본 파일들을 S3에 업로드하고 Meeting의 s3url에 저장
-     * 파이썬 코드의 send_summary_to_api 함수 요청을 처리
+     * 요약본을 업로드한다. 회의는 <b>이미 존재해야 한다.</b>
+     *
+     * <p>이전 구현은 meetingId 가 없으면 최신 회의에 덮어쓰거나 "AI 요약 미팅" 을 새로 만들었다.
+     * 열린 적 없는 회의가 DB 에 생기고, 엉뚱한 회의에 요약본이 붙었다.
+     * 요약본은 <b>이미 끝난 회의의 산출물</b>이므로 회의를 만들 이유가 없다.
      */
-    @Transactional
-    public Map<String, String> uploadSummaryFiles(Long classId, Long meetingId,
-                                                  MultipartFile summaryMd, MultipartFile summaryPdf) {
+    public SummaryUploadResult uploadSummary(Long meetingId, MultipartFile markdown, MultipartFile pdf) {
+        validate(markdown, pdf);
 
-        log.info("📤 요약본 파일 업로드 시작 - classId: {}, meetingId: {}", classId, meetingId);
-        
-        try {
-            // 1. 클래스 존재 여부 확인
-            log.info("🔍 ClassRepository 확인 중...");
-            ClassRoom classRoom = classRepository.findById(classId)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 클래스입니다: " + classId));
-            log.info("✅ 클래스 조회 성공: {}", classRoom.getTitle());
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미팅입니다: " + meetingId));
 
-            // 2. Meeting 조회 또는 생성
-            log.info("🔍 Meeting 조회/생성 중...");
-            Meeting meeting = findOrCreateMeeting(classId, meetingId, classRoom);
-            log.info("✅ Meeting 준비 완료: {}", meeting.getId());
-
-            Map<String, String> result = new HashMap<>();
-            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-            String s3Directory = String.format("summaries/class_%s/meeting_%s_%s", 
-                                              classId, meeting.getId(), timestamp);
-            log.info("📁 S3 디렉토리: {}", s3Directory);
-
-            String primaryUrl = null; // s3url 필드에 저장할 주요 URL (PDF 우선, 없으면 MD)
-            boolean hasUploadedFile = false;
-
-            // 3. Markdown 파일 업로드
-            if (summaryMd != null && summaryMd.getOriginalFilename() != null) {
-                log.info("🔍 Markdown 파일 업로드 시작... (size: {})", summaryMd.getSize());
-                
-                // 빈 파일 경고만 출력하고 계속 진행
-                if (summaryMd.isEmpty()) {
-                    log.warn("⚠️ Markdown 파일이 비어있지만 계속 진행합니다.");
-                } else {
-                    validateMarkdownFile(summaryMd);
-                }
-                
-                String mdFileName = String.format("summary_%s.md", timestamp);
-                String mdUrl = s3Uploader.uploadMultipartFile(summaryMd, s3Directory, mdFileName);
-                result.put("summary_md_url", mdUrl);
-                primaryUrl = mdUrl; // MD를 일단 primary로 설정
-                hasUploadedFile = true;
-                log.info("✅ Markdown 파일 S3 업로드 완료: {}", mdUrl);
-            }
-
-            // 4. PDF 파일 업로드 (우선순위 높음)
-            if (summaryPdf != null && summaryPdf.getOriginalFilename() != null) {
-                log.info("🔍 PDF 파일 업로드 시작... (size: {})", summaryPdf.getSize());
-                
-                // 빈 파일 경고만 출력하고 계속 진행
-                if (summaryPdf.isEmpty()) {
-                    log.warn("⚠️ PDF 파일이 비어있지만 계속 진행합니다.");
-                } else {
-                    validatePdfFile(summaryPdf);
-                }
-                
-                String pdfFileName = String.format("summary_%s.pdf", timestamp);
-                String pdfUrl = s3Uploader.uploadMultipartFile(summaryPdf, s3Directory, pdfFileName);
-                result.put("summary_pdf_url", pdfUrl);
-                primaryUrl = pdfUrl; // PDF가 있으면 항상 primaryUrl로 덮어쓰기 (우선순위)
-                hasUploadedFile = true;
-                log.info("✅ PDF 파일 S3 업로드 완료: {}", pdfUrl);
-            }
-
-            // 업로드된 파일이 하나도 없으면 에러
-            if (!hasUploadedFile) {
-                throw new IllegalArgumentException("업로드할 파일이 없습니다. MD 또는 PDF 파일 중 하나는 필요합니다.");
-            }
-
-            // 5. Meeting 엔티티의 s3url 필드 업데이트 (primaryUrl은 항상 존재)
-            log.info("🔍 Meeting 엔티티 업데이트 중...");
-            meeting.changeS3Url(primaryUrl);
-            meetingRepository.save(meeting);
-            log.info("✅ Meeting s3url 업데이트 완료 - meetingId: {}, s3url: {}", 
-                    meeting.getId(), primaryUrl);
-            
-            // 업로드된 파일 정보 로깅
-            StringBuilder uploadInfo = new StringBuilder("업로드된 파일: ");
-            if (result.containsKey("summary_md_url")) {
-                uploadInfo.append("MD ");
-            }
-            if (result.containsKey("summary_pdf_url")) {
-                uploadInfo.append("PDF ");
-            }
-            uploadInfo.append("(Primary: ").append(primaryUrl.contains(".pdf") ? "PDF" : "MD").append(")");
-            log.info(uploadInfo.toString());
-
-            // 6. 응답 데이터 구성
-            result.put("class_id", classId.toString());
-            result.put("meeting_id", meeting.getId().toString());
-            result.put("s3_url", primaryUrl);
-            result.put("uploaded_at", LocalDateTime.now().toString());
-
-            log.info("🎉 요약본 업로드 완료 - classId: {}, meetingId: {}, primaryUrl: {}, uploadedFiles: {}",
-                    classId, meeting.getId(), primaryUrl, 
-                    result.keySet().stream()
-                        .filter(key -> key.endsWith("_url"))
-                        .reduce((a, b) -> a + ", " + b)
-                        .orElse("none"));
-
-            return result;
-
-        } catch (Exception e) {
-            log.error("❌ 요약본 업로드 실패 - classId: {}, meetingId: {}", classId, meetingId, e);
-            throw new RuntimeException("요약본 업로드 실패: " + e.getMessage(), e);
+        // 빠른 경로. 이미 있으면 S3 업로드 자체를 건너뛴다.
+        // 실제 판정은 아래 쓰기 트랜잭션 안에서 한 번 더 한다 (경쟁 조건).
+        if (meeting.hasSummary()) {
+            log.info("요약본이 이미 있어 업로드를 건너뛴다 - meetingId={}", meetingId);
+            return existingResult(meeting);
         }
+
+        String directory = "summaries/meeting_%d_%s".formatted(meetingId, LocalDateTime.now().format(STAMP));
+        String stamp = LocalDateTime.now().format(STAMP);
+
+        // --- 트랜잭션 밖. 여기가 수십 초 걸릴 수 있다. ---
+        String markdownUrl = upload(markdown, directory, "summary_%s.md".formatted(stamp));
+        String pdfUrl = upload(pdf, directory, "summary_%s.pdf".formatted(stamp));
+
+        return record(meetingId, markdownUrl, pdfUrl);
     }
 
     /**
-     * Meeting 조회 또는 생성
-     * meetingId가 있으면 해당 Meeting 조회, 없으면 새로 생성
+     * 회의에 요약본 URL 을 기록한다. 짧은 쓰기 트랜잭션이다.
+     *
+     * <p>여기서 {@code hasSummary()} 를 다시 확인하는 이유:
+     * 위쪽 빠른 경로와 이 시점 사이에 다른 요청이 먼저 기록했을 수 있다.
+     * 트랜잭션 안에서 확인해야 <b>마지막 판정</b>이 된다.
      */
-    private Meeting findOrCreateMeeting(Long classId, Long meetingId, ClassRoom classRoom) {
-        if (meetingId != null) {
-            // meetingId가 주어진 경우 해당 Meeting 조회
+    private SummaryUploadResult record(Long meetingId, String markdownUrl, String pdfUrl) {
+        return transactionTemplate.execute(status -> {
             Meeting meeting = meetingRepository.findById(meetingId)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미팅입니다: " + meetingId));
 
-            // 미팅이 해당 클래스에 속하는지 확인
-            if (!meeting.getClassRoom().getId().equals(classId)) {
-                throw new IllegalArgumentException("미팅이 해당 클래스에 속하지 않습니다.");
+            if (meeting.hasSummary()) {
+                log.info("경쟁하는 요청이 먼저 기록했다. 이번 업로드는 반영하지 않는다 - meetingId={}", meetingId);
+                return existingResult(meeting);
             }
-            
-            log.info("📋 기존 Meeting 사용 - meetingId: {}", meetingId);
-            return meeting;
-        } else {
-            // meetingId가 없으면 해당 클래스의 최신 미팅 조회 또는 새로 생성
-            Optional<Meeting> latestMeeting = meetingRepository.findTopByClassRoomIdOrderByStartTimeDesc(classId);
-            
-            if (latestMeeting.isPresent()) {
-                Meeting meeting = latestMeeting.get();
-                log.info("📋 최신 Meeting 사용 - meetingId: {}", meeting.getId());
-                return meeting;
-            } else {
-                // 미팅이 없으면 새로 생성
-                Meeting newMeeting = Meeting.builder()
-                        .classRoom(classRoom)
-                        .title("AI 요약 미팅 - " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
-                        .description("파이썬 AI 서버에서 생성된 요약본")
-                        .startTime(LocalDateTime.now())
-                        .build();
-                
-                Meeting savedMeeting = meetingRepository.save(newMeeting);
-                log.info("📋 새 Meeting 생성 - meetingId: {}", savedMeeting.getId());
-                return savedMeeting;
+
+            meeting.recordSummary(markdownUrl, pdfUrl);
+            log.info("요약본 기록 완료 - meetingId={}, md={}, pdf={}", meetingId, markdownUrl != null, pdfUrl != null);
+            return new SummaryUploadResult(
+                    meetingId, meeting.getClassRoom().getId(), markdownUrl, pdfUrl, false);
+        });
+    }
+
+    private SummaryUploadResult existingResult(Meeting meeting) {
+        return new SummaryUploadResult(
+                meeting.getId(),
+                meeting.getClassRoom().getId(),
+                meeting.getSummaryMdUrl(),
+                meeting.getSummaryPdfUrl(),
+                true);
+    }
+
+    private String upload(MultipartFile file, String directory, String fileName) {
+        if (isAbsent(file)) {
+            return null;
+        }
+        return s3Uploader.uploadMultipartFile(file, directory, fileName);
+    }
+
+    /**
+     * 요약본 조회. 이제 MD 와 PDF 를 <b>둘 다</b> 돌려준다.
+     * 이전에는 s3url 단일 컬럼이라 PDF 가 MD 를 덮어썼고 MD 는 조회할 방법이 없었다.
+     */
+    @Transactional(readOnly = true)
+    public Optional<SummaryUploadResult> findLatestSummary(Long classId) {
+        return meetingRepository
+                .findTopByClassRoomIdAndS3urlIsNotNullOrderByStartTimeDesc(classId)
+                .map(this::existingResult);
+    }
+
+    // --- 검증 ---
+
+    /**
+     * 이전 구현은 빈 파일이면 경고만 찍고 검증을 <b>건너뛴 뒤 그대로 업로드</b>했다.
+     * 0바이트 객체가 S3 에 올라가고 DB 에 URL 이 박혔다.
+     */
+    private void validate(MultipartFile markdown, MultipartFile pdf) {
+        boolean hasMarkdown = !isAbsent(markdown);
+        boolean hasPdf = !isAbsent(pdf);
+
+        if (!hasMarkdown && !hasPdf) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다. Markdown(.md) 또는 PDF(.pdf) 중 하나는 필요합니다.");
+        }
+        if (hasMarkdown) {
+            requireExtensionOrType(markdown, ".md", "text/markdown", "text/x-markdown", "text/plain");
+            requireSizeUnder(markdown, MAX_MD_BYTES, "Markdown", "10MB");
+        }
+        if (hasPdf) {
+            requireExtensionOrType(pdf, ".pdf", "application/pdf");
+            requireSizeUnder(pdf, MAX_PDF_BYTES, "PDF", "50MB");
+        }
+    }
+
+    /** 파일 파트가 아예 없거나, 이름이 없거나, 내용이 비었으면 "없는 것" 으로 본다. */
+    private boolean isAbsent(MultipartFile file) {
+        return file == null || file.isEmpty() || file.getOriginalFilename() == null;
+    }
+
+    private void requireExtensionOrType(MultipartFile file, String extension, String... contentTypes) {
+        String name = file.getOriginalFilename();
+        if (name != null && name.toLowerCase().endsWith(extension)) {
+            return;
+        }
+        String actual = file.getContentType();
+        if (actual != null) {
+            for (String allowed : contentTypes) {
+                if (actual.contains(allowed)) {
+                    return;
+                }
             }
         }
+        throw new IllegalArgumentException(
+                "유효하지 않은 %s 파일입니다: name=%s, contentType=%s".formatted(extension, name, actual));
     }
 
-    /**
-     * 클래스의 요약본 정보 조회
-     */
-    public Map<String, String> getSummaryInfo(Long classId) {
-
-        ClassRoom classRoom = classRepository.findById(classId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 클래스입니다: " + classId));
-
-        Map<String, String> result = new HashMap<>();
-        result.put("class_id", classId.toString());
-        result.put("class_name", classRoom.getTitle());
-
-        // 해당 클래스의 요약본이 있는 최신 미팅 조회 (s3url 기준)
-        Optional<Meeting> latestMeetingWithSummary = meetingRepository
-                .findTopByClassRoomIdAndS3urlIsNotNullOrderByStartTimeDesc(classId);
-
-        if (latestMeetingWithSummary.isPresent()) {
-            Meeting meeting = latestMeetingWithSummary.get();
-            result.put("latest_meeting_id", meeting.getId().toString());
-            result.put("latest_meeting_title", meeting.getTitle());
-            result.put("latest_meeting_s3_url", meeting.getS3url());
-            result.put("latest_meeting_start_time", meeting.getStartTime().toString());
-        } else {
-            result.put("message", "요약본이 있는 미팅이 없습니다.");
-        }
-
-        return result;
-    }
-
-    /**
-     * Markdown 파일 검증
-     */
-    private void validateMarkdownFile(MultipartFile file) {
-        if (file.isEmpty()) {
-            throw new IllegalArgumentException("Markdown 파일이 비어있습니다.");
-        }
-
-        String contentType = file.getContentType();
-        String fileName = file.getOriginalFilename();
-
-        log.debug("📝 Markdown 파일 검증 - fileName: {}, contentType: {}, size: {}", 
-                 fileName, contentType, file.getSize());
-
-        // Content-Type 또는 파일 확장자로 검증
-        boolean isValidMd = (contentType != null &&
-                (contentType.contains("text/markdown") ||
-                        contentType.contains("text/x-markdown") ||
-                        contentType.contains("text/plain"))) ||
-                (fileName != null && fileName.toLowerCase().endsWith(".md"));
-
-        if (!isValidMd) {
-            throw new IllegalArgumentException("유효하지 않은 Markdown 파일입니다.");
-        }
-
-        // 파일 크기 제한 (10MB)
-        if (file.getSize() > 10 * 1024 * 1024) {
-            throw new IllegalArgumentException("Markdown 파일 크기가 너무 큽니다. (최대 10MB)");
-        }
-    }
-
-    /**
-     * PDF 파일 검증
-     */
-    private void validatePdfFile(MultipartFile file) {
-        if (file.isEmpty()) {
-            throw new IllegalArgumentException("PDF 파일이 비어있습니다.");
-        }
-
-        String contentType = file.getContentType();
-        String fileName = file.getOriginalFilename();
-
-        log.debug("📄 PDF 파일 검증 - fileName: {}, contentType: {}, size: {}", 
-                 fileName, contentType, file.getSize());
-
-        // Content-Type 또는 파일 확장자로 검증
-        boolean isValidPdf = (contentType != null && contentType.contains("application/pdf")) ||
-                (fileName != null && fileName.toLowerCase().endsWith(".pdf"));
-
-        if (!isValidPdf) {
-            throw new IllegalArgumentException("유효하지 않은 PDF 파일입니다.");
-        }
-
-        // 파일 크기 제한 (50MB)
-        if (file.getSize() > 50 * 1024 * 1024) {
-            throw new IllegalArgumentException("PDF 파일 크기가 너무 큽니다. (최대 50MB)");
+    private void requireSizeUnder(MultipartFile file, long limit, String label, String humanLimit) {
+        if (file.getSize() > limit) {
+            throw new IllegalArgumentException("%s 파일이 너무 큽니다. (최대 %s)".formatted(label, humanLimit));
         }
     }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -61,6 +61,9 @@ spring:
             user-name-attribute: id
 
 edumeet:
+  # 테스트 전용 더미 값. (#27)
+  internal:
+    api-token: test-internal-token
   upload:
     path: ${java.io.tmpdir}/edumeet-test-upload
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,3 +70,9 @@ springdoc:
 logging:
   level:
     com.edu.edumeet: INFO
+
+edumeet:
+  internal:
+    # 서버 간 호출용 공유 시크릿. 파이썬 AI 서버가 X-Internal-Token 헤더로 보낸다. (#27)
+    # 비어 있으면 /api/v1/internal/** 은 전부 거부된다 (fail-closed).
+    api-token: ${INTERNAL_API_TOKEN:}

--- a/src/main/resources/db/migration/V2__add_meeting_summary_urls.sql
+++ b/src/main/resources/db/migration/V2__add_meeting_summary_urls.sql
@@ -1,0 +1,15 @@
+-- 요약본 MD/PDF URL 을 각각 저장한다. (#27)
+--
+-- 기존에는 s3url 단일 컬럼이라 PDF 가 MD 를 덮어썼다.
+-- MD URL 은 HTTP 응답에만 담겨 있어서 나중에 조회할 방법이 없었다.
+--
+-- s3url 은 기존 조회 코드와의 호환을 위해 남긴다.
+-- PDF 가 있으면 PDF, 없으면 MD 를 담는다.
+
+ALTER TABLE meeting
+    ADD COLUMN summary_md_url  VARCHAR(500) NULL COMMENT '요약본 Markdown S3 URL',
+    ADD COLUMN summary_pdf_url VARCHAR(500) NULL COMMENT '요약본 PDF S3 URL';
+
+-- 기존 데이터는 어느 형식인지 URL 확장자로만 판별할 수 있다.
+UPDATE meeting SET summary_pdf_url = s3url WHERE s3url LIKE '%.pdf';
+UPDATE meeting SET summary_md_url  = s3url WHERE s3url LIKE '%.md';

--- a/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
+++ b/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
@@ -77,11 +77,29 @@ class FlywayMigrationTest {
     void hibernate_accepts_the_migrated_schema() {
         // ddl-auto=none 인데 컨텍스트가 떴다는 것은
         // Flyway 가 만든 스키마로 EntityManagerFactory 가 구성됐다는 뜻이다.
-        Integer meetingColumns = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM information_schema.columns " +
-                "WHERE table_schema = DATABASE() AND table_name = 'meeting'",
-                Integer.class);
+        // 컬럼 개수를 세는 단언은 마이그레이션이 추가될 때마다 깨진다.
+        // 개수가 아니라 "엔티티가 요구하는 컬럼이 있는가" 를 본다.
+        assertThat(columnsOf("meeting"))
+                .contains("id", "class_room_id", "title", "start_time", "session_type", "s3url");
+    }
 
-        assertThat(meetingColumns).isEqualTo(8);
+    @Test
+    @DisplayName("V2 가 요약본 컬럼을 추가한다")
+    void v2_adds_summary_columns() {
+        List<String> applied = jdbc.queryForList(
+                "SELECT version FROM flyway_schema_history WHERE success = 1 ORDER BY installed_rank",
+                String.class);
+        assertThat(applied).as("V2 도 적용되어야 한다").contains("2");
+
+        assertThat(columnsOf("meeting"))
+                .as("MD 와 PDF URL 을 각각 저장한다 (#27)")
+                .contains("summary_md_url", "summary_pdf_url");
+    }
+
+    private List<String> columnsOf(String table) {
+        return jdbc.queryForList(
+                "SELECT column_name FROM information_schema.columns " +
+                "WHERE table_schema = DATABASE() AND table_name = ?",
+                String.class, table);
     }
 }

--- a/src/test/java/com/edu/edumeet/integration/openvidu/MeetingSummaryUploadTest.java
+++ b/src/test/java/com/edu/edumeet/integration/openvidu/MeetingSummaryUploadTest.java
@@ -1,0 +1,188 @@
+package com.edu.edumeet.integration.openvidu;
+
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.config.internal.InternalApiTokenFilter;
+import com.edu.edumeet.member.domain.Member;
+import com.edu.edumeet.openvidu.domain.Meeting;
+import com.edu.edumeet.openvidu.domain.SessionType;
+import com.edu.edumeet.s3.util.S3Uploader;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 파이썬 AI 서버의 요약본 업로드 경로를 검증한다. (#27)
+ *
+ * <p>이 경로는 #23 이전에 {@code /api/v1/**} permitAll 에 묻혀 <b>인증 없이 열려 있었다.</b>
+ * 누구나 임의 클래스에 요약본을 덮어쓸 수 있었다.
+ *
+ * <p>{@code @AutoConfigureMockMvc} 를 쓴다. {@code webAppContextSetup} 은
+ * 시큐리티 필터 체인을 타지 않아서 인증이 뚫려 있어도 통과한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("AI 요약본 업로드")
+class MeetingSummaryUploadTest {
+
+    private static final String TOKEN = "test-internal-token";
+
+    @Autowired MockMvc mockMvc;
+    @PersistenceContext EntityManager em;
+
+    @MockitoBean S3Uploader s3Uploader;
+
+    private Long meetingId;
+
+    @BeforeEach
+    void setUp() {
+        Member owner = Member.builder().email("owner@test").nickname("주인").password("x").build();
+        em.persist(owner);
+        ClassRoom classRoom = ClassRoom.builder()
+                .member(owner).title("클래스").description("-")
+                .participantLimit(30).isDeleted(false).build();
+        em.persist(classRoom);
+        Meeting meeting = Meeting.builder()
+                .classRoom(classRoom).title("회의").description("-")
+                .sessionType(SessionType.INTERACTIVE)
+                .startTime(LocalDateTime.now().minusHours(2))
+                .endTime(LocalDateTime.now().minusHours(1))
+                .build();
+        em.persist(meeting);
+        em.flush();
+        meetingId = meeting.getId();
+
+        given(s3Uploader.uploadMultipartFile(any(), anyString(), anyString()))
+                .willAnswer(inv -> "https://s3.test/" + inv.getArgument(2));
+    }
+
+    private MockMultipartFile md(String content) {
+        return new MockMultipartFile("summary_md", "summary.md", "text/markdown", content.getBytes());
+    }
+
+    private MockMultipartFile pdf(String content) {
+        return new MockMultipartFile("summary_pdf", "summary.pdf", "application/pdf", content.getBytes());
+    }
+
+    // --- 인증 ---
+
+    @Test
+    @DisplayName("토큰 없이 부르면 401 이다")
+    void 토큰_없으면_401() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId).file(md("# 요약")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("토큰이 틀리면 401 이다")
+    void 토큰_틀리면_401() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(md("# 요약"))
+                        .header(InternalApiTokenFilter.HEADER, "wrong-token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- 정상 경로 ---
+
+    @Test
+    @DisplayName("MD 와 PDF 를 둘 다 저장한다 - 이전에는 PDF 가 MD 를 덮어썼다")
+    void MD_와_PDF_를_둘다_저장한다() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(md("# 요약")).file(pdf("%PDF-1.4"))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.alreadyExisted").value(false))
+                .andExpect(jsonPath("$.markdownUrl").exists())
+                .andExpect(jsonPath("$.pdfUrl").exists());
+
+        em.flush(); em.clear();
+        Meeting saved = em.find(Meeting.class, meetingId);
+        assertThat(saved.getSummaryMdUrl()).as("MD URL 이 DB 에 남아야 한다").isNotNull();
+        assertThat(saved.getSummaryPdfUrl()).as("PDF URL 이 DB 에 남아야 한다").isNotNull();
+        assertThat(saved.getS3url()).as("하위 호환 필드는 PDF 를 가리킨다").isEqualTo(saved.getSummaryPdfUrl());
+    }
+
+    // --- 멱등성 ---
+
+    @Test
+    @DisplayName("재시도하면 S3 에 다시 올리지 않고 200 을 준다")
+    void 재시도는_중복_업로드를_만들지_않는다() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(md("# 요약"))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isCreated());
+        em.flush();
+
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(md("# 요약"))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alreadyExisted").value(true));
+
+        verify(s3Uploader, org.mockito.Mockito.times(1))
+                .uploadMultipartFile(any(), anyString(), anyString());
+    }
+
+    // --- 검증 (회귀 방지) ---
+
+    @Test
+    @DisplayName("없는 meetingId 는 500 이 아니라 400 이다")
+    void 없는_미팅은_400() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", 999999L)
+                        .file(md("# 요약"))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("빈 파일은 거부한다 - 이전에는 0바이트가 S3 에 올라갔다")
+    void 빈_파일은_거부한다() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(new MockMultipartFile("summary_md", "summary.md", "text/markdown", new byte[0]))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isBadRequest());
+
+        verify(s3Uploader, never()).uploadMultipartFile(any(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("파일이 하나도 없으면 400 이다")
+    void 파일이_없으면_400() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("확장자가 맞지 않으면 400 이다")
+    void 잘못된_확장자는_400() throws Exception {
+        mockMvc.perform(multipart("/api/v1/internal/meetings/{id}/summary", meetingId)
+                        .file(new MockMultipartFile("summary_pdf", "evil.exe",
+                                "application/octet-stream", "MZ".getBytes()))
+                        .header(InternalApiTokenFilter.HEADER, TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/edu/edumeet/integration/security/ApiAuthenticationRequiredTest.java
+++ b/src/test/java/com/edu/edumeet/integration/security/ApiAuthenticationRequiredTest.java
@@ -40,7 +40,11 @@ class ApiAuthenticationRequiredTest {
         mockMvc.perform(get("/api/v1/meetingroom/1"))
                 .andExpect(status().isUnauthorized());
 
-        mockMvc.perform(post("/api/v1/meeting/summary/1"))
+        mockMvc.perform(get("/api/v1/meeting/summary/1"))
+                .andExpect(status().isUnauthorized());
+
+        // 서버 간 경로도 사용자 JWT 로는 못 뚫는다. X-Internal-Token 이 있어야 한다. (#27)
+        mockMvc.perform(post("/api/v1/internal/meetings/1/summary"))
                 .andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
Closes #27

파이썬 AI 서버가 요약본을 올리는 경로를 코드 리딩으로 점검해 **결함 8건**을 고쳤다.
전부 테스트로 고정했다 — **고쳤다는 주장이 아니라 회귀하면 깨지는 테스트**로 남긴다.

## 🔴 이 경로는 인증 없이 열려 있었다

#23 이전에는 `/api/v1/**` 이 permitAll 이라 **누구나 임의 클래스에 요약본을 덮어쓸 수 있었다.**
`anyRequest().authenticated()` 를 살리자 파이썬 호출이 401 이 됐다 — **버그가 만들어진 게 아니라 드러난 것**이다.

경로를 분리했다. 사용자 인증 규칙과 서비스 인증 규칙이 한 목록에 섞이면 어느 쪽이 적용되는지 읽어서 알 수 없다.

```
/api/v1/**            사용자 JWT
/api/v1/internal/**   X-Internal-Token   ← hasRole("INTERNAL")
```

- **토큰이 비어 있으면 전부 거부**한다 (fail-closed)
- 비교는 **상수 시간**이다 (`MessageDigest.isEqual`) — 바이트별로 일찍 끊으면 응답 시간으로 한 글자씩 맞출 수 있다
- 필터는 응답을 직접 쓰지 않고 인증을 설정하지 않은 채 넘긴다. 여기서 401 을 쓰면 EntryPoint 응답 형식과 어긋난다

## 🔴 컨트롤러의 400 분기가 죽은 코드였다

```java
// 서비스
} catch (Exception e) {
    throw new RuntimeException("요약본 업로드 실패: " + e.getMessage(), e);
}

// 컨트롤러 — 절대 실행되지 않는다
} catch (IllegalArgumentException e) { return ResponseEntity.badRequest()...; }
```

`IllegalArgumentException extends RuntimeException extends Exception` 이라 **검증 실패도 재포장됐다.**
**없는 `classId` 를 보내도 400 이 아니라 500 이 나갔다.**

재포장을 걷어내고 전역 advice 에 `IllegalArgumentException → 400` 을 추가했다.

## 🔴 트랜잭션 안에서 S3 업로드

메서드 전체가 `@Transactional` 이고 그 안에서 S3 네트워크 I/O 를 두 번 했다.
**PDF 50MB 를 올리는 동안 DB 커넥션을 계속 붙잡는다.** 커넥션 풀 고갈 경로다.

```
검증        (트랜잭션 없음)
회의 조회    (짧은 읽기)
S3 업로드    (트랜잭션 없음 ← 여기가 오래 걸린다)
DB 기록      (짧은 쓰기)
```

### 왜 TransactionTemplate 인가

오케스트레이션 메서드에서 `this.record(...)` 를 부르면 **Spring AOP 프록시를 거치지 않아
`@Transactional` 이 조용히 무시된다.** 별도 빈으로 쪼개거나 `TransactionTemplate` 을 쓰는 수밖에 없는데,
**트랜잭션 경계가 코드에 그대로 보이는** 쪽을 택했다.

## 🟠 유령 미팅 / 덮어쓰기

`meeting_id` 가 없으면 이전 구현은
1. 해당 클래스의 **최신 회의에 덮어쓰거나**
2. 회의가 없으면 **"AI 요약 미팅" 을 새로 생성**했다

열린 적 없는 회의가 DB 에 생기고 엉뚱한 회의에 요약본이 붙었다.
**요약본은 이미 끝난 회의의 산출물**이므로 회의를 만들 이유가 없다 → `meetingId` 를 경로 필수로 바꿨다.

## 🟠 MD 가 사라졌다

`Meeting.s3url` 단일 컬럼이라 **PDF 가 MD 를 덮어썼다.**
MD URL 은 HTTP 응답에만 담겨서 **나중에 조회할 방법이 없었다.**

V2 마이그레이션으로 `summary_md_url` / `summary_pdf_url` 을 분리했다.
`s3url` 은 기존 조회 코드 호환을 위해 남기고 PDF(없으면 MD)를 가리킨다.

## 🟠 멱등성

파이썬이 타임아웃 후 재시도하면 S3 에 중복 객체가 쌓이고 `s3url` 이 갱신됐다.

- **빠른 경로**: 이미 있으면 S3 업로드 자체를 건너뛴다
- **쓰기 트랜잭션 안에서 한 번 더 확인** — 그 사이 다른 요청이 먼저 기록했을 수 있다

`201`(이번에 기록) / `200`(재시도, `alreadyExisted: true`) 로 구분해서 준다.
파이썬 로그에서 최초 성공과 재시도 성공이 구분돼야 읽힌다.

## 🟠 빈 파일이 통과했다

```java
if (summaryMd.isEmpty()) {
    log.warn("⚠️ 비어있지만 계속 진행합니다.");   // ← 검증을 건너뛴다
} else {
    validateMarkdownFile(summaryMd);
}
```

검증 메서드 안에도 `isEmpty()` 체크가 있었지만 **호출 자체가 건너뛰어졌다.**
0바이트 객체가 S3 에 올라가고 DB 에 URL 이 박혔다.

## 테스트

```
테스트 185개 통과 (기존 176 + 신규 9)
```

| 테스트 | 고정하는 결함 |
|---|---|
| `토큰_없으면_401` / `토큰_틀리면_401` | 인증 부재 |
| `없는_미팅은_400` | 500 재포장 |
| `MD_와_PDF_를_둘다_저장한다` | PDF 가 MD 덮어씀 |
| `재시도는_중복_업로드를_만들지_않는다` | 멱등성 |
| `빈_파일은_거부한다` | 0바이트 업로드 |
| `잘못된_확장자는_400` / `파일이_없으면_400` | 검증 |
| `v2_adds_summary_columns` | 마이그레이션 적용 |

`@AutoConfigureMockMvc` 를 쓴다. `webAppContextSetup` 은 **시큐리티 필터 체인을 타지 않아서**
인증이 뚫려 있어도 전부 통과한다.

## 남는 것

- **파이썬 저장소가 이 리포에 없어 클라이언트 변경은 미반영**이다.
  맞춰야 할 규약은 [`docs/ops/03-internal-api-contract.md`](docs/ops/03-internal-api-contract.md) 에 남겼다
- **토큰 회전 절차가 없다.** 유출되면 환경변수를 바꾸고 재배포해야 한다.
  호출 빈도가 낮고(회의당 1회) 내부 호출이라 감수했다
- 요약본 **재생성 경로가 없다** (현재는 첫 기록이 이긴다). 필요해지면 명시적 경로를 따로 만든다

관련: #23, #29