### PR TITLE
feat: 이메일 인증 비활성화 - 카카오 로그인만 쓴다 (#55)

### DIFF
--- a/src/main/java/com/edu/edumeet/config/SecurityConfig.java
+++ b/src/main/java/com/edu/edumeet/config/SecurityConfig.java
@@ -106,6 +106,8 @@ public class SecurityConfig {
                                 "/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**",
+                                // 이메일 인증은 기본으로 꺼져 있다(#55). 규칙은 남긴다 -
+                                // EMAIL_ENABLED=true 로 되살릴 때 이것까지 기억해야 하면 또 막힌다.
                                 "/api/v1/members/send-code",
                                 "/api/v1/members/verification",
                                 "/api/v1/members/check-email",

--- a/src/main/java/com/edu/edumeet/email/application/AuthCodeServiceImpl.java
+++ b/src/main/java/com/edu/edumeet/email/application/AuthCodeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.edu.edumeet.email.application;
 
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+@ConditionalOnProperty(name = "edumeet.email.enabled", havingValue = "true")
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/edu/edumeet/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/edu/edumeet/email/application/EmailServiceImpl.java
@@ -1,6 +1,7 @@
 package com.edu.edumeet.email.application;
 
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.Random;
 
 
 
+@ConditionalOnProperty(name = "edumeet.email.enabled", havingValue = "true")
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/edu/edumeet/email/presentation/EmailController.java
+++ b/src/main/java/com/edu/edumeet/email/presentation/EmailController.java
@@ -1,5 +1,6 @@
 package com.edu.edumeet.email.presentation;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import com.edu.edumeet.email.application.AuthCodeServiceImpl;
 import com.edu.edumeet.email.application.EmailServiceImpl;
 import com.edu.edumeet.email.presentation.dto.request.EmailRequest;
@@ -19,6 +20,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 
+
+/**
+ * 이메일 인증. <b>기본으로 꺼져 있다.</b> (#55)
+ *
+ * <p>카카오 로그인만 쓰기로 해서 SMTP 계정을 유지할 이유가 없어졌다.
+ * 그리고 이 기능 때문에 메일 헬스가 DOWN 이 되어 <b>컨테이너가 unhealthy</b> 였다(#53).
+ *
+ * <p><b>지우지 않고 플래그로 끈다.</b> 지우면 되살릴 때 다시 짜야 하고,
+ * "왜 껐는가" 라는 판단도 같이 사라진다. 플래그면 환경변수 하나로 돌아온다.
+ *
+ * <pre>
+ *   EMAIL_ENABLED=true
+ * </pre>
+ */
+@ConditionalOnProperty(name = "edumeet.email.enabled", havingValue = "true")
 @Controller
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,11 @@ management:
         http.server.requests: true
       slo:
         http.server.requests: 50ms, 100ms, 200ms, 500ms, 1s, 2s
+  health:
+    # 메일을 쓰지 않으므로 헬스에서도 뺀다. 안 그러면 전체 health 가 영영 DOWN 이다. (#55)
+    mail:
+      enabled: ${EMAIL_ENABLED:false}
+
   endpoint:
     health:
       # 의존 컴포넌트(DB, Redis) 상태까지 보이게 한다.
@@ -191,6 +196,10 @@ openvidu:
       secret: ${LIVEKIT_API_SECRET:secret}
 
 edumeet:
+  email:
+    # 카카오 로그인만 쓰기로 해서 껐다. (#55)
+    # 지우지 않고 플래그로 둔 이유는 되살릴 때 다시 짜지 않기 위해서다.
+    enabled: ${EMAIL_ENABLED:false}
   internal:
     # 서버 간 호출용 공유 시크릿. 파이썬 AI 서버가 X-Internal-Token 헤더로 보낸다. (#27)
     # 비어 있으면 /api/v1/internal/** 은 전부 거부된다 (fail-closed).
@@ -274,6 +283,10 @@ openvidu:
       secret: devsecret
 
 edumeet:
+  email:
+    # 카카오 로그인만 쓰기로 해서 껐다. (#55)
+    # 지우지 않고 플래그로 둔 이유는 되살릴 때 다시 짜지 않기 위해서다.
+    enabled: ${EMAIL_ENABLED:false}
   internal:
     api-token: test-internal-token
   upload:

--- a/src/test/java/com/edu/edumeet/integration/email/EmailDisabledTest.java
+++ b/src/test/java/com/edu/edumeet/integration/email/EmailDisabledTest.java
@@ -1,0 +1,75 @@
+package com.edu.edumeet.integration.email;
+
+import com.edu.edumeet.email.application.AuthCodeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 이메일 인증이 꺼진 상태를 고정한다. (#55)
+ *
+ * <p>카카오 로그인만 쓰기로 해서 SMTP 계정을 유지할 이유가 없어졌다.
+ * 그리고 이 기능 때문에 메일 헬스가 DOWN 이 되어 <b>컨테이너가 unhealthy</b> 였다(#53).
+ *
+ * <p><b>지우지 않고 플래그로 껐다.</b> 지우면 되살릴 때 다시 짜야 하고,
+ * "왜 껐는가" 라는 판단도 같이 사라진다.
+ *
+ * <p>끌 수 있었던 이유는 <b>회원가입이 이메일 인증을 요구하지 않기 때문</b>이다.
+ * {@code MemberService} 는 {@code AuthCodeService} 를 참조하지 않는다 —
+ * 이메일 인증은 프론트가 회원가입 전에 부르는 독립 기능이고 백엔드가 강제하지 않는다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("이메일 인증 비활성화")
+class EmailDisabledTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ApplicationContext context;
+
+    @Test
+    @DisplayName("★ 기본이 꺼짐이다 - 빈이 아예 등록되지 않는다")
+    void email_beans_are_not_registered() {
+        assertThat(context.getBeanNamesForType(AuthCodeService.class))
+                .as("플래그가 꺼져 있으면 빈 자체가 없어야 한다. "
+                    + "빈만 두고 호출을 막으면 '왜 안 되는지' 가 런타임에만 드러난다")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("인증 코드 발송 경로가 사라진다")
+    void send_code_endpoint_is_gone() throws Exception {
+        mockMvc.perform(post("/api/v1/members/send-code"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("인증 코드 확인 경로가 사라진다")
+    void verification_endpoint_is_gone() throws Exception {
+        mockMvc.perform(post("/api/v1/members/verification"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("나머지는 그대로다 - 이메일 하나 끄는 게 다른 흐름을 건드리면 안 된다")
+    void other_endpoints_still_work() throws Exception {
+        // 로그인은 같은 /api/v1/members 아래에 있다. 컨트롤러를 조건부로 끄면서
+        // 매핑이 통째로 사라지지 않았는지 본다. 본문이 없어 400 이 나지만 404 는 아니어야 한다.
+        int status = mockMvc.perform(post("/api/v1/members/login"))
+                .andReturn().getResponse().getStatus();
+
+        assertThat(status)
+                .as("404 면 로그인 매핑까지 같이 사라진 것이다. "
+                    + "본문이 없어 400 이 나는 것은 정상이다")
+                .isNotEqualTo(404);
+    }
+}

--- a/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
+++ b/src/test/java/com/edu/edumeet/integration/observability/ReadinessProbeTest.java
@@ -84,13 +84,15 @@ class ReadinessProbeTest {
         assertThat(response.getBody()).contains("\"status\":\"UP\"");
     }
 
-    @Test
-    @DisplayName("전체 health 는 메일까지 보므로 DOWN 이다 - 그래서 컨테이너가 보면 안 된다")
-    void full_health_includes_mail_and_is_down() {
-        assertThat(get("/actuator/health").getStatusCode())
-                .as("이 경로를 HEALTHCHECK 에 쓰면 메일 없이는 절대 healthy 가 못 된다")
-                .isNotEqualTo(HttpStatus.OK);
-    }
+    /*
+     * 여기 있던 "전체 health 는 메일 때문에 DOWN 이다" 테스트를 지웠다.
+     * #55 에서 이메일 인증을 끄면서 메일 헬스 인디케이터도 함께 꺼졌고,
+     * 그 전제가 사라졌다. 조건이 없어졌는데 테스트만 남겨두면
+     * "무엇을 지키는 테스트인가" 를 아무도 답할 수 없게 된다.
+     *
+     * readiness 를 따로 두는 이유 자체는 그대로다 - 전체 health 는 diskSpace 처럼
+     * "죽어도 트래픽은 받을 수 있는" 것까지 본다. 그 구분은 아래 설정 테스트가 지킨다.
+     */
 
     /**
      * 응답 본문으로는 확인할 수 없다. {@code show-details: when-authorized} 라


### PR DESCRIPTION
Closes #55

SMTP 계정을 유지할 이유가 없고, **이것 때문에 컨테이너가 unhealthy** 였습니다(#53).
#53 이 증상을 막았다면 이건 **원인을 없앱니다.**

## 끌 수 있는 상태였습니다 — 먼저 확인했습니다

| 확인 | 결과 |
|---|---|
| 회원가입이 이메일 인증을 요구하나 | **아니다.** `MemberService` 는 `AuthCodeService` 를 참조하지 않는다 |
| email 패키지 밖에서 쓰는 곳 | **없다** |
| 테스트 의존 | **없다** |

이메일 인증은 **프론트가 회원가입 전에 부르는 독립 기능**이고 백엔드가 강제하지 않습니다.
그래서 끄는 것이 다른 흐름을 건드리지 않습니다.

## 지우지 않고 플래그로 껐습니다

```yaml
edumeet:
  email:
    enabled: ${EMAIL_ENABLED:false}
```

> 지우면 되살릴 때 다시 짜야 하고, **"왜 껐는가" 라는 판단도 같이 사라집니다.**
> 플래그면 환경변수 하나로 돌아옵니다.

`@ConditionalOnProperty` 로 **빈 자체가 등록되지 않게** 했습니다.
빈만 두고 호출을 막으면 *"왜 안 되는지"* 가 런타임에만 드러납니다.

`SecurityConfig` 의 permitAll 규칙은 **남겼습니다.**
되살릴 때 그것까지 기억해야 하면 또 막힙니다.

## 테스트 하나를 지웠습니다

`readiness` 테스트 중 *"전체 health 는 메일 때문에 DOWN"* 을 확인하던 것이 있었는데,
메일 헬스를 끄면서 **그 전제가 사라졌습니다.**

> 조건이 없어졌는데 테스트만 남겨두면 **"무엇을 지키는 테스트인가" 를 아무도 답할 수 없게 됩니다.**
> 지운 자리에 이유를 주석으로 남겼습니다.

```
테스트 212개 통과
```

관련: #53