### PR TITLE
fix: AWS 자격증명이 없으면 앱이 아예 뜨지 않는다 (#51)

### DIFF
--- a/src/main/java/com/edu/edumeet/s3/config/S3Config.java
+++ b/src/main/java/com/edu/edumeet/s3/config/S3Config.java
@@ -1,5 +1,7 @@
 package com.edu.edumeet.s3.config;
 
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,7 +15,20 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import java.time.Duration;
 
 @Configuration
+@Slf4j
 public class S3Config {
+
+    /**
+     * 자격증명이 없을 때 쓰는 자리표시자. {@code application.yml} 의 기본값과 같아야 한다. (#51)
+     *
+     * <p>빈 문자열을 두면 {@code AwsBasicCredentials.create} 가 NPE 를 던져
+     * <b>앱 전체가 뜨지 못한다.</b> S3 는 첨부·썸네일·요약본에만 쓰이는데
+     * 그것 때문에 서비스가 안 뜨는 건 과하다.
+     *
+     * <p>대신 <b>조용히 넘어가지 않는다.</b> 기동 시 경고를 남긴다 -
+     * 설정이 빠진 채로 떠 있는 상태를 로그만 보고 알 수 있어야 한다.
+     */
+    private static final String NOT_CONFIGURED = "not-configured";
 
     /**
      * 한 번의 S3 호출이 재시도까지 포함해 잡을 수 있는 최대 시간.
@@ -44,6 +59,14 @@ public class S3Config {
     private String region;
 
 
+
+    @PostConstruct
+    void warnIfNotConfigured() {
+        if (NOT_CONFIGURED.equals(accessKey) || NOT_CONFIGURED.equals(secretKey)) {
+            log.warn("AWS 자격증명이 설정되지 않았다. 앱은 뜨지만 S3 를 쓰는 기능(첨부·썸네일·요약본)은 "
+                     + "호출 시점에 실패한다. .env 의 AWS_ACCESS_KEY / AWS_SECRET_KEY 를 채워야 한다. (#51)");
+        }
+    }
 
     @Bean
     public S3Client s3Client() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,12 +75,14 @@ spring:
   cloud:
     aws:
       credentials:
-        access-key: ${AWS_ACCESS_KEY:}
-        secret-key: ${AWS_SECRET_KEY:}
+        # 비어 있으면 S3Client 생성이 NPE 로 죽어 앱 전체가 안 뜬다. (#51)
+        # 자리표시자를 기본값으로 두어 뜨게 하되, S3Config 가 기동 시 경고를 남긴다.
+        access-key: ${AWS_ACCESS_KEY:not-configured}
+        secret-key: ${AWS_SECRET_KEY:not-configured}
       region:
         static: ${AWS_REGION:ap-northeast-2}
       s3:
-        bucket: ${AWS_S3_BUCKET:}
+        bucket: ${AWS_S3_BUCKET:not-configured}
 
   security:
     oauth2:

--- a/src/test/java/com/edu/edumeet/integration/config/S3OptionalCredentialsTest.java
+++ b/src/test/java/com/edu/edumeet/integration/config/S3OptionalCredentialsTest.java
@@ -1,0 +1,62 @@
+package com.edu.edumeet.integration.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AWS 자격증명이 없어도 앱이 뜬다. (#51)
+ *
+ * <p>배포가 여기서 멈췄었다.
+ * <pre>
+ * Caused by: java.lang.NullPointerException: Access key ID cannot be blank.
+ *   Error creating bean with name 's3Client'
+ * </pre>
+ *
+ * <p>S3 는 첨부·썸네일·요약본에만 쓰인다. <b>그것 때문에 서비스 전체가 못 뜨는 건 과하다.</b>
+ *
+ * <p>다만 <b>조용히 넘어가면 안 된다.</b> {@code S3Config} 가 기동 시 경고를 남긴다 —
+ * #49 에서 배운 게 정확히 그것이다. 설정 실수는 또 나고,
+ * <b>그 실수가 조용해지는 쪽을 막는 게 더 중요하다.</b>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        // 자격증명을 아예 안 준 상태를 만든다. 기본값(not-configured)이 적용된다.
+        "spring.cloud.aws.credentials.access-key=not-configured",
+        "spring.cloud.aws.credentials.secret-key=not-configured",
+})
+@DisplayName("AWS 자격증명 없이 기동")
+class S3OptionalCredentialsTest {
+
+    @Autowired ApplicationContext context;
+
+    @Test
+    @DisplayName("★ 자격증명이 없어도 컨텍스트가 뜬다")
+    void context_starts_without_credentials() {
+        assertThat(context)
+                .as("S3 하나 때문에 앱 전체가 못 뜨면 안 된다")
+                .isNotNull();
+        assertThat(context.getBean(S3Client.class))
+                .as("빈은 만들어진다. 실제 호출은 그때 가서 실패한다")
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("기본값이 비어 있지 않다 - 빈 문자열이면 NPE 로 죽는다")
+    void placeholder_is_not_blank() {
+        String accessKey = context.getEnvironment()
+                .getProperty("spring.cloud.aws.credentials.access-key");
+
+        assertThat(accessKey)
+                .as("AwsBasicCredentials.create 는 빈 값에서 NPE 를 던진다")
+                .isNotBlank();
+    }
+}


### PR DESCRIPTION
Closes #51

배포가 여기서 멈췄습니다.

```
Caused by: java.lang.NullPointerException: Access key ID cannot be blank.
  Error creating bean with name 's3Client'
```

**S3 는 첨부·썸네일·요약본에만 쓰입니다. 그것 때문에 서비스 전체가 못 뜨는 건 과합니다.**

그리고 #47 PR 에 *"기본값이 있으니 clone 직후 그냥 뜬다"* 고 적었는데 **거짓이었습니다.**
`application.yml` 의 AWS 기본값이 빈 문자열이라 **로컬에서도 같은 NPE** 가 났습니다.

## 세 가지 중에 골랐습니다

| | |
|---|---|
| ❌ 빈 값 그대로 | 앱이 안 뜬다 |
| ❌ `@Lazy` | 뜨긴 하는데 **첫 업로드에서 같은 NPE**. 문제가 더 늦게, 더 엉뚱한 곳에서 터진다 |
| ✅ **자리표시자 + 기동 시 경고** | 앱은 뜬다. **설정이 빠졌다는 사실이 로그에 남는다** |

> **"뜨지만 S3 는 안 된다" 와 "아예 안 뜬다" 중 전자가 낫습니다.**
> 다만 **조용하면 안 됩니다.** #49 에서 배운 게 정확히 그겁니다 —
> *설정 실수는 언제든 또 나고, 그 실수가 조용해지는 쪽을 막는 게 더 중요합니다.*

```java
@PostConstruct
void warnIfNotConfigured() {
    if (NOT_CONFIGURED.equals(accessKey) || NOT_CONFIGURED.equals(secretKey)) {
        log.warn("AWS 자격증명이 설정되지 않았다. 앱은 뜨지만 S3 를 쓰는 기능은 호출 시점에 실패한다...");
    }
}
```

```
테스트 206개 통과 (기존 204 + 신규 2)
```

## 다음에 볼 것 — 이 작업 중 발견

`ObjectCannedACL.PUBLIC_READ` 를 **모든 업로드 경로(4곳)** 에서 쓰고 있습니다.
**과제 제출물과 회의 요약본(수업 STT 전문)이 URL 만 알면 열립니다.**
프리사인드 URL 코드는 이미 있는데(`generatePresignedUrl`) 쓰이지 않고 있습니다.

별도 이슈로 다룹니다.

관련: #47, #49