### PR TITLE
fix: 배포가 없는 이미지 태그를 당긴다 (#45)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,11 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=sha,prefix=,format=short
+            # ★ long 이어야 한다. 배포 스크립트가 ${{ github.sha }}(40자)로 당기는데
+            #   short(7자)로 푸시하면 같은 커밋인데 이름이 달라 manifest unknown 이 난다. (#45)
+            #   배포 쪽에서 자르는 방법도 있지만, 자르는 코드가 하나 더 생기면
+            #   또 어긋날 자리가 생긴다. 양쪽이 같은 값을 쓰게 한다.
+            type=sha,prefix=,format=long
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Closes #45

시크릿을 넣자 SSH 는 뚫렸고(`Login Succeeded`) **그 다음에서** 실패했습니다.

```
Image ghcr.io/dj258255/edumeet:bf47ac1e22e9e34e4994ad70209341ef0ad727b0
Error manifest unknown
```

## 원인

| | 태그 |
|---|---|
| 빌드가 **푸시** | `type=sha,prefix=,format=short` → **`bf47ac1`** (7자) |
| 배포가 **당김** | `${{ github.sha }}` → **`bf47ac1e22e9e…`** (40자) |

**같은 커밋인데 이름이 다릅니다.** #26 에서 만든 버그입니다.

지금까지 안 드러난 이유는 단순합니다 — **시크릿이 없어서 여기까지 온 적이 없었습니다.**
`missing server host` 에서 매번 멈췄으니 그 뒤 단계는 한 번도 실행되지 않았습니다.

## 고침

`format=long` 으로 맞췄습니다.

배포 쪽에서 `${{ github.sha }}` 를 7자로 자르는 방법도 있지만,
**자르는 코드가 하나 더 생기면 또 어긋날 자리가 생깁니다.** 양쪽이 같은 값을 쓰게 합니다.

관련: #26, #34