### PR TITLE
feat: 관측 기반 구축 - Prometheus + Grafana (#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,11 @@ EXPOSE 8080
 #   ExitOnOutOfMemoryError  OOM 이면 죽는다. 좀비 상태로 버티는 것보다 재시작이 낫다
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
 ENV SPRING_PROFILES_ACTIVE=prod
+# 액추에이터는 관리 포트로 분리한다. 지표를 인터넷 쪽 포트에 두지 않기 위해서다. (#28)
+# 이 포트가 바뀌면 아래 HEALTHCHECK 도 같이 바뀐다.
+ENV MANAGEMENT_PORT=9090
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD curl -fsS http://localhost:8080/actuator/health || exit 1
+  CMD curl -fsS http://localhost:${MANAGEMENT_PORT:-9090}/actuator/health || exit 1
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     // 컨테이너 healthcheck 와 운영 관측에 쓴다. 노출 엔드포인트는 application.yml 에서 제한한다.
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    // /actuator/prometheus 는 이 레지스트리가 있어야 생긴다. (#28)
+    // exposure.include 에 prometheus 를 적어둬도 레지스트리가 없으면 404 였다.
+    implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.data:spring-data-redis:3.2.5")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,6 +51,11 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
+    # ★ 관리 포트(9090)는 publish 하지 않는다. expose 만 한다.
+    #   지표는 URI 패턴·호출량·커넥션 수 같은 내부 정보를 담는다.
+    #   Prometheus 는 같은 네트워크 안에 있으므로 이걸로 충분하다.
+    expose:
+      - "9090"
     volumes:
       - app_logs:/app/logs
       - app_upload:/app/upload
@@ -64,7 +69,46 @@ services:
         condition: service_healthy
     networks: [edumeet]
 
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    container_name: edumeet-prometheus
+    restart: unless-stopped
+    # 마찬가지로 외부 노출 금지. Grafana 가 네트워크 안에서 붙는다.
+    expose:
+      - "9090"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      # 개인 서버라 디스크가 넉넉하지 않다. 15일이면 회귀 분석에 충분하다.
+      - --storage.tsdb.retention.time=15d
+    depends_on: [app]
+    networks: [edumeet]
+
+  grafana:
+    image: grafana/grafana:11.5.1
+    container_name: edumeet-grafana
+    restart: unless-stopped
+    # 사람이 봐야 하므로 이것만 publish 한다. 비밀번호는 .env 로 준다.
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD 를 .env 에 설정해야 한다}
+      # 익명 접근을 막는다. 지표는 내부 정보다.
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      # 대시보드를 UI 로 만들면 재현이 안 된다. 파일로 넣고 저장소에 커밋한다.
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on: [prometheus]
+    networks: [edumeet]
+
 volumes:
+  prometheus_data:
+  grafana_data:
   mysql_data:
   redis_data:
   app_logs:

--- a/docs/ops/04-observability.md
+++ b/docs/ops/04-observability.md
@@ -1,0 +1,142 @@
+# 관측 기반 — 붕괴를 보려면 먼저 보여야 한다
+
+> 작성 2026-08-22 · #28 · Phase 0
+
+## 0. 왜 지금인가
+
+[전송 비용 모델](02-egress-cost-model.md)의 결론이 뒤집히면서 이 프로젝트의 주제가
+**비용 최적화가 아니라 가용성 한계 측정**이 됐다.
+
+> 무료 10TB 를 넘기려면 시청자 7,400명 × 1시간.
+> **그 전에 2 OCPU / 12GB VM 이 먼저 죽는다.**
+
+한계를 측정하려면 **관측이 먼저** 있어야 한다.
+지금까지는 k6 로 밖에서 때리고 응답만 봤다. 안에서 무엇이 먼저 포화되는지는 볼 수 없었다.
+
+## 1. 발견 — 설정만 있고 동작하지 않았다
+
+```yaml
+management.endpoints.web.exposure.include: health, info, metrics, prometheus
+```
+
+**`/actuator/prometheus` 는 404 였다.** `micrometer-registry-prometheus` 의존성이 없었기 때문이다.
+
+> `include` 는 **"있으면 열어라"** 이지 **"만들어라"** 가 아니다.
+
+### 그리고 의존성을 넣어도 여전히 404 였다
+
+```
+@ConditionalOnEnabledMetricsExport management.defaults.metrics.export.enabled is considered false
+```
+
+`management.prometheus.metrics.export.enabled: true` 를 **명시해야** 레지스트리가 생성된다.
+
+찾기 어려웠던 이유 — **`/actuator/metrics` 는 200 이었다.**
+"액추에이터는 되는데 prometheus 만 안 된다" 로 보여서 보안 설정을 한참 뒤졌다.
+
+**설정 파일만 보고 "관측이 되어 있다" 고 믿으면 안 된다.**
+그래서 [`PrometheusEndpointTest`](../../src/test/java/com/edu/edumeet/integration/observability/PrometheusEndpointTest.java) 로 고정했다.
+
+## 2. 곁다리로 나온 진짜 버그 — 모든 에러가 401 로 둔갑했다
+
+디버깅 중 발견했다.
+
+```
+Secured GET /actuator/prometheus     ← 보안은 통과
+Securing GET /error                  ← 404 라서 /error 로 포워드
+→ 401 Unauthorized                   ← /error 가 인증을 요구한다
+```
+
+**Spring 은 처리되지 않은 요청을 `/error` 로 포워드하는데, 이 경로가 인증을 요구하고 있었다.**
+그래서 **404 든 500 이든 전부 401 로 나갔다.** 액추에이터만의 문제가 아니라 **API 전체의 문제**였다.
+
+오타 난 URL 을 호출하면 "인증이 잘못됐나" 를 뒤지게 된다. `/error` 를 permitAll 로 열었다.
+
+## 3. 설계 — 지표를 인터넷에 두지 않는다
+
+```
+8080  서비스 포트   publish   ← 인터넷
+9090  관리 포트     expose    ← 컨테이너 네트워크 안에서만
+```
+
+지표는 **URI 패턴·호출량·커넥션 수** 같은 내부 정보를 담는다.
+인증을 붙이는 대신 **네트워크로 격리**했다. Prometheus 는 같은 네트워크 안에 있다.
+
+| 서비스 | 공개 |
+|---|---|
+| app | **8080** (9090 은 내부만) |
+| grafana | **3001** |
+| mysql / redis / prometheus | 내부만 |
+
+### 부작용 — 헬스체크가 옮겨간다
+
+**포트를 분리하면 액추에이터가 서비스 포트에서 통째로 사라진다.**
+`Dockerfile` 의 `HEALTHCHECK` 가 `localhost:8080/actuator/health` 를 보고 있었으므로
+**컨테이너가 영영 unhealthy 로 남았을 것이다.** 관리 포트로 바꿨다.
+
+이것도 테스트로 고정했다 (`health_moves_to_management_port`).
+
+### 포트 판정을 손으로 하지 않는다
+
+```java
+if (ManagementPortType.get(environment) == ManagementPortType.DIFFERENT) { ... }
+```
+
+`management.server.port=0`(임의 포트)이면 `server.port` 도 0 일 수 있어서
+**직접 비교하면 "같은 포트" 로 잘못 판정**된다. Boot 가 이미 이 판단을 한다.
+
+## 4. 대시보드는 손으로 만들지 않는다
+
+```bash
+python3 scripts/make_dashboard.py    # → observability/grafana/dashboards/edumeet-baseline.json
+```
+
+UI 로 만든 대시보드는 **재현이 안 되고, 누가 무엇을 왜 넣었는지 남지 않는다.**
+생성 스크립트에 의도를 주석으로 남기고 결과 JSON 을 커밋한다.
+
+| 패널 | 보는 이유 |
+|---|---|
+| HTTP 처리율 | 멈추면 포화. 다만 **첫 신호는 여기가 아니다** |
+| **p50 / p95 / p99** | **평균은 포화를 숨긴다. p99 가 먼저 벌어진다** |
+| 5xx 비율 | 0 이어도 안심할 수 없다 — 지연으로만 나타나는 포화가 있다 |
+| 느린 엔드포인트 top | 어디가 느린지 URI 단위 |
+| JVM 힙 / GC 정지 | 브로드캐스트가 힙을 밀면 여기부터 반응 |
+| CPU | 2 OCPU. **여기가 먼저 찬다** |
+| **Hikari 대기(pending)** | **0 이 아니면 커넥션을 기다리는 스레드가 있다** — 트랜잭션 안 느린 I/O 가 여기서 드러난다 |
+
+### `or vector(0)` 가 없으면 "No data" 가 뜬다
+
+5xx 가 하나도 없으면 시계열 자체가 생기지 않아 패널이 비어 보인다.
+**"에러 0" 과 "지표 고장" 이 구분되지 않는다.** 그래서 `or vector(0)` 를 붙였다.
+
+## 5. 검증 — 실제로 긁히는지 확인했다
+
+파일만 쓰고 "됐다" 고 하지 않는다.
+
+```
+스크레이프 대상    edumeet-app   up   /actuator/prometheus
+지표 라인          160개, application="edumeet" 태그 확인
+서비스 포트         /actuator/prometheus → 404 (의도대로)
+대시보드 PromQL     9개 전부 값 반환
+```
+
+`promtool check config` 로 Prometheus 설정 문법도 확인했다.
+
+## 6. 다음 — 채팅이 있어야 붙는다
+
+이 문서의 범위는 **지금 있는 코드**에 대한 기준선이다.
+
+붕괴 5단계 중 ②(스레드 풀 포화)·③(느린 클라이언트)·⑤(다중 인스턴스)를 보려면
+**WebSocket 채팅을 먼저 만들어야 한다.** 이 리포에는 아직 없다.
+
+| 나중에 추가 | |
+|---|---|
+| `WebSocketMessageBrokerStats` → Micrometer | Spring 이 이미 계산하는데 30초마다 INFO 로그로만 나간다 |
+| inbound/outbound **큐 길이** | 기본 큐가 무한이라 **포화가 에러가 아니라 지연으로만** 나타난다 |
+| 세션 버퍼 / 강제 종료 수 | 느린 클라이언트 |
+
+## 7. 미확인
+
+- **Grafana 대시보드를 실제 화면으로 확인하지 않았다.** PromQL 이 값을 내는 것까지만 검증했다
+- 알림(Alertmanager) 없음. 기준선을 잡기 전에는 임계값을 정할 수 없다
+- Prometheus 보존 15일은 임의값. 디스크 사용량을 보고 조정한다

--- a/observability/grafana/dashboards/edumeet-baseline.json
+++ b/observability/grafana/dashboards/edumeet-baseline.json
@@ -1,0 +1,541 @@
+{
+  "uid": "edumeet-baseline",
+  "title": "EduMeet — 기준 지표",
+  "description": "붕괴 측정 이전의 기준선. 채팅을 붙이기 전 상태를 여기서 확인한다. (#28)",
+  "tags": [
+    "edumeet",
+    "baseline"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP 처리율 (req/s)",
+      "type": "timeseries",
+      "description": "처리율이 멈추면 포화다. 다만 포화의 첫 신호는 여기가 아니라 p99 다.",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{service=\"edumeet\"}[1m]))",
+          "legendFormat": "전체",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{service=\"edumeet\"}[1m]))",
+          "legendFormat": "{{status}}",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "HTTP 지연 p50 / p95 / p99",
+      "type": "timeseries",
+      "description": "평균은 포화를 숨긴다. p99 가 먼저 벌어진다.",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p50",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p95",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p99",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "5xx 비율",
+      "type": "timeseries",
+      "description": "에러가 아니라 지연으로만 나타나는 포화도 있다. 이 값이 0 이어도 안심할 수 없다.",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(http_server_requests_seconds_count{service=\"edumeet\",status=~\"5..\"}[1m])) or vector(0)) / clamp_min(sum(rate(http_server_requests_seconds_count{service=\"edumeet\"}[1m])), 0.001)",
+          "legendFormat": "5xx 비율",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "느린 엔드포인트 top (p95)",
+      "type": "timeseries",
+      "description": "어디가 느린지 URI 단위로 본다.",
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 16,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "topk(5, histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{service=\"edumeet\"}[5m]))))",
+          "legendFormat": "{{uri}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "JVM 힙",
+      "type": "timeseries",
+      "description": "MaxRAMPercentage 가 안 먹으면 여기가 호스트 메모리 기준으로 잡힌다.",
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{service=\"edumeet\",area=\"heap\"})",
+          "legendFormat": "사용",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "sum(jvm_memory_committed_bytes{service=\"edumeet\",area=\"heap\"})",
+          "legendFormat": "커밋",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes{service=\"edumeet\",area=\"heap\"})",
+          "legendFormat": "최대",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "GC 정지 시간",
+      "type": "timeseries",
+      "description": "브로드캐스트가 힙을 밀어올리면 여기부터 반응한다.",
+      "gridPos": {
+        "x": 8,
+        "y": 14,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{service=\"edumeet\"}[1m])",
+          "legendFormat": "{{action}} {{cause}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "CPU 사용률",
+      "type": "timeseries",
+      "description": "2 OCPU 다. 여기가 먼저 차면 비용이 아니라 가용성이 한계다.",
+      "gridPos": {
+        "x": 16,
+        "y": 14,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "process_cpu_usage{service=\"edumeet\"}",
+          "legendFormat": "프로세스",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "system_cpu_usage{service=\"edumeet\"}",
+          "legendFormat": "시스템",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "DB 커넥션 풀 (Hikari)",
+      "type": "timeseries",
+      "description": "대기(pending)가 0 이 아니면 커넥션을 기다리는 스레드가 있다는 뜻이다. 트랜잭션 안에서 느린 I/O 를 하면 여기가 먼저 드러난다.",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{service=\"edumeet\"}",
+          "legendFormat": "사용 중",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "hikaricp_connections_idle{service=\"edumeet\"}",
+          "legendFormat": "유휴",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "hikaricp_connections_pending{service=\"edumeet\"}",
+          "legendFormat": "대기",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "커넥션 획득 대기 시간",
+      "type": "timeseries",
+      "description": "풀이 마르면 이 값이 먼저 튄다.",
+      "gridPos": {
+        "x": 12,
+        "y": 21,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "rate(hikaricp_connections_acquire_seconds_sum{service=\"edumeet\"}[1m]) / clamp_min(rate(hikaricp_connections_acquire_seconds_count{service=\"edumeet\"}[1m]), 0.001)",
+          "legendFormat": "평균 획득 시간",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+# 대시보드를 손으로 만들면 재현이 안 된다. JSON 을 저장소에 두고 자동 등록한다. (#28)
+apiVersion: 1
+providers:
+  - name: edumeet
+    folder: EduMeet
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+# 데이터소스를 UI 로 등록하면 컨테이너를 다시 만들 때마다 사라진다. 파일로 고정한다. (#28)
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,24 @@
+# Prometheus 스크레이프 설정 (#28)
+#
+# 앱의 관리 포트(9090)를 컨테이너 네트워크 안에서 긁는다.
+# 이 포트는 호스트로 publish 되지 않으므로 인터넷에서는 닿지 않는다.
+
+global:
+  # 5초는 과하고 60초는 붕괴 순간을 놓친다. 부하 시험 중에도 형태가 보이는 값.
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    env: prod
+
+scrape_configs:
+  - job_name: edumeet-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["app:9090"]
+        labels:
+          service: edumeet
+
+  # Prometheus 자기 자신. 스크레이프가 밀리는지 봐야 지표를 믿을 수 있다.
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/scripts/make_dashboard.py
+++ b/scripts/make_dashboard.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Grafana 대시보드 JSON 생성. (#28)
+
+대시보드를 UI 로 만들면 재현이 안 된다. 누가 무엇을 왜 넣었는지도 남지 않는다.
+여기서 만들고 결과 JSON 을 저장소에 커밋한다.
+
+    python3 scripts/make_dashboard.py
+
+패널을 바꾸려면 이 파일을 고치고 다시 돌린다. JSON 을 직접 편집하지 않는다.
+"""
+import json
+import pathlib
+
+OUT = pathlib.Path("observability/grafana/dashboards/edumeet-baseline.json")
+JOB = 'service="edumeet"'
+
+
+def target(expr, legend):
+    return {"expr": expr, "legendFormat": legend, "refId": "A", "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"}}
+
+
+def panel(pid, title, x, y, w, h, targets, unit="short", desc="", stack=False):
+    return {
+        "id": pid, "title": title, "type": "timeseries", "description": desc,
+        "gridPos": {"x": x, "y": y, "w": w, "h": h},
+        "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+        "targets": [dict(t, refId=chr(65 + i)) for i, t in enumerate(targets)],
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "custom": {"lineWidth": 1, "fillOpacity": 15 if not stack else 40,
+                           "stacking": {"mode": "normal" if stack else "none"}},
+            },
+            "overrides": [],
+        },
+        "options": {"legend": {"displayMode": "list", "placement": "bottom"},
+                    "tooltip": {"mode": "multi", "sort": "desc"}},
+    }
+
+
+# ── 붕괴를 보려면 "평균" 이 아니라 "꼬리" 와 "대기열" 을 봐야 한다.
+#    처리율이 그대로인데 p99 만 오르는 구간이 포화의 첫 신호다.
+panels = [
+    panel(1, "HTTP 처리율 (req/s)", 0, 0, 12, 8, [
+        target(f'sum(rate(http_server_requests_seconds_count{{{JOB}}}[1m]))', "전체"),
+        target(f'sum by (status) (rate(http_server_requests_seconds_count{{{JOB}}}[1m]))', "{{status}}"),
+    ], "reqps", "처리율이 멈추면 포화다. 다만 포화의 첫 신호는 여기가 아니라 p99 다."),
+
+    panel(2, "HTTP 지연 p50 / p95 / p99", 12, 0, 12, 8, [
+        target(f'histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{{{JOB}}}[1m])))', "p50"),
+        target(f'histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{{{JOB}}}[1m])))', "p95"),
+        target(f'histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{{{JOB}}}[1m])))', "p99"),
+    ], "s", "평균은 포화를 숨긴다. p99 가 먼저 벌어진다."),
+
+    # `or vector(0)` 이 없으면 5xx 가 하나도 없을 때 시계열 자체가 안 생겨서
+    # 패널이 "No data" 를 띄운다. "에러 0" 과 "지표 고장" 이 구분되지 않는다.
+    panel(3, "5xx 비율", 0, 8, 8, 6, [
+        target(f'(sum(rate(http_server_requests_seconds_count{{{JOB},status=~"5.."}}[1m])) or vector(0)) '
+               f'/ clamp_min(sum(rate(http_server_requests_seconds_count{{{JOB}}}[1m])), 0.001)', "5xx 비율"),
+    ], "percentunit", "에러가 아니라 지연으로만 나타나는 포화도 있다. 이 값이 0 이어도 안심할 수 없다."),
+
+    panel(4, "느린 엔드포인트 top (p95)", 8, 8, 16, 6, [
+        target(f'topk(5, histogram_quantile(0.95, sum by (le, uri) '
+               f'(rate(http_server_requests_seconds_bucket{{{JOB}}}[5m]))))', "{{uri}}"),
+    ], "s", "어디가 느린지 URI 단위로 본다."),
+
+    panel(5, "JVM 힙", 0, 14, 8, 7, [
+        target(f'sum(jvm_memory_used_bytes{{{JOB},area="heap"}})', "사용"),
+        target(f'sum(jvm_memory_committed_bytes{{{JOB},area="heap"}})', "커밋"),
+        target(f'sum(jvm_memory_max_bytes{{{JOB},area="heap"}})', "최대"),
+    ], "bytes", "MaxRAMPercentage 가 안 먹으면 여기가 호스트 메모리 기준으로 잡힌다."),
+
+    panel(6, "GC 정지 시간", 8, 14, 8, 7, [
+        target(f'rate(jvm_gc_pause_seconds_sum{{{JOB}}}[1m])', "{{action}} {{cause}}"),
+    ], "s", "브로드캐스트가 힙을 밀어올리면 여기부터 반응한다."),
+
+    panel(7, "CPU 사용률", 16, 14, 8, 7, [
+        target(f'process_cpu_usage{{{JOB}}}', "프로세스"),
+        target(f'system_cpu_usage{{{JOB}}}', "시스템"),
+    ], "percentunit", "2 OCPU 다. 여기가 먼저 차면 비용이 아니라 가용성이 한계다."),
+
+    panel(8, "DB 커넥션 풀 (Hikari)", 0, 21, 12, 7, [
+        target(f'hikaricp_connections_active{{{JOB}}}', "사용 중"),
+        target(f'hikaricp_connections_idle{{{JOB}}}', "유휴"),
+        target(f'hikaricp_connections_pending{{{JOB}}}', "대기"),
+    ], "short", "대기(pending)가 0 이 아니면 커넥션을 기다리는 스레드가 있다는 뜻이다. "
+                "트랜잭션 안에서 느린 I/O 를 하면 여기가 먼저 드러난다."),
+
+    panel(9, "커넥션 획득 대기 시간", 12, 21, 12, 7, [
+        target(f'rate(hikaricp_connections_acquire_seconds_sum{{{JOB}}}[1m]) '
+               f'/ clamp_min(rate(hikaricp_connections_acquire_seconds_count{{{JOB}}}[1m]), 0.001)', "평균 획득 시간"),
+    ], "s", "풀이 마르면 이 값이 먼저 튄다."),
+]
+
+dashboard = {
+    "uid": "edumeet-baseline",
+    "title": "EduMeet — 기준 지표",
+    "description": "붕괴 측정 이전의 기준선. 채팅을 붙이기 전 상태를 여기서 확인한다. (#28)",
+    "tags": ["edumeet", "baseline"],
+    "timezone": "browser",
+    "schemaVersion": 39,
+    "version": 1,
+    "refresh": "10s",
+    "time": {"from": "now-30m", "to": "now"},
+    "panels": panels,
+}
+
+OUT.parent.mkdir(parents=True, exist_ok=True)
+OUT.write_text(json.dumps(dashboard, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+print(f"{OUT}  패널 {len(panels)}개")

--- a/src/main/java/com/edu/edumeet/config/SecurityConfig.java
+++ b/src/main/java/com/edu/edumeet/config/SecurityConfig.java
@@ -7,6 +7,8 @@ import com.edu.edumeet.member.service.CustomOauth2UserService;
 import com.edu.edumeet.util.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -39,7 +41,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, Environment environment) throws Exception {
         log.info("SecurityFilterChain 설정 시작");
         
         http
@@ -58,9 +60,39 @@ public class SecurityConfig {
 
                 // 이전에는 목록 마지막에 "/api/v1/**" 이 있어서 위에 나열한 경로가 전부 무의미했고
                 // anyRequest().authenticated() 가 사실상 죽은 코드였다. (#23)
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers(
+                .authorizeHttpRequests(authorize -> {
+                    authorize.requestMatchers(CorsUtils::isPreFlightRequest).permitAll();
+
+                    // 관리 포트가 서비스 포트와 분리되어 있으면 actuator 를 통과시킨다. (#28)
+                    //
+                    // 지표는 URI 패턴·호출량·커넥션 수 같은 내부 정보를 담는다.
+                    // 그래서 인증이 아니라 "네트워크로 격리" 한다 -
+                    // docker-compose 에서 관리 포트는 expose 만 하고 publish 하지 않으므로
+                    // 컨테이너 네트워크 안(Prometheus)에서만 닿는다.
+                    //
+                    // 포트 번호를 손으로 비교하지 않는다. management.server.port=0 (임의 포트) 이면
+                    // server.port 도 0 일 수 있어서 "같은 포트" 로 잘못 판정되고, 규칙이 조용히 안 걸린다.
+                    // Boot 가 이미 이 판단을 한다 - 0 은 DIFFERENT 로 친다.
+                    //
+                    // 매처는 URI 로 직접 판단한다. EndpointRequest.toAnyEndpoint() 도,
+                    // requestMatchers("/actuator/**") 도 여기서는 걸리지 않는다 -
+                    // 관리 포트를 분리하면 액추에이터가 별도 자식 컨텍스트에서 돌아가는데
+                    // 이 필터 체인은 부모 컨텍스트에 있어서 핸들러 매핑을 해석하지 못하고
+                    // 매칭이 "조용히" 실패한다. 예외가 아니라 401 로만 드러나서 찾기 어렵다.
+                    //
+                    // 서비스 포트에서는 이 경로가 아예 존재하지 않으므로(404) permitAll 이어도 안전하다.
+                    if (ManagementPortType.get(environment) == ManagementPortType.DIFFERENT) {
+                        String basePath = environment.getProperty("management.endpoints.web.base-path", "/actuator");
+                        log.info("관리 포트가 분리되어 있다. {} 이하는 네트워크 격리로 보호한다.", basePath);
+                        authorize.requestMatchers(r -> {
+                            String uri = r.getRequestURI();
+                            return uri.equals(basePath) || uri.startsWith(basePath + "/");
+                        }).permitAll();
+                    } else {
+                        log.warn("관리 포트가 분리되지 않았다. actuator 는 health 외에는 인증을 요구한다.");
+                    }
+
+                    authorize.requestMatchers(
                                 "/api/v1/members/signup",
                                 "/api/v1/members/login",
                                 "/api/v1/members/refresh",
@@ -83,13 +115,17 @@ public class SecurityConfig {
                                 // 컨테이너 healthcheck 와 로드밸런서가 부른다.
                                 // show-details 를 when-authorized 로 막아 내부 정보는 안 나간다.
                                 "/actuator/health",
-                                "/actuator/health/**"
+                                "/actuator/health/**",
+                                // Spring 은 처리되지 않은 요청을 /error 로 포워드한다.
+                                // 여기가 인증을 요구하면 404 든 500 이든 전부 401 로 둔갑해서
+                                // "인증이 잘못됐나" 를 한참 뒤진다. 실제 상태 코드가 나가게 열어둔다.
+                                "/error"
                         ).permitAll()
                         // 서버 간 호출. 사용자 JWT 가 아니라 공유 시크릿으로 인증한다. (#27)
                         // 경로를 분리해야 "사용자 인증" 과 "서비스 인증" 규칙이 섞이지 않는다.
-                        .requestMatchers("/api/v1/internal/**").hasRole("INTERNAL")
-                        .anyRequest().authenticated()
-                )
+                            .requestMatchers("/api/v1/internal/**").hasRole("INTERNAL")
+                            .anyRequest().authenticated();
+                })
 
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,10 +51,35 @@ server:
 # 운영 관측. 컨테이너 healthcheck 가 /actuator/health 를 부른다.
 # 필요한 것만 연다. env, beans, heapdump 같은 것은 노출하지 않는다.
 management:
+  # 관리 포트를 분리한다. (#28)
+  # 메트릭은 URI 패턴·호출량·커넥션 수 같은 내부 정보를 담는다. 8080 에 두면 인터넷에 나간다.
+  # docker-compose 에서 이 포트는 expose 만 하고 publish 하지 않는다.
+  server:
+    port: ${MANAGEMENT_PORT:9090}
   endpoints:
     web:
       exposure:
         include: health, info, metrics, prometheus
+  # Prometheus 익스포트를 명시적으로 켠다.
+  # 이걸 빼면 @ConditionalOnEnabledMetricsExport 가 false 로 평가돼
+  # PrometheusMeterRegistry 빈이 생기지 않고 /actuator/prometheus 가 404 가 된다.
+  # 그런데 /actuator/metrics 는 200 이라 "액추에이터는 되는데" 로 보여서 찾기 어렵다. (#28)
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    # 인스턴스가 여러 대가 되면 이 태그 없이는 어느 서버 지표인지 구분할 수 없다.
+    tags:
+      application: edumeet
+    distribution:
+      # p95/p99 를 Prometheus 에서 계산하려면 히스토그램 버킷이 필요하다.
+      # 평균만 보면 꼬리 지연이 안 보인다 - 붕괴는 평균이 아니라 꼬리에서 먼저 드러난다.
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 50ms, 100ms, 200ms, 500ms, 1s, 2s
+
   endpoint:
     health:
       # 의존 컴포넌트(DB, Redis) 상태까지 보이게 한다.

--- a/src/test/java/com/edu/edumeet/integration/observability/PrometheusEndpointTest.java
+++ b/src/test/java/com/edu/edumeet/integration/observability/PrometheusEndpointTest.java
@@ -1,0 +1,106 @@
+package com.edu.edumeet.integration.observability;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 관측 엔드포인트가 실제로 존재하고, 인터넷 쪽 포트에는 노출되지 않는지 확인한다. (#28)
+ *
+ * <p><b>왜 실제 포트를 띄우는가</b> — 이 설계의 핵심은 <b>포트 분리</b>다.
+ * MockMvc 는 포트 개념이 없어서 "관리 포트로만 열려 있다" 를 검증할 수 없다.
+ * 두 포트를 실제로 띄워야 의미가 있다.
+ *
+ * <p>이전에는 {@code exposure.include} 에 {@code prometheus} 가 적혀 있었지만
+ * {@code micrometer-registry-prometheus} 의존성이 없어서 <b>엔드포인트 자체가 404</b> 였다.
+ * {@code include} 는 "있으면 열어라" 이지 "만들어라" 가 아니다.
+ * <b>설정 파일만 보고 관측이 되어 있다고 믿으면 안 된다.</b>
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "management.server.port=0")   // 0 = 임의 포트. 서비스 포트와 분리된다.   // 0 = 임의 포트. 8080 과 분리된다.
+@ActiveProfiles("test")
+@DisplayName("관측 엔드포인트")
+class PrometheusEndpointTest {
+
+    @LocalServerPort int serverPort;
+    @LocalManagementPort int managementPort;
+
+    @Autowired TestRestTemplate rest;
+    @Autowired Environment environment;
+
+    private ResponseEntity<String> get(int port, String path) {
+        return rest.getForEntity("http://localhost:" + port + path, String.class);
+    }
+
+    @Test
+    @DisplayName("Boot 가 관리 포트를 분리된 것으로 판정한다 - 보안 규칙이 여기에 달려 있다")
+    void management_port_is_detected_as_separated() {
+        assertThat(ManagementPortType.get(environment))
+                .as("SAME 이면 SecurityConfig 의 actuator permitAll 규칙이 걸리지 않는다")
+                .isEqualTo(ManagementPortType.DIFFERENT);
+        assertThat(managementPort).isNotEqualTo(serverPort);
+    }
+
+    @Test
+    @DisplayName("관리 포트에서 Prometheus 지표가 나온다")
+    void prometheus_is_served_on_management_port() {
+        ResponseEntity<String> response = get(managementPort, "/actuator/prometheus");
+
+        assertThat(response.getStatusCode())
+                .as("레지스트리 의존성이 없으면 여기서 404 가 난다")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .as("JVM 지표는 레지스트리가 살아 있으면 무조건 나온다")
+                .contains("jvm_memory_used_bytes")
+                .as("공통 태그. 다중 인스턴스가 되면 이게 없어서 어느 서버인지 구분이 안 된다")
+                .contains("application=\"edumeet\"");
+    }
+
+    @Test
+    @DisplayName("HTTP 요청 히스토그램이 기록된다 - 평균이 아니라 꼬리를 봐야 한다")
+    void http_histogram_is_recorded() {
+        get(serverPort, "/api/v1/members/login");   // 지표를 하나 만든다
+
+        assertThat(get(managementPort, "/actuator/prometheus").getBody())
+                .as("percentiles-histogram 이 꺼져 있으면 bucket 계열이 안 나온다")
+                .contains("http_server_requests_seconds_bucket");
+    }
+
+    @Test
+    @DisplayName("★ 서비스 포트에서는 지표가 나오지 않는다")
+    void prometheus_is_not_exposed_on_service_port() {
+        ResponseEntity<String> response = get(serverPort, "/actuator/prometheus");
+
+        assertThat(response.getStatusCode())
+                .as("지표는 URI 패턴·호출량·커넥션 수 같은 내부 정보를 담는다. "
+                    + "8080 은 인터넷에 열리는 포트이므로 여기서 나오면 안 된다")
+                .isNotEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("헬스체크도 관리 포트로 옮겨간다 - Dockerfile HEALTHCHECK 가 여기를 봐야 한다")
+    void health_moves_to_management_port() {
+        // 테스트 환경에는 Redis 가 없어서 health 는 DOWN(503) 이다.
+        // 여기서 확인하려는 건 "상태가 UP 인가" 가 아니라 "이 포트에서 응답하는가" 다.
+        assertThat(get(managementPort, "/actuator/health").getStatusCode())
+                .as("컨테이너 HEALTHCHECK 는 이 포트를 부른다. 401/404 면 영영 unhealthy 다")
+                .isIn(HttpStatus.OK, HttpStatus.SERVICE_UNAVAILABLE);
+
+        assertThat(get(serverPort, "/actuator/health").getStatusCode())
+                .as("포트를 분리하면 액추에이터는 서비스 포트에서 통째로 사라진다. "
+                    + "이걸 모르면 Dockerfile 의 healthcheck 가 조용히 깨진다")
+                .isNotEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
Closes #28

붕괴 지점을 측정하려면 **관측이 먼저** 있어야 한다. 계획 문서의 **Phase 0** 에 해당한다.

> ⚠️ 이슈 본문의 WebSocket 관련 서술은 [코멘트로 정정](https://github.com/dj258255/edumeet/issues/28#issuecomment-)했다.
> **채팅이 아직 이 리포에 없어서** 관련 계측은 채팅 구현 이후로 미룬다.

## 🔴 `/actuator/prometheus` 가 404 였다

```yaml
management.endpoints.web.exposure.include: health, info, metrics, prometheus
```

노출 설정은 있었지만 `micrometer-registry-prometheus` 의존성이 없었다.
**`include` 는 "있으면 열어라" 이지 "만들어라" 가 아니다.**

### 그리고 의존성을 넣어도 여전히 404 였다

```
@ConditionalOnEnabledMetricsExport management.defaults.metrics.export.enabled is considered false
```

`management.prometheus.metrics.export.enabled: true` 를 **명시해야** 레지스트리가 생성된다.

**찾기 어려웠던 이유 — `/actuator/metrics` 는 200 이었다.**
"액추에이터는 되는데 prometheus 만 안 된다" 로 보여서 보안 설정을 한참 뒤졌다.
`PrometheusMeterRegistry` 빈 개수를 세어보고서야 원인이 잡혔다.

## 🔴 곁다리로 나온 진짜 버그 — 모든 에러가 401 로 둔갑했다

디버깅 중 발견했다. Security DEBUG 로그가 결정적이었다.

```
Secured GET /actuator/prometheus     ← 보안은 통과했다
Securing GET /error                  ← 404 라서 /error 로 포워드
→ 401 Unauthorized                   ← /error 가 인증을 요구한다
```

**Spring 은 처리되지 않은 요청을 `/error` 로 포워드하는데, 이 경로가 인증을 요구하고 있었다.**
그래서 **404 든 500 이든 전부 401 로 나갔다.**

액추에이터만의 문제가 아니라 **API 전체의 문제**다.
오타 난 URL 을 호출하면 "인증이 잘못됐나" 를 뒤지게 된다.

## 지표를 인터넷에 두지 않는다

```
8080  서비스 포트   publish   ← 인터넷
9090  관리 포트     expose    ← 컨테이너 네트워크 안에서만
```

지표는 **URI 패턴·호출량·커넥션 수** 같은 내부 정보를 담는다.
인증 대신 **네트워크로 격리**했다.

| 서비스 | 공개 |
|---|---|
| app | **8080** (9090 은 내부만) |
| grafana | **3001** |
| mysql / redis / prometheus | 내부만 |

### ⚠️ 부작용 — 헬스체크가 옮겨간다

**포트를 분리하면 액추에이터가 서비스 포트에서 통째로 사라진다.**
`Dockerfile` 의 `HEALTHCHECK` 가 `localhost:8080/actuator/health` 를 보고 있었으므로
**컨테이너가 영영 unhealthy 로 남았을 것이다.** 관리 포트로 바꾸고 테스트로 고정했다.

### 포트 판정을 손으로 하지 않는다

```java
if (ManagementPortType.get(environment) == ManagementPortType.DIFFERENT) { ... }
```

`management.server.port=0`(임의 포트)이면 `server.port` 도 0 일 수 있어서
**직접 비교하면 "같은 포트" 로 잘못 판정**된다. 처음엔 이렇게 짰다가 테스트에서 걸렸다.

## 대시보드는 손으로 만들지 않는다

```bash
python3 scripts/make_dashboard.py
```

UI 로 만든 대시보드는 **재현이 안 되고, 누가 무엇을 왜 넣었는지 남지 않는다.**
생성 스크립트에 의도를 주석으로 남기고 결과 JSON 을 커밋한다.

핵심 패널 — **평균이 아니라 꼬리와 대기열을 본다**:

| 패널 | 보는 이유 |
|---|---|
| **p50 / p95 / p99** | 평균은 포화를 숨긴다. p99 가 먼저 벌어진다 |
| **Hikari 대기(pending)** | 0 이 아니면 커넥션을 기다리는 스레드가 있다 — #27 에서 고친 "트랜잭션 안 S3 업로드" 가 여기서 드러났을 것 |
| CPU | 2 OCPU. 비용보다 여기가 먼저 찬다 |

### `or vector(0)` 가 없으면 "No data" 가 뜬다

5xx 가 하나도 없으면 시계열 자체가 생기지 않아 패널이 비어 보인다.
**"에러 0" 과 "지표 고장" 이 구분되지 않는다.** 검증 중 발견해서 고쳤다.

## ✅ 검증 — 파일만 쓰고 "됐다" 고 하지 않는다

앱을 실제로 띄우고 Prometheus 컨테이너로 긁었다.

```
스크레이프 대상    edumeet-app   up   http://.../actuator/prometheus
지표 라인          160개, application="edumeet" 태그 확인
서비스 포트         /actuator/prometheus → 404 (의도대로)
대시보드 PromQL     9개 전부 값 반환
promtool check     SUCCESS
docker compose      publish 는 app:8080 / grafana:3001 뿐
```

```
테스트 190개 통과 (기존 185 + 신규 5)
```

## 남는 것

- **Grafana 대시보드를 실제 화면으로 확인하지 않았다.** PromQL 이 값을 내는 것까지만 검증했다
- 알림(Alertmanager) 없음 — 기준선을 잡기 전에는 임계값을 정할 수 없다
- Prometheus 보존 15일은 임의값
- **채팅 관련 계측은 채팅을 만든 뒤** (별도 이슈)

관련: #26, #29