### PR TITLE
feat: WebSocket 채팅 (Phase 1) - 측정 대상을 만든다 (#33)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     implementation("org.springframework.data:spring-data-redis:3.2.5")
     // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-security")
+    // 채팅. STOMP + SimpleBroker 로 시작한다 - 기본 구성의 한계를 먼저 재기 위해서다. (#33)
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
 
     // 스키마 마이그레이션. 운영은 ddl-auto=none 이라 스키마 변경 경로가 없었다. (#29)
     // 평문 SQL 이라 DBA 리뷰와 수동 실행이 가능하다. 단일 DB(MySQL)라 Liquibase 의 추상화 이점이 없다.

--- a/src/main/java/com/edu/edumeet/chat/config/ChatAccessDeniedException.java
+++ b/src/main/java/com/edu/edumeet/chat/config/ChatAccessDeniedException.java
@@ -1,0 +1,13 @@
+package com.edu.edumeet.chat.config;
+
+/**
+ * STOMP 단계에서 거절한다. (#33)
+ *
+ * <p>{@code ChannelInterceptor} 에서 던지면 Spring 이 클라이언트에 ERROR 프레임을 보내고
+ * 연결을 끊는다. HTTP 상태 코드가 없는 세계라 <b>메시지가 곧 응답</b>이다.
+ */
+public class ChatAccessDeniedException extends RuntimeException {
+    public ChatAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/edu/edumeet/chat/config/StompAuthChannelInterceptor.java
@@ -1,0 +1,108 @@
+package com.edu.edumeet.chat.config;
+
+import com.edu.edumeet.config.jwt.JwtService;
+import com.edu.edumeet.openvidu.repository.MeetingParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * STOMP 프레임 단계의 인증·인가. (#33)
+ *
+ * <h3>왜 HTTP 필터로 안 되는가</h3>
+ * Spring Security 의 필터 체인은 <b>WebSocket 핸드셰이크(HTTP GET /ws)까지만</b> 관여한다.
+ * 그 뒤로 흐르는 STOMP 프레임은 HTTP 요청이 아니므로 필터를 타지 않는다.
+ * 핸드셰이크만 막으면 <b>연결 이후에는 아무 방이나 구독할 수 있다.</b>
+ *
+ * <h3>어디서 무엇을 보는가</h3>
+ * <pre>
+ *   CONNECT     JWT 검증 → Principal 설정        (내가 누구인가)
+ *   SUBSCRIBE   방 참가 기록 확인                 (이 방을 볼 자격이 있는가)
+ * </pre>
+ *
+ * SUBSCRIBE 를 막지 않으면 남의 회의 채팅을 그대로 받아볼 수 있다.
+ * 연결당 한 번씩만 도는 경로라 여기서 DB 를 한 번 보는 비용은 받아들인다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    /** 방 하나가 이 목적지다. */
+    private static final Pattern ROOM_DESTINATION = Pattern.compile("^/topic/rooms/(\\d+)$");
+    private static final String BEARER = "Bearer ";
+
+    private final JwtService jwtService;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || accessor.getCommand() == null) {
+            return message;
+        }
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            authenticate(accessor);
+        } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            authorizeSubscription(accessor);
+        }
+        return message;
+    }
+
+    private void authenticate(StompHeaderAccessor accessor) {
+        String header = accessor.getFirstNativeHeader("Authorization");
+        if (header == null || !header.startsWith(BEARER)) {
+            throw new ChatAccessDeniedException("인증 토큰이 없습니다.");
+        }
+        String token = header.substring(BEARER.length());
+        if (!jwtService.isTokenValid(token)) {
+            throw new ChatAccessDeniedException("유효하지 않은 토큰입니다.");
+        }
+
+        String email = jwtService.extractUsername(token);
+        accessor.setUser(new UsernamePasswordAuthenticationToken(
+                email, null, AuthorityUtils.createAuthorityList("ROLE_USER")));
+        log.debug("STOMP 연결 - {}", email);
+    }
+
+    private void authorizeSubscription(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            throw new ChatAccessDeniedException("구독 대상이 없습니다.");
+        }
+        Matcher matcher = ROOM_DESTINATION.matcher(destination);
+        if (!matcher.matches()) {
+            // 방 목적지가 아니면 이 인터셉터가 판단할 일이 아니다.
+            // 다만 알 수 없는 /topic 은 열어두지 않는다.
+            throw new ChatAccessDeniedException("구독할 수 없는 대상입니다: " + destination);
+        }
+
+        Principal user = accessor.getUser();
+        if (user == null) {
+            throw new ChatAccessDeniedException("인증되지 않은 연결입니다.");
+        }
+
+        Long meetingId = Long.valueOf(matcher.group(1));
+        boolean joined = meetingParticipantRepository
+                .findActive(meetingId, user.getName())
+                .isPresent();
+        if (!joined) {
+            log.warn("참가하지 않은 방 구독 시도 - meetingId={}, email={}", meetingId, user.getName());
+            throw new ChatAccessDeniedException("참가하지 않은 회의의 채팅은 볼 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/edu/edumeet/chat/config/WebSocketConfig.java
@@ -1,0 +1,64 @@
+package com.edu.edumeet.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * 채팅 STOMP 설정. (#33)
+ *
+ * <h3>왜 SimpleBroker 인가</h3>
+ * 인메모리 단일 인스턴스 브로커다. 다중 인스턴스로 확장되지 않는다는 걸 알면서 고른다.
+ * <b>처음부터 외부 브로커로 가면 무엇을 피했는지 말할 수 없다.</b>
+ * 기본 구성이 몇 명에서 무너지는지 먼저 재고, 그 수치를 근거로 다음을 고른다.
+ *
+ * <h3>왜 SockJS 를 안 붙이는가</h3>
+ * 부하 시험에서 <b>k6 는 STOMP 도 SockJS 도 모른다.</b> 프레임을 문자열로 조립해야 하므로
+ * 순수 WebSocket 엔드포인트를 연다. 브라우저 폴백이 필요해지면 별도 엔드포인트를 추가한다.
+ *
+ * <h3>스레드 풀을 지금 손대지 않는 이유</h3>
+ * Boot 기본값은 {@code applicationTaskExecutor} 이고 <b>큐 용량이 무한</b>이다.
+ * 이건 알려진 위험이지만 <b>지금 고치면 무엇을 고쳤는지 잴 수 없다.</b>
+ * Phase 2 에서 OOM 을 재현한 뒤에 제한을 건다.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Value("${front.url}")
+    private String frontUrl;
+
+    @Value("${front.url2}")
+    private String frontUrl2;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독 대상. 방 하나가 /topic/rooms/{meetingId} 다.
+        registry.enableSimpleBroker("/topic");
+        // 클라이언트가 서버로 보낼 때의 접두사. @MessageMapping 이 이 뒤를 받는다.
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns(frontUrl, frontUrl2);
+    }
+
+    /**
+     * 인증은 여기서 한다. HTTP 필터 체인은 <b>핸드셰이크까지만</b> 관여하고
+     * 그 뒤 STOMP 프레임에는 관여하지 않는다.
+     */
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/controller/ChatController.java
+++ b/src/main/java/com/edu/edumeet/chat/controller/ChatController.java
@@ -1,0 +1,48 @@
+package com.edu.edumeet.chat.controller;
+
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.dto.ChatSendRequest;
+import com.edu.edumeet.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * 채팅 수신·브로드캐스트. (#33)
+ *
+ * <pre>
+ *   클라이언트 → /app/rooms/{meetingId}/send
+ *   서버      → /topic/rooms/{meetingId}
+ * </pre>
+ *
+ * <p><b>보낸 사람을 페이로드에서 읽지 않는다.</b> {@link Principal} 은
+ * {@code StompAuthChannelInterceptor} 가 CONNECT 때 검증한 JWT 에서 나온다.
+ * 페이로드를 믿으면 남의 이름으로 보낼 수 있다.
+ *
+ * <p>{@code @SendTo} 대신 {@link SimpMessagingTemplate} 을 쓰는 이유는
+ * 목적지에 {@code meetingId} 가 들어가기 때문이다.
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/rooms/{meetingId}/send")
+    public void send(@DestinationVariable Long meetingId,
+                     ChatSendRequest request,
+                     Principal principal) {
+
+        ChatMessageResponse response =
+                chatService.handle(meetingId, principal.getName(), request.content());
+
+        messagingTemplate.convertAndSend("/topic/rooms/" + meetingId, response);
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/domain/ChatMessage.java
+++ b/src/main/java/com/edu/edumeet/chat/domain/ChatMessage.java
@@ -1,0 +1,54 @@
+package com.edu.edumeet.chat.domain;
+
+import com.edu.edumeet.openvidu.domain.Meeting;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅 메시지. <b>INTERACTIVE 세션만 저장한다.</b> (#33)
+ *
+ * <p>BROADCAST(라이브방송)는 저장하지 않는다. 시청자 수천 명 × 초당 수십 메시지면
+ * 쓰기가 폭증하는데, 방송 채팅은 원래 휘발성이다.
+ * 이 분기가 없으면 <b>브로드캐스트 성능 측정이 DB 쓰기에 묻힌다.</b>
+ */
+@Entity
+@Table(name = "chat_message",
+       indexes = @Index(name = "idx_chat_message_meeting_sent", columnList = "meeting_id, sent_at"))
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    @Column(name = "sender_email", nullable = false, length = 255)
+    private String senderEmail;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    public static ChatMessage of(Meeting meeting, String senderEmail, String content) {
+        return ChatMessage.builder()
+                .meeting(meeting)
+                .senderEmail(senderEmail)
+                .content(content)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/edu/edumeet/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,16 @@
+package com.edu.edumeet.chat.dto;
+
+/**
+ * 방으로 브로드캐스트되는 것. (#33)
+ *
+ * @param publishedAt 서버가 발행한 시각(epoch millis).
+ *                    <b>end-to-end 지연은 기본 메트릭에 없다.</b> k6 가 수신 시각과 이 값을 빼서
+ *                    커스텀 Trend 에 넣을 수 있도록 페이로드에 담는다.
+ *                    이게 없으면 "서버가 처리한 시간" 만 보이고 "사용자가 받기까지" 는 안 보인다.
+ */
+public record ChatMessageResponse(
+        Long meetingId,
+        String sender,
+        String content,
+        long publishedAt
+) {}

--- a/src/main/java/com/edu/edumeet/chat/dto/ChatSendRequest.java
+++ b/src/main/java/com/edu/edumeet/chat/dto/ChatSendRequest.java
@@ -1,0 +1,4 @@
+package com.edu.edumeet.chat.dto;
+
+/** 클라이언트가 보내는 것. 보낸 사람은 헤더의 Principal 에서 읽는다 - 페이로드를 믿지 않는다. */
+public record ChatSendRequest(String content) {}

--- a/src/main/java/com/edu/edumeet/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/edu/edumeet/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,18 @@
+package com.edu.edumeet.chat.repository;
+
+import com.edu.edumeet.chat.domain.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    /** 최근 메시지부터. 입장 시 지난 대화를 보여주는 용도다. */
+    @Query("SELECT m FROM ChatMessage m WHERE m.meeting.id = :meetingId ORDER BY m.sentAt DESC")
+    List<ChatMessage> findRecent(@Param("meetingId") Long meetingId, Pageable pageable);
+
+    long countByMeetingId(Long meetingId);
+}

--- a/src/main/java/com/edu/edumeet/chat/service/ChatService.java
+++ b/src/main/java/com/edu/edumeet/chat/service/ChatService.java
@@ -1,0 +1,94 @@
+package com.edu.edumeet.chat.service;
+
+import com.edu.edumeet.chat.domain.ChatMessage;
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.repository.ChatMessageRepository;
+import com.edu.edumeet.openvidu.domain.Meeting;
+import com.edu.edumeet.openvidu.domain.SessionType;
+import com.edu.edumeet.openvidu.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 채팅 메시지 처리. (#33)
+ *
+ * <p>Phase 1 은 <b>동작 확인까지</b>다. 성능 측정과 백프레셔는 Phase 2 부터다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatService {
+
+    private static final int MAX_CONTENT_LENGTH = 1000;
+    private static final int RECENT_LIMIT = 50;
+
+    private final MeetingRepository meetingRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    /**
+     * 메시지를 받아 브로드캐스트할 형태로 만든다. 저장 여부는 세션 형태가 정한다.
+     *
+     * <p>{@code publishedAt} 은 <b>저장 후가 아니라 반환 직전</b>에 찍는다.
+     * 수신자가 재는 지연에 DB 왕복이 포함되어야 실제 체감과 맞는다.
+     */
+    @Transactional
+    public ChatMessageResponse handle(Long meetingId, String senderEmail, String content) {
+        String trimmed = validate(content);
+
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회의입니다: " + meetingId));
+
+        if (meeting.getEndTime() != null) {
+            throw new IllegalArgumentException("이미 종료된 회의입니다.");
+        }
+
+        if (shouldPersist(meeting.getSessionType())) {
+            chatMessageRepository.save(ChatMessage.of(meeting, senderEmail, trimmed));
+        }
+
+        return new ChatMessageResponse(
+                meetingId, senderEmail, trimmed, System.currentTimeMillis());
+    }
+
+    /** 입장 시 보여줄 지난 대화. 저장하지 않는 BROADCAST 는 항상 빈 목록이다. */
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponse> recentMessages(Long meetingId) {
+        return chatMessageRepository.findRecent(meetingId, PageRequest.of(0, RECENT_LIMIT))
+                .stream()
+                .sorted(Comparator.comparing(ChatMessage::getSentAt))   // 오래된 것부터 보여준다
+                .map(m -> new ChatMessageResponse(
+                        meetingId, m.getSenderEmail(), m.getContent(),
+                        m.getSentAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()))
+                .toList();
+    }
+
+    /**
+     * BROADCAST 는 저장하지 않는다.
+     *
+     * <p>시청자 수천 명 × 초당 수십 메시지면 쓰기가 폭증한다. 방송 채팅은 원래 휘발성이고,
+     * 무엇보다 <b>이 분기가 없으면 브로드캐스트 성능 측정이 DB 쓰기에 묻힌다.</b>
+     */
+    private boolean shouldPersist(SessionType sessionType) {
+        return sessionType == SessionType.INTERACTIVE;
+    }
+
+    private String validate(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("빈 메시지는 보낼 수 없습니다.");
+        }
+        String trimmed = content.strip();
+        if (trimmed.length() > MAX_CONTENT_LENGTH) {
+            throw new IllegalArgumentException(
+                    "메시지가 너무 깁니다. (최대 %d자)".formatted(MAX_CONTENT_LENGTH));
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/edu/edumeet/config/SecurityConfig.java
+++ b/src/main/java/com/edu/edumeet/config/SecurityConfig.java
@@ -116,6 +116,10 @@ public class SecurityConfig {
                                 // show-details 를 when-authorized 로 막아 내부 정보는 안 나간다.
                                 "/actuator/health",
                                 "/actuator/health/**",
+                                // WebSocket 핸드셰이크. 여기서 막지 않고 STOMP CONNECT 에서 JWT 를 본다. (#33)
+                                // HTTP 필터는 핸드셰이크까지만 관여하고 이후 STOMP 프레임에는 관여하지 않으므로,
+                                // 어차피 프레임 단계의 인증이 따로 필요하다. StompAuthChannelInterceptor 가 한다.
+                                "/ws/**",
                                 // Spring 은 처리되지 않은 요청을 /error 로 포워드한다.
                                 // 여기가 인증을 요구하면 404 든 500 이든 전부 401 로 둔갑해서
                                 // "인증이 잘못됐나" 를 한참 뒤진다. 실제 상태 코드가 나가게 열어둔다.

--- a/src/main/resources/db/migration/V3__create_chat_message.sql
+++ b/src/main/resources/db/migration/V3__create_chat_message.sql
@@ -1,0 +1,19 @@
+-- 채팅 메시지. (#33)
+--
+-- INTERACTIVE(화상강의) 세션의 메시지만 저장한다.
+-- BROADCAST(라이브방송)는 저장하지 않으므로 이 테이블에 들어오지 않는다.
+-- 시청자 수천 명 x 초당 수십 메시지면 쓰기가 폭증하고,
+-- 무엇보다 그 쓰기가 브로드캐스트 성능 측정을 가린다.
+
+CREATE TABLE chat_message (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    meeting_id   BIGINT       NOT NULL,
+    sender_email VARCHAR(255) NOT NULL,
+    content      VARCHAR(1000) NOT NULL,
+    sent_at      DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_chat_message_meeting FOREIGN KEY (meeting_id) REFERENCES meeting (id)
+) ENGINE=InnoDB;
+
+-- 조회는 항상 "이 회의의 최근 메시지" 다. 복합 인덱스로 정렬까지 받는다.
+CREATE INDEX idx_chat_message_meeting_sent ON chat_message (meeting_id, sent_at);

--- a/src/test/java/com/edu/edumeet/integration/chat/ChatStompTest.java
+++ b/src/test/java/com/edu/edumeet/integration/chat/ChatStompTest.java
@@ -1,0 +1,261 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.dto.ChatSendRequest;
+import com.edu.edumeet.chat.repository.ChatMessageRepository;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.config.jwt.JwtService;
+import com.edu.edumeet.member.domain.Member;
+import com.edu.edumeet.openvidu.domain.Meeting;
+import com.edu.edumeet.openvidu.domain.MeetingParticipant;
+import com.edu.edumeet.openvidu.domain.SessionType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 채팅 STOMP 경로를 실제 WebSocket 연결로 검증한다. (#33)
+ *
+ * <p><b>왜 실제 연결인가</b> — Spring Security 의 HTTP 필터 체인은
+ * <b>핸드셰이크까지만</b> 관여하고 그 뒤 STOMP 프레임에는 관여하지 않는다.
+ * MockMvc 로는 이 경계 자체를 재현할 수 없다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("채팅 STOMP")
+class ChatStompTest {
+
+    @LocalServerPort int port;
+
+    @Autowired JwtService jwtService;
+    @Autowired ChatMessageRepository chatMessageRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private WebSocketStompClient stompClient;
+    private Long interactiveMeetingId;
+    private Long broadcastMeetingId;
+    private String memberToken;
+    private String outsiderToken;
+
+    /** 테스트마다 새 이메일을 쓴다. 정리 순서를 맞추려 FK 를 타고 지우는 것보다 단순하다. */
+    private static final java.util.concurrent.atomic.AtomicInteger SEQ =
+            new java.util.concurrent.atomic.AtomicInteger();
+
+    private String member;
+    private String outsider;
+
+    @BeforeEach
+    void setUp() {
+        stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        int n = SEQ.incrementAndGet();
+        member = "chat-member-" + n + "@test";
+        outsider = "chat-outsider-" + n + "@test";
+
+        transactionTemplate.executeWithoutResult(status -> {
+            Member owner = Member.builder().email(member).nickname("참가자").password("x").build();
+            em.persist(owner);
+            Member other = Member.builder().email(outsider).nickname("외부인").password("x").build();
+            em.persist(other);
+
+            ClassRoom classRoom = ClassRoom.builder()
+                    .member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(classRoom);
+
+            interactiveMeetingId = persistMeeting(classRoom, SessionType.INTERACTIVE, member);
+            broadcastMeetingId = persistMeeting(classRoom, SessionType.BROADCAST, member);
+        });
+
+        memberToken = jwtService.generateAccessToken(1L, member);
+        outsiderToken = jwtService.generateAccessToken(2L, outsider);
+    }
+
+    private Long persistMeeting(ClassRoom classRoom, SessionType type, String participantEmail) {
+        Meeting meeting = Meeting.builder()
+                .classRoom(classRoom).title("회의 " + type).description("-")
+                .sessionType(type).startTime(LocalDateTime.now().minusMinutes(10))
+                .build();
+        em.persist(meeting);
+        em.persist(MeetingParticipant.join(meeting, participantEmail));
+        em.flush();
+        return meeting.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stompClient != null) {
+            stompClient.stop();
+        }
+        transactionTemplate.executeWithoutResult(status -> {
+            em.createQuery("DELETE FROM ChatMessage").executeUpdate();
+            em.createQuery("DELETE FROM MeetingParticipant").executeUpdate();
+            em.createQuery("DELETE FROM Meeting").executeUpdate();
+        });
+    }
+
+    private StompSession connect(String token) throws Exception {
+        return connect(token, new StompSessionHandlerAdapter() {});
+    }
+
+    /**
+     * 세션 단위 오류(ERROR 프레임, 전송 오류)는 <b>connect() 에 넘긴 핸들러</b>가 받는다.
+     * subscribe() 에 넘기는 것은 프레임 핸들러라서 여기로 오지 않는다.
+     */
+    private StompSession connect(String token, StompSessionHandler handler) throws Exception {
+        StompHeaders headers = new StompHeaders();
+        if (token != null) {
+            headers.add("Authorization", "Bearer " + token);
+        }
+        return stompClient.connectAsync("ws://localhost:" + port + "/ws",
+                        new WebSocketHttpHeaders(), headers, handler)
+                .get(5, TimeUnit.SECONDS);
+    }
+
+    /** 브로드캐스트를 한 건 기다린다. */
+    private CompletableFuture<ChatMessageResponse> subscribe(StompSession session, Long meetingId) {
+        CompletableFuture<ChatMessageResponse> received = new CompletableFuture<>();
+        session.subscribe("/topic/rooms/" + meetingId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders headers) { return ChatMessageResponse.class; }
+            @Override public void handleFrame(StompHeaders headers, Object payload) {
+                received.complete((ChatMessageResponse) payload);
+            }
+        });
+        return received;
+    }
+
+    // ── 인증 ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("토큰 없이 CONNECT 하면 거절된다")
+    void 토큰_없으면_연결_거절() {
+        assertThatThrownBy(() -> connect(null))
+                .as("HTTP 필터는 핸드셰이크만 본다. 프레임 단계에서 막아야 한다")
+                .isInstanceOf(ExecutionException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰이면 거절된다")
+    void 잘못된_토큰이면_연결_거절() {
+        assertThatThrownBy(() -> connect("not-a-real-token"))
+                .isInstanceOf(ExecutionException.class);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰이면 연결된다")
+    void 유효한_토큰이면_연결된다() throws Exception {
+        StompSession session = connect(memberToken);
+        assertThat(session.isConnected()).isTrue();
+        session.disconnect();
+    }
+
+    // ── 구독 권한 ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("★ 참가하지 않은 방은 구독할 수 없다")
+    void 참가하지_않은_방은_구독_불가() throws Exception {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch rejected = new CountDownLatch(1);
+
+        StompSession session = connect(outsiderToken, new StompSessionHandlerAdapter() {
+            @Override public void handleTransportError(StompSession s, Throwable ex) {
+                error.set(ex); rejected.countDown();
+            }
+            @Override public void handleException(StompSession s, StompCommand c,
+                                                  StompHeaders h, byte[] p, Throwable ex) {
+                error.set(ex); rejected.countDown();
+            }
+        });
+
+        session.subscribe("/topic/rooms/" + interactiveMeetingId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders headers) { return ChatMessageResponse.class; }
+            @Override public void handleFrame(StompHeaders headers, Object payload) {
+                error.set(new AssertionError("메시지가 도착하면 안 된다: " + payload));
+                rejected.countDown();
+            }
+        });
+
+        assertThat(rejected.await(5, TimeUnit.SECONDS))
+                .as("구독을 막지 않으면 남의 회의 채팅을 그대로 받아볼 수 있다")
+                .isTrue();
+        assertThat(error.get())
+                .as("도착한 것은 메시지가 아니라 거절이어야 한다")
+                .isNotInstanceOf(AssertionError.class);
+    }
+
+    // ── 브로드캐스트 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("보낸 메시지가 방으로 브로드캐스트된다")
+    void 메시지가_방으로_브로드캐스트된다() throws Exception {
+        StompSession session = connect(memberToken);
+        CompletableFuture<ChatMessageResponse> received = subscribe(session, interactiveMeetingId);
+        Thread.sleep(300);   // 구독 등록이 브로커에 반영될 시간
+
+        long before = System.currentTimeMillis();
+        session.send("/app/rooms/" + interactiveMeetingId + "/send", new ChatSendRequest("안녕하세요"));
+
+        ChatMessageResponse response = received.get(5, TimeUnit.SECONDS);
+        assertThat(response.content()).isEqualTo("안녕하세요");
+        assertThat(response.sender())
+                .as("보낸 사람은 페이로드가 아니라 JWT 에서 나와야 한다")
+                .isEqualTo(member);
+        assertThat(response.publishedAt())
+                .as("k6 가 이 값으로 end-to-end 지연을 잰다")
+                .isGreaterThanOrEqualTo(before);
+        session.disconnect();
+    }
+
+    // ── 저장 정책 ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("INTERACTIVE 는 저장한다")
+    void INTERACTIVE_는_저장한다() throws Exception {
+        StompSession session = connect(memberToken);
+        CompletableFuture<ChatMessageResponse> received = subscribe(session, interactiveMeetingId);
+        Thread.sleep(300);
+        session.send("/app/rooms/" + interactiveMeetingId + "/send", new ChatSendRequest("수업 기록"));
+        received.get(5, TimeUnit.SECONDS);
+
+        assertThat(chatMessageRepository.countByMeetingId(interactiveMeetingId)).isEqualTo(1);
+        session.disconnect();
+    }
+
+    @Test
+    @DisplayName("★ BROADCAST 는 저장하지 않는다 - 저장하면 브로드캐스트 측정이 DB 쓰기에 묻힌다")
+    void BROADCAST_는_저장하지_않는다() throws Exception {
+        StompSession session = connect(memberToken);
+        CompletableFuture<ChatMessageResponse> received = subscribe(session, broadcastMeetingId);
+        Thread.sleep(300);
+        session.send("/app/rooms/" + broadcastMeetingId + "/send", new ChatSendRequest("방송 채팅"));
+
+        assertThat(received.get(5, TimeUnit.SECONDS).content()).isEqualTo("방송 채팅");
+        assertThat(chatMessageRepository.countByMeetingId(broadcastMeetingId))
+                .as("시청자 수천 명 x 초당 수십 메시지면 쓰기가 폭증한다")
+                .isZero();
+        session.disconnect();
+    }
+}

--- a/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
+++ b/src/test/java/com/edu/edumeet/integration/migration/FlywayMigrationTest.java
@@ -59,17 +59,29 @@ class FlywayMigrationTest {
                 .contains("1");
     }
 
+    /**
+     * V1 baseline 이 만드는 테이블. 개수를 세면 마이그레이션이 추가될 때마다 깨진다.
+     * <b>이름으로 확인하면 V2·V3 가 무엇을 더 만들든 이 단언은 유효하다.</b>
+     */
+    private static final List<String> BASELINE_TABLES = List.of(
+            "assignment", "assignment_file_upload", "board", "board_category", "board_file_upload",
+            "class_invite", "class_member", "class_room", "class_room_seq", "class_room_tags",
+            "meeting", "meeting_participant", "member", "refresh_token", "reply",
+            "student_submission_status", "submission", "submission_file_upload");
+
     @Test
     @DisplayName("V1 이 엔티티가 기대하는 테이블을 전부 만든다")
-    void v1_creates_all_tables() {
-        Integer tableCount = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM information_schema.tables " +
-                "WHERE table_schema = DATABASE() AND table_name <> 'flyway_schema_history'",
-                Integer.class);
+    void v1_creates_all_baseline_tables() {
+        assertThat(allTables())
+                .as("baseline 은 엔티티에서 생성했으므로 이 목록이 전부 있어야 한다")
+                .containsAll(BASELINE_TABLES);
+    }
 
-        assertThat(tableCount)
-                .as("엔티티에서 생성한 baseline 이므로 18개 테이블이 나와야 한다")
-                .isEqualTo(18);
+    private List<String> allTables() {
+        return jdbc.queryForList(
+                "SELECT table_name FROM information_schema.tables " +
+                "WHERE table_schema = DATABASE() AND table_name <> 'flyway_schema_history'",
+                String.class);
     }
 
     @Test
@@ -94,6 +106,19 @@ class FlywayMigrationTest {
         assertThat(columnsOf("meeting"))
                 .as("MD 와 PDF URL 을 각각 저장한다 (#27)")
                 .contains("summary_md_url", "summary_pdf_url");
+    }
+
+    @Test
+    @DisplayName("V3 가 채팅 테이블을 만든다")
+    void v3_creates_chat_message() {
+        List<String> applied = jdbc.queryForList(
+                "SELECT version FROM flyway_schema_history WHERE success = 1 ORDER BY installed_rank",
+                String.class);
+        assertThat(applied).contains("3");
+
+        assertThat(allTables()).contains("chat_message");
+        assertThat(columnsOf("chat_message"))
+                .contains("meeting_id", "sender_email", "content", "sent_at");
     }
 
     private List<String> columnsOf(String table) {


### PR DESCRIPTION
Closes #33

붕괴 측정의 전제입니다. **이 리포에는 채팅이 아예 없었습니다** — 의존성도 소스도.

> **측정 없음. 동작 확인까지입니다.** 한계가 몇 명에서 오는지 재는 것은 Phase 2 부터입니다.

## 일부러 기본 구성으로 시작합니다

| | 고른 것 | 알면서 감수하는 것 |
|---|---|---|
| 브로커 | `SimpleBroker` | 인메모리 단일 인스턴스. 다중 인스턴스로 확장 안 됨 |
| 스레드 풀 | Boot 기본값 | **큐 용량이 무한** |

**처음부터 외부 브로커로 가면 무엇을 피했는지 말할 수 없습니다.**
스레드 풀도 지금 고치면 Phase 2 에서 **무엇을 고쳤는지 잴 수 없습니다.**
기본 구성이 몇 명에서 무너지는지 먼저 재고, 그 수치를 근거로 다음을 고릅니다.

## 🔴 인증을 STOMP 프레임 단계에서 합니다

Spring Security 의 필터 체인은 **WebSocket 핸드셰이크(HTTP GET `/ws`)까지만** 관여합니다.
그 뒤로 흐르는 STOMP 프레임은 HTTP 요청이 아니라 필터를 타지 않습니다.

**핸드셰이크만 막으면 연결 이후에는 아무 방이나 구독할 수 있습니다.**

```
CONNECT     JWT 검증 → Principal 설정        (내가 누구인가)
SUBSCRIBE   방 참가 기록 확인                 (이 방을 볼 자격이 있는가)
```

그리고 **보낸 사람을 페이로드에서 읽지 않습니다.** `Principal` 은 CONNECT 때 검증한 JWT 에서 나옵니다.
페이로드를 믿으면 남의 이름으로 보낼 수 있습니다.

## 저장 정책을 세션 형태로 나눕니다

| | 저장 | 이유 |
|---|---|---|
| `INTERACTIVE` | 한다 | 수업 기록. 정원 30이라 쓰기량이 작다 |
| `BROADCAST` | **안 한다** | 수천 명 × 초당 수십 = 쓰기 폭증. 방송 채팅은 휘발성이 정상 |

**이 분기가 없으면 브로드캐스트 성능 측정이 DB 쓰기에 묻힙니다.**

## SockJS 를 붙이지 않습니다

부하 시험에서 **k6 는 STOMP 도 SockJS 도 모릅니다.** 프레임을 문자열로 조립해야 하므로
순수 WebSocket 엔드포인트를 엽니다. 브라우저 폴백이 필요해지면 별도로 추가합니다.

## end-to-end 지연을 잴 수 있게 합니다

```java
public record ChatMessageResponse(Long meetingId, String sender, String content, long publishedAt)
```

**end-to-end 지연은 기본 메트릭에 없습니다.** 서버 처리 시간만 보이고 "사용자가 받기까지"는 안 보입니다.
k6 가 수신 시각과 `publishedAt` 을 빼서 커스텀 Trend 에 넣을 수 있도록 페이로드에 담습니다.

## 테스트는 실제 WebSocket 연결로 합니다

**MockMvc 로는 이 경계 자체를 재현할 수 없습니다** — 핸드셰이크와 프레임의 구분이 없으니까요.

| 테스트 | 확인하는 것 |
|---|---|
| `토큰_없으면_연결_거절` / `잘못된_토큰이면_연결_거절` | 프레임 단계 인증 |
| **`참가하지_않은_방은_구독_불가`** | 남의 회의 채팅을 받아볼 수 없다 |
| `메시지가_방으로_브로드캐스트된다` | 발신자가 JWT 에서 나온다 |
| `INTERACTIVE_는_저장한다` / **`BROADCAST_는_저장하지_않는다`** | 저장 정책 |
| `v3_creates_chat_message` | 마이그레이션 |

> 처음엔 구독 거절 테스트가 실패했습니다. **세션 단위 오류는 `connect()` 에 넘긴 핸들러가 받는데
> `subscribe()` 에 넘긴 것으로 잡으려 했기 때문**입니다. 후자는 프레임 핸들러입니다.

## 덤: 개수 단언을 또 고쳤습니다

`v1_creates_all_tables` 가 테이블 **개수 18**을 단언하고 있었는데, V2 에 이어 **V3 에서 또 깨졌습니다.**
개수는 마이그레이션이 추가될 때마다 깨집니다. **이름 목록**으로 바꿨습니다.

```
테스트 198개 통과 (기존 190 + 신규 8)
```

## 다음

- `WebSocketMessageBrokerStats` → Micrometer (#28 에서 미룬 부분 — 이제 붙일 대상이 생겼습니다)
- Phase 2: 무한 큐 OOM 재현 → **붕괴 ③**

관련: #28, `docs/plan/01-chat-breaking-points.md`