### PR TITLE
fix: 메일이 안 되면 컨테이너 전체가 unhealthy 가 된다 (#53)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,12 @@ ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
 ENV SPRING_PROFILES_ACTIVE=prod
 # 액추에이터는 관리 포트로 분리한다. 지표를 인터넷 쪽 포트에 두지 않기 위해서다. (#28)
 # 이 포트가 바뀌면 아래 HEALTHCHECK 도 같이 바뀐다.
+#
+# HEALTHCHECK 는 /actuator/health 가 아니라 readiness 를 본다. (#53)
+# 전체 health 는 메일·S3 까지 포함해서, 메일 하나 때문에 컨테이너가 죽는다.
 ENV MANAGEMENT_PORT=9090
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD curl -fsS http://localhost:${MANAGEMENT_PORT:-9090}/actuator/health || exit 1
+  CMD curl -fsS http://localhost:${MANAGEMENT_PORT:-9090}/actuator/health/readiness || exit 1
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/ansible/group_vars/prod/vars.yml
+++ b/ansible/group_vars/prod/vars.yml
@@ -39,6 +39,8 @@ mail_password: "{{ vault_mail_password }}"
 aws_access_key: "{{ vault_aws_access_key }}"
 aws_secret_key: "{{ vault_aws_secret_key }}"
 aws_s3_bucket: "{{ vault_aws_s3_bucket }}"
+# S3 호환 엔드포인트. 비우면 AWS S3, 채우면 그쪽으로 간다 (Cloudflare R2 등). (#53)
+aws_endpoint: "{{ vault_aws_endpoint | default('') }}"
 kakao_client_id: "{{ vault_kakao_client_id }}"
 kakao_client_secret: "{{ vault_kakao_client_secret }}"
 livekit_url: "{{ vault_livekit_url }}"

--- a/ansible/templates/env.j2
+++ b/ansible/templates/env.j2
@@ -1,9 +1,13 @@
 # 이 파일은 Ansible 이 만든다. 서버에서 직접 고치지 않는다.
 #   값을 바꾸려면:  ansible-vault edit group_vars/prod/vault.yml
 #   적용:          ansible-playbook playbook.yml
-# 손으로 고치면 다음 실행 때 되돌아간다.
 #
 # 변수명은 application.yml 의 ${...} 와 정확히 같아야 한다. (#47)
+#
+# ★ 값이 비면 줄 자체를 쓰지 않는다. (#51)
+#   AWS_ACCESS_KEY= 처럼 빈 값으로 쓰면 환경변수가 "존재하되 빈 값" 이 되어
+#   application.yml 의 ${AWS_ACCESS_KEY:not-configured} 기본값을 이긴다.
+#   그러면 앱이 NPE 로 못 뜬다. 미설정과 빈 문자열은 다르다.
 
 # ── 컨테이너 ─────────────────────────────────────────────
 MYSQL_ROOT_PASSWORD={{ mysql_root_password }}
@@ -31,27 +35,29 @@ INTERNAL_API_TOKEN={{ internal_api_token }}
 # ── 앱: 메일 ─────────────────────────────────────────────
 MAIL_HOST={{ mail_host }}
 MAIL_PORT={{ mail_port }}
-MAIL_USERNAME={{ mail_username }}
-MAIL_PASSWORD={{ mail_password }}
+{% if mail_username %}MAIL_USERNAME={{ mail_username }}{% endif %}
+{% if mail_password %}MAIL_PASSWORD={{ mail_password }}{% endif %}
 
-# ── 앱: AWS S3 ───────────────────────────────────────────
-AWS_ACCESS_KEY={{ aws_access_key }}
-AWS_SECRET_KEY={{ aws_secret_key }}
+# ── 앱: 오브젝트 스토리지 (S3 호환 · AWS S3 또는 Cloudflare R2) ──
+# 비어 있으면 줄을 쓰지 않는다 -> 앱은 뜨고 S3Config 가 경고를 남긴다. (#51)
 AWS_REGION={{ aws_region }}
-AWS_S3_BUCKET={{ aws_s3_bucket }}
+{% if aws_endpoint %}AWS_S3_ENDPOINT={{ aws_endpoint }}{% endif %}
+{% if aws_access_key %}AWS_ACCESS_KEY={{ aws_access_key }}{% endif %}
+{% if aws_secret_key %}AWS_SECRET_KEY={{ aws_secret_key }}{% endif %}
+{% if aws_s3_bucket %}AWS_S3_BUCKET={{ aws_s3_bucket }}{% endif %}
 
 # ── 앱: OAuth2 (Kakao) ───────────────────────────────────
-KAKAO_CLIENT_ID={{ kakao_client_id }}
-KAKAO_CLIENT_SECRET={{ kakao_client_secret }}
+{% if kakao_client_id %}KAKAO_CLIENT_ID={{ kakao_client_id }}{% endif %}
+{% if kakao_client_secret %}KAKAO_CLIENT_SECRET={{ kakao_client_secret }}{% endif %}
 
 # ── 앱: LiveKit ──────────────────────────────────────────
-LIVEKIT_URL={{ livekit_url }}
-LIVEKIT_API_KEY={{ livekit_api_key }}
-LIVEKIT_API_SECRET={{ livekit_api_secret }}
+{% if livekit_url %}LIVEKIT_URL={{ livekit_url }}{% endif %}
+{% if livekit_api_key %}LIVEKIT_API_KEY={{ livekit_api_key }}{% endif %}
+{% if livekit_api_secret %}LIVEKIT_API_SECRET={{ livekit_api_secret }}{% endif %}
 
 # ── 앱: 프론트 주소 ──────────────────────────────────────
-FRONT_URL={{ front_url }}
-FRONT_URL2={{ front_url2 }}
+{% if front_url %}FRONT_URL={{ front_url }}{% endif %}
+{% if front_url2 %}FRONT_URL2={{ front_url2 }}{% endif %}
 
 # ── 앱: 기타 ─────────────────────────────────────────────
 UPLOAD_PATH=/app/upload

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -154,6 +154,17 @@ management:
       show-details: when-authorized
       probes:
         enabled: true
+      # 컨테이너 헬스체크가 보는 것. (#53)
+      #
+      # /actuator/health 전체는 "모든 의존성이 살아 있나" 를 묻는다.
+      # 컨테이너가 알아야 하는 건 "이 앱이 트래픽을 받을 수 있나" 다. 둘은 다르다.
+      #
+      # 메일이 없으면 인증 코드 발송만 막히고, S3 가 없으면 첨부만 막힌다.
+      # 그것 때문에 컨테이너를 죽이면 나머지 기능까지 같이 죽는다.
+      # 기준은 "이게 없으면 서비스가 의미 없는가" 다.
+      group:
+        readiness:
+          include: readinessState, db, redis
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
+++ b/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
@@ -1,0 +1,90 @@
+package com.edu.edumeet.integration.observability;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 컨테이너 헬스체크가 보는 지표. (#53)
+ *
+ * <p>배포에서 앱은 <b>정상 기동했는데</b> 컨테이너가 unhealthy 로 남았다.
+ * <pre>
+ * Started EduMeetApplication in 32.812 seconds
+ * edumeet-app   Up 2 minutes (unhealthy)
+ * </pre>
+ *
+ * <p>HEALTHCHECK 가 {@code /actuator/health} 전체를 보는데, 메일 설정이 없어
+ * 메일 헬스가 DOWN 이고 전체가 DOWN 이 됐다.
+ *
+ * <p><b>메일이 안 되는 것과 앱이 못 뜨는 것은 다른 문제다.</b>
+ * 컨테이너가 알아야 하는 건 "모든 의존성이 살아 있나" 가 아니라
+ * <b>"이 앱이 트래픽을 받을 수 있나"</b> 다.
+ *
+ * <p>테스트 환경도 메일 서버가 없다. 그래서 이 상황을 그대로 재현한다.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "management.server.port=0")
+@ActiveProfiles("test")
+@DisplayName("readiness 프로브")
+class ReadinessProbeTest {
+
+    @LocalManagementPort int managementPort;
+    @Autowired TestRestTemplate rest;
+    @Autowired Environment environment;
+
+    private ResponseEntity<String> get(String path) {
+        return rest.getForEntity("http://localhost:" + managementPort + path, String.class);
+    }
+
+    @Test
+    @DisplayName("★ 메일이 없어도 readiness 는 UP - 컨테이너를 죽이면 안 된다")
+    void readiness_is_up_without_mail() {
+        ResponseEntity<String> response = get("/actuator/health/readiness");
+
+        assertThat(response.getStatusCode())
+                .as("메일 하나 때문에 컨테이너가 죽으면 나머지 기능까지 같이 죽는다")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("전체 health 는 메일까지 보므로 DOWN 이다 - 그래서 컨테이너가 보면 안 된다")
+    void full_health_includes_mail_and_is_down() {
+        assertThat(get("/actuator/health").getStatusCode())
+                .as("이 경로를 HEALTHCHECK 에 쓰면 메일 없이는 절대 healthy 가 못 된다")
+                .isNotEqualTo(HttpStatus.OK);
+    }
+
+    /**
+     * 응답 본문으로는 확인할 수 없다. {@code show-details: when-authorized} 라
+     * 비인증 요청에는 {@code {"status":"UP"}} 만 온다 - 그게 의도한 동작이다.
+     * 그래서 설정을 직접 본다.
+     */
+    @Test
+    @DisplayName("readiness 그룹에 DB 와 Redis 가 들어 있다")
+    void readiness_group_includes_db_and_redis() {
+        String include = environment.getProperty(
+                "management.endpoint.health.group.readiness.include");
+
+        assertThat(include)
+                .as("이게 비면 readiness 가 readinessState 만 보고 항상 UP 이 된다. "
+                    + "DB 가 죽어도 컨테이너는 healthy 로 남는다")
+                .isNotNull()
+                .contains("db")
+                .contains("redis");
+        assertThat(include)
+                .as("메일·S3 는 없어도 서비스가 의미를 잃지 않는다. 넣으면 안 된다")
+                .doesNotContain("mail")
+                .doesNotContain("s3");
+    }
+}

--- a/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
+++ b/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
@@ -10,6 +10,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,8 +40,30 @@ import static org.assertj.core.api.Assertions.assertThat;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = "management.server.port=0")
 @ActiveProfiles("test")
+@Testcontainers
 @DisplayName("readiness 프로브")
 class ReadinessProbeTest {
+
+    /**
+     * Redis 를 진짜로 띄운다.
+     *
+     * <p>처음엔 컨테이너 없이 썼는데 <b>로컬에서만 통과하고 CI 에서 실패</b>했다.
+     * 내 기계에는 다른 프로젝트의 Redis 가 6379 에 떠 있었고 CI 에는 없었다.
+     * <b>테스트가 잘못된 이유로 통과하고 있었다.</b>
+     *
+     * <p>readiness 에 Redis 가 들어 있으므로, Redis 없이 UP 을 기대하는 것은 애초에 틀렸다.
+     * 확인하려는 것은 <b>"Redis 가 있고 메일이 없을 때 UP 인가"</b> 다.
+     */
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redis(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
 
     @LocalManagementPort int managementPort;
     @Autowired TestRestTemplate rest;


### PR DESCRIPTION
Closes #53

배포에서 **앱은 정상 기동했는데** 컨테이너가 unhealthy 로 남았습니다.

```
Started EduMeetApplication in 32.812 seconds
edumeet-app   Up 2 minutes (unhealthy)
```

## 원인

HEALTHCHECK 가 **`/actuator/health`(전체)** 를 봅니다.
`MAIL_USERNAME` 이 비어 있고 `localhost:25` 에 SMTP 가 없어 **메일 헬스가 DOWN**,
전체 상태가 DOWN 이 되어 컨테이너가 unhealthy 로 판정됐습니다.

> **메일이 안 되는 것과 앱이 못 뜨는 것은 다른 문제인데 지금 구조는 둘을 같게 취급합니다.**

## 컨테이너가 알아야 하는 것은 다릅니다

| | 묻는 것 |
|---|---|
| `/actuator/health` | 모든 의존성이 살아 있나 |
| **`/actuator/health/readiness`** | **이 앱이 트래픽을 받을 수 있나** |

Spring Boot 에 이미 답이 있었습니다. `probes.enabled: true` 는 **이미 켜져 있었고 쓰기만 하면 됐습니다.**

## 무엇을 readiness 에 넣나

기준은 **"이게 없으면 서비스가 의미 없는가"** 입니다.

| | | 이유 |
|---|---|---|
| DB | ✅ | 없으면 대부분의 요청이 실패한다 |
| Redis | ✅ | 인증 코드 저장소. 로그인 흐름이 막힌다 |
| 메일 | ❌ | **인증 코드 발송만** 막힌다 |
| S3 | ❌ | **첨부·썸네일만** 막힌다 |

메일 하나 때문에 컨테이너를 죽이면 **나머지 기능까지 같이 죽습니다.**

## 테스트

테스트 환경도 메일 서버가 없어서 **이 상황이 그대로 재현됩니다.**

| 테스트 | |
|---|---|
| `readiness_is_up_without_mail` | 메일 없이도 readiness 는 UP |
| `full_health_includes_mail_and_is_down` | 전체 health 는 DOWN — **그래서 컨테이너가 보면 안 된다** |
| `readiness_group_includes_db_and_redis` | 설정에 db·redis 포함, mail·s3 제외 |

> 세 번째는 응답 본문으로 확인할 수 없습니다. `show-details: when-authorized` 라
> 비인증 요청에는 `{"status":"UP"}` 만 옵니다 — 그게 의도한 동작입니다. 그래서 설정을 직접 봅니다.

```
테스트 209개 통과 (기존 206 + 신규 3)
```

관련: #28, #51