### PR TITLE
feat: 채팅 계측 - 큐 길이를 보이게 만든다 (#39)

### DIFF
--- a/docs/ops/04-observability.md
+++ b/docs/ops/04-observability.md
@@ -122,20 +122,60 @@ UI 로 만든 대시보드는 **재현이 안 되고, 누가 무엇을 왜 넣�
 
 `promtool check config` 로 Prometheus 설정 문법도 확인했다.
 
-## 6. 다음 — 채팅이 있어야 붙는다
+## 6. 채팅 계측 (#39)
 
-이 문서의 범위는 **지금 있는 코드**에 대한 기준선이다.
+채팅이 생겼으므로(#33) 붙일 대상이 생겼다.
 
-붕괴 5단계 중 ②(스레드 풀 포화)·③(느린 클라이언트)·⑤(다중 인스턴스)를 보려면
-**WebSocket 채팅을 먼저 만들어야 한다.** 이 리포에는 아직 없다.
+### `WebSocketMessageBrokerStats` 를 쓰지 않았다
 
-| 나중에 추가 | |
+Spring 이 같은 값을 이미 계산한다. 다만 **전부 `String` 으로만 노출한다.**
+
+```java
+String getClientInboundExecutorStatsInfo()   // "pool size = 8, active threads = 0, ..."
+```
+
+문자열을 파싱하면 Spring 이 형식을 바꾸는 순간 **조용히 깨진다.**
+그래서 **실행기 객체를 Micrometer 에 직접 바인딩**하고, 세션·방·발행량은 이벤트로 직접 센다.
+
+### 무엇을 재는가
+
+| 지표 | 무엇을 보는가 | 붕괴 단계 |
+|---|---|---|
+| **`executor_queued_tasks`** | **대기열 길이 — 포화의 첫 신호** | ②③ |
+| `executor_active_threads` / `pool_size` | active 가 pool 에 붙으면 그 뒤는 전부 큐로 간다 | ②③ |
+| `chat_sessions_active` | 커넥션 한계 | ④ |
+| `chat_rooms_active` | 활성 방 수 | ① |
+| `chat_messages_published_total` | 발행량 | ① |
+| **`chat_fanout_recipients`** | **실제 전달 대상 수** | ① |
+
+> **fan-out 배수가 브로드캐스트 비용의 본체다.**
+> 발행량만 세면 30명 방과 3,000명 방이 같아 보인다. **실제 쓰기량 = 발행량 × 이 값**이다.
+
+### 정리하지 않으면 지표가 부풀려진다
+
+`SessionUnsubscribeEvent` 는 **목적지를 담지 않는다.** 구독 id 만 온다.
+그리고 브라우저를 닫으면 **UNSUBSCRIBE 없이 세션이 사라진다** — 이게 정상 경로다.
+
+그래서 `(세션, 구독id) → 목적지` 를 들고 있다가 끊길 때 정리한다.
+안 하면 **방이 비었는데 구독자 수가 줄지 않아 fan-out 배수가 계속 부풀려진다.**
+테스트로 고정했다 (`fanout_records_recipient_count` 마지막 단언).
+
+### `_bucket` 이 없으면 패널이 빈 화면이다
+
+`chat.fanout.recipients` 에 `publishPercentileHistogram()` 을 붙였다.
+빠지면 `chat_fanout_recipients_bucket` 이 안 나오고 대시보드의
+`histogram_quantile` 패널이 통째로 **"No data"** 가 된다. §4 의 5xx 패널과 같은 함정이다.
+
+이것도 테스트로 고정했다.
+
+## 7. 남은 것
+
+| | |
 |---|---|
-| `WebSocketMessageBrokerStats` → Micrometer | Spring 이 이미 계산하는데 30초마다 INFO 로그로만 나간다 |
-| inbound/outbound **큐 길이** | 기본 큐가 무한이라 **포화가 에러가 아니라 지연으로만** 나타난다 |
-| 세션 버퍼 / 강제 종료 수 | 느린 클라이언트 |
+| 세션 버퍼 / 강제 종료 수 | 느린 클라이언트 (붕괴 ③) — Phase 3 |
+| Redis Pub/Sub 전파 지연 | 다중 인스턴스 (붕괴 ⑤) — Phase 5 |
 
-## 7. 미확인
+## 8. 미확인
 
 - **Grafana 대시보드를 실제 화면으로 확인하지 않았다.** PromQL 이 값을 내는 것까지만 검증했다
 - 알림(Alertmanager) 없음. 기준선을 잡기 전에는 임계값을 정할 수 없다

--- a/observability/grafana/dashboards/edumeet-chat.json
+++ b/observability/grafana/dashboards/edumeet-chat.json
@@ -1,0 +1,451 @@
+{
+  "uid": "edumeet-chat",
+  "title": "EduMeet — 채팅 붕괴 측정",
+  "description": "붕괴 5단계를 보는 대시보드. 처리율이 아니라 대기열과 fan-out 배수를 본다. (#39)",
+  "tags": [
+    "edumeet",
+    "chat",
+    "breaking-points"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "★ STOMP 큐 길이 - 포화의 첫 신호",
+      "type": "timeseries",
+      "description": "기본 실행기는 큐가 무한이라 스레드 풀이 절대 거부하지 않는다. 그래서 포화가 에러가 아니라 지연으로만 나타난다. 에러율은 0인데 여기가 오른다. 붕괴 2·3단계.",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "executor_queued_tasks{service=\"edumeet\",name=\"clientInboundChannelExecutor\"}",
+          "legendFormat": "inbound",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "executor_queued_tasks{service=\"edumeet\",name=\"clientOutboundChannelExecutor\"}",
+          "legendFormat": "outbound",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "STOMP 활성 스레드",
+      "type": "timeseries",
+      "description": "active 가 pool 에 붙으면 더 못 밀어 넣는다. 그 뒤로는 전부 큐로 간다.",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "executor_active_threads{service=\"edumeet\",name=\"clientInboundChannelExecutor\"}",
+          "legendFormat": "inbound active",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "executor_pool_size_threads{service=\"edumeet\",name=\"clientInboundChannelExecutor\"}",
+          "legendFormat": "inbound pool",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "executor_active_threads{service=\"edumeet\",name=\"clientOutboundChannelExecutor\"}",
+          "legendFormat": "outbound active",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "executor_pool_size_threads{service=\"edumeet\",name=\"clientOutboundChannelExecutor\"}",
+          "legendFormat": "outbound pool",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "★ fan-out 배수 - 브로드캐스트 비용의 본체",
+      "type": "timeseries",
+      "description": "발행 1건이 수신 N건이 된다. 발행량만 보면 30명 방과 3,000명 방이 같아 보인다. 실제 쓰기량 = 발행량 x 이 값.",
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(chat_fanout_recipients_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p50",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(chat_fanout_recipients_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p95",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(chat_fanout_recipients_bucket{service=\"edumeet\"}[1m])))",
+          "legendFormat": "p99",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "발행량 / 실제 전달량",
+      "type": "timeseries",
+      "description": "두 선의 간격이 곧 fan-out 배수다. 방이 커질수록 벌어진다.",
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "rate(chat_messages_published_total{service=\"edumeet\"}[1m])",
+          "legendFormat": "발행 (msg/s)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "rate(chat_fanout_recipients_sum{service=\"edumeet\"}[1m])",
+          "legendFormat": "실제 전달 (msg/s)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "세션 수 / 활성 방 수",
+      "type": "timeseries",
+      "description": "세션 수가 커넥션 한계(붕괴 4단계)에 닿는지 본다.",
+      "gridPos": {
+        "x": 12,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "chat_sessions_active{service=\"edumeet\"}",
+          "legendFormat": "STOMP 세션",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "chat_rooms_active{service=\"edumeet\"}",
+          "legendFormat": "활성 방",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "JVM 힙 - 큐가 무한이면 여기가 먼저 찬다",
+      "type": "timeseries",
+      "description": "붕괴 3단계(무한 큐 OOM)는 큐 길이와 힙이 같이 오르는 형태로 나타난다.",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{service=\"edumeet\",area=\"heap\"})",
+          "legendFormat": "사용",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes{service=\"edumeet\",area=\"heap\"})",
+          "legendFormat": "최대",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "GC 정지 시간",
+      "type": "timeseries",
+      "description": "힙이 차면 GC 가 먼저 반응하고, 그게 다시 큐를 밀어올린다.",
+      "gridPos": {
+        "x": 12,
+        "y": 22,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{service=\"edumeet\"}[1m])",
+          "legendFormat": "{{action}} {{cause}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/make_dashboard.py
+++ b/scripts/make_dashboard.py
@@ -11,7 +11,7 @@
 import json
 import pathlib
 
-OUT = pathlib.Path("observability/grafana/dashboards/edumeet-baseline.json")
+OUT_DIR = pathlib.Path("observability/grafana/dashboards")
 JOB = 'service="edumeet"'
 
 
@@ -92,6 +92,52 @@ panels = [
     ], "s", "풀이 마르면 이 값이 먼저 튄다."),
 ]
 
+# ── 채팅 붕괴 측정 (#39) ─────────────────────────────────────────────
+# 계획 문서의 붕괴 5단계를 이 대시보드로 본다.
+# 핵심은 처리율이 아니라 "대기열" 과 "fan-out 배수" 다.
+chat_panels = [
+    panel(1, "★ STOMP 큐 길이 - 포화의 첫 신호", 0, 0, 24, 8, [
+        target(f'executor_queued_tasks{{{JOB},name="clientInboundChannelExecutor"}}', "inbound"),
+        target(f'executor_queued_tasks{{{JOB},name="clientOutboundChannelExecutor"}}', "outbound"),
+    ], "short",
+       "기본 실행기는 큐가 무한이라 스레드 풀이 절대 거부하지 않는다. "
+       "그래서 포화가 에러가 아니라 지연으로만 나타난다. 에러율은 0인데 여기가 오른다. 붕괴 2·3단계."),
+
+    panel(2, "STOMP 활성 스레드", 0, 8, 12, 7, [
+        target(f'executor_active_threads{{{JOB},name="clientInboundChannelExecutor"}}', "inbound active"),
+        target(f'executor_pool_size_threads{{{JOB},name="clientInboundChannelExecutor"}}', "inbound pool"),
+        target(f'executor_active_threads{{{JOB},name="clientOutboundChannelExecutor"}}', "outbound active"),
+        target(f'executor_pool_size_threads{{{JOB},name="clientOutboundChannelExecutor"}}', "outbound pool"),
+    ], "short", "active 가 pool 에 붙으면 더 못 밀어 넣는다. 그 뒤로는 전부 큐로 간다."),
+
+    panel(3, "★ fan-out 배수 - 브로드캐스트 비용의 본체", 12, 8, 12, 7, [
+        target(f'histogram_quantile(0.50, sum by (le) (rate(chat_fanout_recipients_bucket{{{JOB}}}[1m])))', "p50"),
+        target(f'histogram_quantile(0.95, sum by (le) (rate(chat_fanout_recipients_bucket{{{JOB}}}[1m])))', "p95"),
+        target(f'histogram_quantile(0.99, sum by (le) (rate(chat_fanout_recipients_bucket{{{JOB}}}[1m])))', "p99"),
+    ], "short",
+       "발행 1건이 수신 N건이 된다. 발행량만 보면 30명 방과 3,000명 방이 같아 보인다. "
+       "실제 쓰기량 = 발행량 x 이 값."),
+
+    panel(4, "발행량 / 실제 전달량", 0, 15, 12, 7, [
+        target(f'rate(chat_messages_published_total{{{JOB}}}[1m])', "발행 (msg/s)"),
+        target(f'rate(chat_fanout_recipients_sum{{{JOB}}}[1m])', "실제 전달 (msg/s)"),
+    ], "short", "두 선의 간격이 곧 fan-out 배수다. 방이 커질수록 벌어진다."),
+
+    panel(5, "세션 수 / 활성 방 수", 12, 15, 12, 7, [
+        target(f'chat_sessions_active{{{JOB}}}', "STOMP 세션"),
+        target(f'chat_rooms_active{{{JOB}}}', "활성 방"),
+    ], "short", "세션 수가 커넥션 한계(붕괴 4단계)에 닿는지 본다."),
+
+    panel(6, "JVM 힙 - 큐가 무한이면 여기가 먼저 찬다", 0, 22, 12, 7, [
+        target(f'sum(jvm_memory_used_bytes{{{JOB},area="heap"}})', "사용"),
+        target(f'sum(jvm_memory_max_bytes{{{JOB},area="heap"}})', "최대"),
+    ], "bytes", "붕괴 3단계(무한 큐 OOM)는 큐 길이와 힙이 같이 오르는 형태로 나타난다."),
+
+    panel(7, "GC 정지 시간", 12, 22, 12, 7, [
+        target(f'rate(jvm_gc_pause_seconds_sum{{{JOB}}}[1m])', "{{action}} {{cause}}"),
+    ], "s", "힙이 차면 GC 가 먼저 반응하고, 그게 다시 큐를 밀어올린다."),
+]
+
 dashboard = {
     "uid": "edumeet-baseline",
     "title": "EduMeet — 기준 지표",
@@ -105,6 +151,21 @@ dashboard = {
     "panels": panels,
 }
 
-OUT.parent.mkdir(parents=True, exist_ok=True)
-OUT.write_text(json.dumps(dashboard, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-print(f"{OUT}  패널 {len(panels)}개")
+chat_dashboard = {
+    "uid": "edumeet-chat",
+    "title": "EduMeet — 채팅 붕괴 측정",
+    "description": "붕괴 5단계를 보는 대시보드. 처리율이 아니라 대기열과 fan-out 배수를 본다. (#39)",
+    "tags": ["edumeet", "chat", "breaking-points"],
+    "timezone": "browser",
+    "schemaVersion": 39,
+    "version": 1,
+    "refresh": "5s",   # 붕괴는 빠르게 온다. 기준 대시보드보다 촘촘하게 본다.
+    "time": {"from": "now-15m", "to": "now"},
+    "panels": chat_panels,
+}
+
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+for name, d in [("edumeet-baseline", dashboard), ("edumeet-chat", chat_dashboard)]:
+    path = OUT_DIR / f"{name}.json"
+    path.write_text(json.dumps(d, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"{path}  패널 {len(d['panels'])}개")

--- a/src/main/java/com/edu/edumeet/chat/controller/ChatController.java
+++ b/src/main/java/com/edu/edumeet/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.edu.edumeet.chat.controller;
 
 import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.metrics.ChatMetrics;
 import com.edu.edumeet.chat.dto.ChatSendRequest;
 import com.edu.edumeet.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class ChatController {
 
     private final ChatService chatService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMetrics chatMetrics;
 
     @MessageMapping("/rooms/{meetingId}/send")
     public void send(@DestinationVariable Long meetingId,
@@ -43,6 +45,11 @@ public class ChatController {
         ChatMessageResponse response =
                 chatService.handle(meetingId, principal.getName(), request.content());
 
-        messagingTemplate.convertAndSend("/topic/rooms/" + meetingId, response);
+        String destination = "/topic/rooms/" + meetingId;
+        messagingTemplate.convertAndSend(destination, response);
+
+        // 발행 1건이 수신 N건이 되는 배수가 브로드캐스트 비용의 본체다. (#39)
+        // 발행량만 세면 30명 방과 3,000명 방이 같아 보인다.
+        chatMetrics.published(destination);
     }
 }

--- a/src/main/java/com/edu/edumeet/chat/metrics/ChatMetrics.java
+++ b/src/main/java/com/edu/edumeet/chat/metrics/ChatMetrics.java
@@ -1,0 +1,93 @@
+package com.edu.edumeet.chat.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 채팅 지표. (#39)
+ *
+ * <h3>왜 WebSocketMessageBrokerStats 를 쓰지 않는가</h3>
+ * Spring 이 같은 값을 이미 계산하지만 <b>전부 {@code String} 으로만 노출한다.</b>
+ * <pre>
+ *   String getClientInboundExecutorStatsInfo()   // "pool size = 8, active threads = 0, ..."
+ * </pre>
+ * 문자열을 파싱하면 Spring 이 형식을 바꾸는 순간 조용히 깨진다.
+ * 세션·방·발행량은 <b>이벤트로 직접 센다.</b>
+ *
+ * <h3>fan-out 배수를 왜 따로 재는가</h3>
+ * 발행 1건이 수신 N건이 되는 <b>배수가 브로드캐스트 비용의 본체</b>다.
+ * 발행량만 보면 30명 방과 3,000명 방이 같아 보인다.
+ */
+@Component
+@Slf4j
+public class ChatMetrics {
+
+    private final AtomicInteger activeSessions = new AtomicInteger();
+    /** 목적지 → 구독자 수. 방이 비면 제거해서 게이지가 실제 활성 방을 가리키게 한다. */
+    private final Map<String, AtomicInteger> subscribersByRoom = new ConcurrentHashMap<>();
+
+    private final Counter publishedMessages;
+    private final DistributionSummary fanoutRecipients;
+
+    public ChatMetrics(MeterRegistry registry) {
+        Gauge.builder("chat.sessions.active", activeSessions, AtomicInteger::get)
+                .description("현재 열려 있는 STOMP 세션 수")
+                .register(registry);
+
+        Gauge.builder("chat.rooms.active", subscribersByRoom, Map::size)
+                .description("구독자가 하나 이상인 방 수")
+                .register(registry);
+
+        this.publishedMessages = Counter.builder("chat.messages.published")
+                .description("서버가 브로드캐스트한 메시지 수 (fan-out 이전)")
+                .register(registry);
+
+        this.fanoutRecipients = DistributionSummary.builder("chat.fanout.recipients")
+                .description("발행 1건이 실제로 전달된 대상 수. 브로드캐스트 비용의 본체다")
+                .publishPercentileHistogram()
+                .register(registry);
+    }
+
+    public void sessionConnected() {
+        activeSessions.incrementAndGet();
+    }
+
+    public void sessionDisconnected() {
+        activeSessions.updateAndGet(n -> Math.max(0, n - 1));
+    }
+
+    public void subscribed(String destination) {
+        subscribersByRoom.computeIfAbsent(destination, d -> new AtomicInteger()).incrementAndGet();
+    }
+
+    /**
+     * 구독자가 0이 되면 항목 자체를 지운다.
+     * 남겨두면 {@code chat.rooms.active} 가 "한 번이라도 쓰인 방" 을 세게 되어
+     * 활성 방 수와 어긋난다.
+     */
+    public void unsubscribed(String destination) {
+        subscribersByRoom.computeIfPresent(destination, (d, count) ->
+                count.decrementAndGet() <= 0 ? null : count);
+    }
+
+    /** 발행 1건과 그 수신자 수를 함께 기록한다. */
+    public void published(String destination) {
+        publishedMessages.increment();
+        AtomicInteger subscribers = subscribersByRoom.get(destination);
+        fanoutRecipients.record(subscribers == null ? 0 : subscribers.get());
+    }
+
+    /** 세션이 끊길 때 그 세션의 구독을 정리하기 위해 필요하다. */
+    public int subscriberCount(String destination) {
+        AtomicInteger count = subscribersByRoom.get(destination);
+        return count == null ? 0 : count.get();
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/metrics/ChatSessionEventListener.java
+++ b/src/main/java/com/edu/edumeet/chat/metrics/ChatSessionEventListener.java
@@ -1,0 +1,82 @@
+package com.edu.edumeet.chat.metrics;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * STOMP 생명주기 이벤트를 지표로 옮긴다. (#39)
+ *
+ * <h3>왜 구독을 직접 추적하는가</h3>
+ * {@code SessionUnsubscribeEvent} 는 <b>목적지를 담지 않는다.</b> 구독 id 만 온다.
+ * 그리고 세션이 그냥 끊기면 UNSUBSCRIBE 없이 사라진다.
+ * 그래서 (세션, 구독id) → 목적지를 들고 있다가 정리한다.
+ * 이걸 안 하면 <b>방이 비었는데도 구독자 수가 줄지 않아 fan-out 배수가 계속 부풀려진다.</b>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatSessionEventListener {
+
+    private final ChatMetrics chatMetrics;
+
+    /** "sessionId:subscriptionId" → destination */
+    private final Map<String, String> destinationBySubscription = new ConcurrentHashMap<>();
+
+    @EventListener
+    public void onConnected(SessionConnectedEvent event) {
+        chatMetrics.sessionConnected();
+    }
+
+    @EventListener
+    public void onSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            return;
+        }
+        destinationBySubscription.put(key(accessor.getSessionId(), accessor.getSubscriptionId()), destination);
+        chatMetrics.subscribed(destination);
+    }
+
+    @EventListener
+    public void onUnsubscribe(SessionUnsubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination =
+                destinationBySubscription.remove(key(accessor.getSessionId(), accessor.getSubscriptionId()));
+        if (destination != null) {
+            chatMetrics.unsubscribed(destination);
+        }
+    }
+
+    /**
+     * 세션이 끊기면 그 세션의 구독을 전부 정리한다.
+     * UNSUBSCRIBE 없이 연결이 끊기는 경우가 정상 경로다 - 브라우저를 닫으면 그렇게 된다.
+     */
+    @EventListener
+    public void onDisconnect(SessionDisconnectEvent event) {
+        chatMetrics.sessionDisconnected();
+
+        String prefix = event.getSessionId() + ":";
+        destinationBySubscription.entrySet().removeIf(entry -> {
+            if (entry.getKey().startsWith(prefix)) {
+                chatMetrics.unsubscribed(entry.getValue());
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private String key(String sessionId, String subscriptionId) {
+        return sessionId + ":" + subscriptionId;
+    }
+}

--- a/src/main/java/com/edu/edumeet/chat/metrics/StompExecutorMetricsConfig.java
+++ b/src/main/java/com/edu/edumeet/chat/metrics/StompExecutorMetricsConfig.java
@@ -1,0 +1,80 @@
+package com.edu.edumeet.chat.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * STOMP 채널 실행기를 Micrometer 에 바인딩한다. (#39)
+ *
+ * <h3>왜 이게 붕괴 측정의 핵심인가</h3>
+ * 기본 실행기는 <b>큐 용량이 무한</b>이다. 스레드 풀이 절대 거부하지 않으므로
+ * <b>포화가 에러가 아니라 지연으로만 나타난다.</b>
+ * 에러율만 보면 서버는 정상인데 사용자는 메시지를 수 초 뒤에 받는다.
+ *
+ * <p>{@code executor.queued} 가 없으면 그 상태를 볼 방법이 없다.
+ *
+ * <h3>왜 이름으로 찾는가</h3>
+ * {@code AbstractMessageBrokerConfiguration} 이 정의하는 빈이라 타입으로 찾으면
+ * 애플리케이션의 다른 {@code TaskExecutor} 와 섞인다. 이름으로 콕 집는다.
+ * <b>없으면 조용히 넘어간다</b> — Spring 이 구현을 바꿔도 앱이 뜨지 못하는 일은 없어야 한다.
+ */
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class StompExecutorMetricsConfig implements InitializingBean {
+
+    private static final List<String> EXECUTOR_BEANS = List.of(
+            "clientInboundChannelExecutor",
+            "clientOutboundChannelExecutor");
+
+    private final ApplicationContext applicationContext;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void afterPropertiesSet() {
+        for (String beanName : EXECUTOR_BEANS) {
+            bind(beanName);
+        }
+    }
+
+    private void bind(String beanName) {
+        if (!applicationContext.containsBean(beanName)) {
+            log.warn("{} 빈이 없다. 큐 길이 지표 없이 뜬다 - 붕괴 측정 전에 확인해야 한다.", beanName);
+            return;
+        }
+        Object bean = applicationContext.getBean(beanName);
+        ExecutorService executor = unwrap(bean);
+        if (executor == null) {
+            log.warn("{} 이 ThreadPoolTaskExecutor 가 아니다({}). 큐 길이를 잴 수 없다.",
+                    beanName, bean.getClass().getName());
+            return;
+        }
+        ExecutorServiceMetrics.monitor(
+                meterRegistry, executor, beanName, List.of(Tag.of("component", "stomp")));
+        log.info("STOMP 실행기 계측 등록 - {}", beanName);
+    }
+
+    private ExecutorService unwrap(Object bean) {
+        if (bean instanceof ThreadPoolTaskExecutor taskExecutor) {
+            return taskExecutor.getThreadPoolExecutor();
+        }
+        if (bean instanceof ExecutorService executorService) {
+            return executorService;
+        }
+        if (bean instanceof TaskExecutor) {
+            return null;   // 큐를 노출하지 않는 구현이다
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/edu/edumeet/integration/chat/ChatMetricsTest.java
+++ b/src/test/java/com/edu/edumeet/integration/chat/ChatMetricsTest.java
@@ -1,0 +1,196 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.dto.ChatSendRequest;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.config.jwt.JwtService;
+import com.edu.edumeet.member.domain.Member;
+import com.edu.edumeet.openvidu.domain.Meeting;
+import com.edu.edumeet.openvidu.domain.MeetingParticipant;
+import com.edu.edumeet.openvidu.domain.SessionType;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 채팅 지표가 실제로 /actuator/prometheus 에 나오는지 확인한다. (#39)
+ *
+ * <p>계측 코드를 쓰고 "지표를 붙였다" 고 하면 안 된다.
+ * #28 에서 <b>설정은 있는데 엔드포인트가 404 였던</b> 일을 겪었다.
+ * 여기서는 <b>연결·구독·발행을 실제로 하고 그 수가 지표에 반영되는지</b>까지 본다.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "management.server.port=0")
+@ActiveProfiles("test")
+@DisplayName("채팅 지표")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ChatMetricsTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @LocalServerPort int port;
+    @LocalManagementPort int managementPort;
+
+    @Autowired TestRestTemplate rest;
+    @Autowired JwtService jwtService;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private WebSocketStompClient stompClient;
+    private Long meetingId;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        String email = "metrics-" + SEQ.incrementAndGet() + "@test";
+        transactionTemplate.executeWithoutResult(status -> {
+            Member owner = Member.builder().email(email).nickname("참가자").password("x").build();
+            em.persist(owner);
+            ClassRoom classRoom = ClassRoom.builder()
+                    .member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(classRoom);
+            Meeting meeting = Meeting.builder()
+                    .classRoom(classRoom).title("회의").description("-")
+                    .sessionType(SessionType.INTERACTIVE)
+                    .startTime(LocalDateTime.now().minusMinutes(5)).build();
+            em.persist(meeting);
+            em.persist(MeetingParticipant.join(meeting, email));
+            em.flush();
+            meetingId = meeting.getId();
+        });
+        token = jwtService.generateAccessToken(1L, email);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stompClient != null) stompClient.stop();
+    }
+
+    private String scrape() {
+        return rest.getForObject(
+                "http://localhost:" + managementPort + "/actuator/prometheus", String.class);
+    }
+
+    /** Prometheus 텍스트에서 값 하나를 읽는다. 이름이 없으면 null. */
+    private Double metric(String body, String name) {
+        Matcher m = Pattern.compile("^" + Pattern.quote(name) + "\\{[^}]*\\}\\s+([0-9.eE+-]+)$",
+                Pattern.MULTILINE).matcher(body);
+        return m.find() ? Double.parseDouble(m.group(1)) : null;
+    }
+
+    private StompSession connect() throws Exception {
+        StompHeaders headers = new StompHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        return stompClient.connectAsync("ws://localhost:" + port + "/ws",
+                        new WebSocketHttpHeaders(), headers, new StompSessionHandlerAdapter() {})
+                .get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("★ 큐 길이 지표가 존재한다 - 없으면 붕괴 2단계는 관측 자체가 불가능하다")
+    void executor_queue_metrics_exist() {
+        String body = scrape();
+
+        assertThat(body)
+                .as("기본 실행기는 큐가 무한이라 포화가 에러가 아니라 지연으로만 나타난다. "
+                    + "이 지표가 없으면 그 상태를 볼 방법이 없다")
+                .contains("executor_queued_tasks")
+                .contains("clientInboundChannelExecutor")
+                .contains("clientOutboundChannelExecutor");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("연결하면 세션 수가 오르고 끊으면 내려간다")
+    void session_gauge_tracks_connections() throws Exception {
+        double before = orZero(metric(scrape(), "chat_sessions_active"));
+
+        StompSession session = connect();
+        Thread.sleep(400);
+        assertThat(metric(scrape(), "chat_sessions_active"))
+                .as("연결 후 세션 수가 올라야 한다")
+                .isEqualTo(before + 1);
+
+        session.disconnect();
+        Thread.sleep(600);
+        assertThat(metric(scrape(), "chat_sessions_active"))
+                .as("끊으면 되돌아와야 한다. 안 줄면 붕괴 4단계 측정이 부풀려진다")
+                .isEqualTo(before);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("★ fan-out 배수가 기록된다 - 발행량만 세면 30명 방과 3000명 방이 같아 보인다")
+    void fanout_records_recipient_count() throws Exception {
+        StompSession session = connect();
+        CompletableFuture<ChatMessageResponse> received = new CompletableFuture<>();
+        session.subscribe("/topic/rooms/" + meetingId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders h) { return ChatMessageResponse.class; }
+            @Override public void handleFrame(StompHeaders h, Object p) {
+                received.complete((ChatMessageResponse) p);
+            }
+        });
+        Thread.sleep(400);
+
+        assertThat(metric(scrape(), "chat_rooms_active"))
+                .as("구독한 방이 하나 잡혀야 한다").isEqualTo(1.0);
+
+        double publishedBefore = orZero(metric(scrape(), "chat_messages_published_total"));
+        session.send("/app/rooms/" + meetingId + "/send", new ChatSendRequest("측정"));
+        received.get(5, TimeUnit.SECONDS);
+        Thread.sleep(300);
+
+        String body = scrape();
+        assertThat(metric(body, "chat_messages_published_total")).isEqualTo(publishedBefore + 1);
+        assertThat(body)
+                .as("수신자 수 분포가 기록되어야 한다")
+                .contains("chat_fanout_recipients");
+        assertThat(orZero(metric(body, "chat_fanout_recipients_sum")))
+                .as("구독자 1명에게 갔으므로 합이 1 이상이어야 한다")
+                .isGreaterThanOrEqualTo(1.0);
+
+        // publishPercentileHistogram() 이 빠지면 _bucket 이 안 나오고
+        // 대시보드의 histogram_quantile 패널이 통째로 "No data" 가 된다. (#28 의 5xx 패널과 같은 함정)
+        assertThat(body)
+                .as("histogram_quantile 을 쓰려면 버킷이 있어야 한다")
+                .contains("chat_fanout_recipients_bucket");
+
+        session.disconnect();
+        Thread.sleep(600);
+        assertThat(orZero(metric(scrape(), "chat_rooms_active")))
+                .as("세션이 끊기면 UNSUBSCRIBE 없이 사라진다. 정리하지 않으면 방이 영영 남는다")
+                .isZero();
+    }
+
+    private double orZero(Double v) {
+        return v == null ? 0.0 : v;
+    }
+}


### PR DESCRIPTION
Closes #39

#28 에서 미룬 부분입니다. 채팅이 생겼으니(#33) 이제 붙일 대상이 있습니다.

## 🔴 왜 큐 길이인가

STOMP 채널의 기본 실행기는 **큐 용량이 무한**입니다.

> **스레드 풀이 절대 거부하지 않습니다. 그래서 포화가 에러가 아니라 지연으로만 나타납니다.**

에러율만 보면 서버는 정상인데 사용자는 메시지를 수 초 뒤에 받습니다.
**`executor_queued_tasks` 가 없으면 붕괴 ②는 관측 자체가 불가능합니다.**

## `WebSocketMessageBrokerStats` 를 쓰지 않았습니다

Spring 이 같은 값을 이미 계산합니다. 다만 **전부 `String` 으로만 노출합니다.**

```java
String getClientInboundExecutorStatsInfo()   // "pool size = 8, active threads = 0, ..."
```

문자열을 파싱하면 Spring 이 형식을 바꾸는 순간 **조용히 깨집니다.**
**실행기 객체를 Micrometer 에 직접 바인딩**하고, 세션·방·발행량은 이벤트로 직접 셉니다.

빈을 **이름으로** 찾습니다 — 타입으로 찾으면 앱의 다른 `TaskExecutor` 와 섞입니다.
없으면 **경고만 남기고 넘어갑니다.** Spring 이 구현을 바꿔도 앱이 못 뜨는 일은 없어야 합니다.

## ★ fan-out 배수가 브로드캐스트 비용의 본체입니다

```
실제 쓰기량 = 발행량 × fan-out 배수
```

**발행량만 세면 30명 방과 3,000명 방이 같아 보입니다.**
`chat.fanout.recipients` 로 발행 1건이 실제로 몇 명에게 갔는지 분포를 기록합니다.

## 정리하지 않으면 지표가 부풀려집니다

`SessionUnsubscribeEvent` 는 **목적지를 담지 않습니다.** 구독 id 만 옵니다.
그리고 **브라우저를 닫으면 UNSUBSCRIBE 없이 세션이 사라집니다** — 이게 정상 경로입니다.

그래서 `(세션, 구독id) → 목적지` 를 들고 있다가 끊길 때 정리합니다.
안 하면 **방이 비었는데 구독자 수가 줄지 않아 fan-out 배수가 계속 부풀려집니다.**

## `_bucket` 이 없으면 패널이 빈 화면입니다

`publishPercentileHistogram()` 이 빠지면 `chat_fanout_recipients_bucket` 이 안 나오고
대시보드의 `histogram_quantile` 패널이 통째로 **"No data"** 가 됩니다.

**#32 의 5xx 패널과 똑같은 함정**이라 테스트로 고정했습니다.

## 지표가 실제로 나오는지 확인했습니다

계측 코드를 쓰고 *"지표를 붙였다"* 고 하지 않습니다.
#32 에서 **설정은 있는데 엔드포인트가 404 였던** 일을 겪었습니다.

| 테스트 | 확인하는 것 |
|---|---|
| **`executor_queue_metrics_exist`** | 큐 길이 지표가 실제로 존재 |
| `session_gauge_tracks_connections` | 연결하면 오르고 **끊으면 내려간다** |
| **`fanout_records_recipient_count`** | 배수 기록 + `_bucket` 존재 + **세션 종료 시 방 정리** |

연결·구독·발행을 **실제로 하고** `/actuator/prometheus` 를 긁어서 값을 확인합니다.

## Grafana 대시보드

```bash
python3 scripts/make_dashboard.py    # 두 개를 생성한다
```

| 대시보드 | |
|---|---|
| `EduMeet — 기준 지표` | HTTP·JVM·Hikari (기존) |
| **`EduMeet — 채팅 붕괴 측정`** | 큐 길이 · fan-out 배수 · 세션/방 · 힙·GC |

채팅 대시보드는 refresh 를 **5초**로 뒀습니다. 붕괴는 빠르게 옵니다.

```
테스트 201개 통과 (기존 198 + 신규 3)
```

## 다음

**Phase 2: 무한 큐 OOM 재현 → 붕괴 ③.** 이 계측이 그 측정 도구가 됩니다.
`-Xmx512m` 로 발화율을 처리량 이상으로 유지하면 수 분 내에 재현됩니다.

관련: #28, #33