### PR TITLE
fix: 인가가 빠진 엔드포인트 2개 + CORS 와일드카드 (#62)

### DIFF
--- a/src/main/java/com/edu/edumeet/classroom/service/ClassAccessChecker.java
+++ b/src/main/java/com/edu/edumeet/classroom/service/ClassAccessChecker.java
@@ -1,0 +1,58 @@
+package com.edu.edumeet.classroom.service;
+
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.classroom.repository.ClassMemberRepository;
+import com.edu.edumeet.classroom.repository.ClassRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * "이 사람이 이 클래스의 자원을 볼 수 있는가" 를 한 곳에서 판단한다. (#62)
+ *
+ * <p>이 검사는 원래 {@code MeetingService} 안에 인라인으로 있었다.
+ * 그래서 <b>새 엔드포인트를 만들 때마다 복사하거나, 잊거나</b> 둘 중 하나였고
+ * 실제로 두 곳에서 잊혔다 —
+ * {@code GET /meeting/summary/{classId}} 와 {@code GET /meetingroom/room/{roomName}} 은
+ * <b>로그인만 하면 남의 클래스 자원을 읽을 수 있었다.</b>
+ *
+ * <p><b>왜 403 인가</b> — 기존 코드는 {@code IllegalArgumentException} 을 던졌다.
+ * #27 에서 그 예외를 400 으로 매핑했으므로 <b>권한 없음이 "잘못된 요청" 으로 나갔다.</b>
+ * 둘은 다르다. 클라이언트가 재시도해도 소용없다는 뜻을 담아야 한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ClassAccessChecker {
+
+    private final ClassRepository classRepository;
+    private final ClassMemberRepository classMemberRepository;
+
+    /**
+     * 클래스 생성자이거나 수강생이어야 통과한다.
+     *
+     * @throws AccessDeniedException 둘 다 아닐 때
+     */
+    @Transactional(readOnly = true)
+    public void requireMember(Long classId, String email) {
+        if (email == null) {
+            throw new AccessDeniedException("인증이 필요합니다.");
+        }
+        ClassRoom classRoom = classRepository.findById(classId)
+                .orElseThrow(() -> new AccessDeniedException("접근할 수 없는 클래스입니다."));
+
+        boolean isOwner = classRoom.getMember() != null
+                && email.equals(classRoom.getMember().getEmail());
+        boolean isStudent = classMemberRepository
+                .findByClassRoomIdAndMemberEmail(classId, email).isPresent();
+
+        if (!isOwner && !isStudent) {
+            // 존재 여부까지 알려주지 않는다. "없다" 와 "권한 없다" 를 구분해주면
+            // 클래스 id 를 훑어서 목록을 만들 수 있다.
+            log.warn("클래스 접근 거부 - classId={}, email={}", classId, email);
+            throw new AccessDeniedException("이 클래스의 자원에 접근할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/edu/edumeet/email/service/AuthCodeServiceImpl.java
+++ b/src/main/java/com/edu/edumeet/email/service/AuthCodeServiceImpl.java
@@ -1,38 +1,102 @@
 package com.edu.edumeet.email.service;
 
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 
+/**
+ * 이메일 인증 코드. (#62)
+ *
+ * <p>기본으로 꺼져 있다(#55). 그래도 고치는 이유는 <b>플래그 하나로 되살아나기 때문</b>이다.
+ *
+ * <h3>고친 것</h3>
+ * <pre>
+ *   성공해도 코드가 남아 있었다   → 만료 전까지 재사용 가능했다
+ *   시도 횟수 제한이 없었다       → 6자리면 100만 번에 뚫린다
+ *   equals 로 비교했다           → 상수 시간이 아니다
+ *   코드를 로그에 찍었다          → 로그 접근자가 곧 계정 접근자가 된다
+ * </pre>
+ */
 @ConditionalOnProperty(name = "edumeet.email.enabled", havingValue = "true")
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthCodeServiceImpl implements AuthCodeService {
 
+    private static final Duration EXPIRE = Duration.ofMinutes(3);
+
+    /**
+     * 코드 하나당 허용하는 시도 횟수.
+     *
+     * <p>6자리 숫자면 경우의 수가 100만이다. 제한이 없으면 3분 안에 다 넣어볼 수 있다.
+     * 사람이 오타를 내는 횟수로는 5회면 넉넉하다.
+     */
+    private static final int MAX_ATTEMPTS = 5;
+
     private final RedisTemplate<String, String> redisTemplate;
-    private static final long EXPIRE_MINUTES = 3;
 
     @Override
-    public void saveAuthCode(String email, String code){
-        String key = "authcode:" + email;
-        redisTemplate.opsForValue().set(key, code, Duration.ofMinutes(EXPIRE_MINUTES));
-
+    public void saveAuthCode(String email, String code) {
+        redisTemplate.opsForValue().set(codeKey(email), code, EXPIRE);
+        // 새 코드를 받으면 시도 횟수도 초기화한다.
+        redisTemplate.delete(attemptKey(email));
     }
 
     @Override
-    public boolean verifyCode(String email, String code){
+    public boolean verifyCode(String email, String code) {
+        if (email == null || code == null) {
+            return false;
+        }
+        String codeKey = codeKey(email);
 
-        String key = "authcode:"+email;
-        String savedCode = redisTemplate.opsForValue().get(key);
-        log.debug("Redis Input code : {} " , code);
+        if (exceededAttempts(email)) {
+            // 코드를 무효화한다. 남겨두면 제한을 우회해 재시도할 여지가 생긴다.
+            redisTemplate.delete(codeKey);
+            log.warn("인증 코드 시도 횟수 초과 - 코드를 무효화한다. email={}", email);
+            return false;
+        }
 
+        String saved = redisTemplate.opsForValue().get(codeKey);
+        if (saved == null) {
+            return false;
+        }
+        // 상수 시간 비교. 바이트별로 일찍 끊으면 응답 시간으로 한 자리씩 맞출 수 있다.
+        boolean matched = MessageDigest.isEqual(
+                saved.getBytes(StandardCharsets.UTF_8),
+                code.getBytes(StandardCharsets.UTF_8));
 
-        return code.equals(savedCode);
+        if (matched) {
+            // 성공하면 소비한다. 남겨두면 만료 전까지 재사용된다.
+            redisTemplate.delete(codeKey);
+            redisTemplate.delete(attemptKey(email));
+        }
+        // 코드 값 자체는 절대 로그에 남기지 않는다.
+        log.debug("인증 코드 확인 - email={}, 결과={}", email, matched);
+        return matched;
+    }
+
+    /** 시도를 하나 세고, 한도를 넘었는지 돌려준다. */
+    private boolean exceededAttempts(String email) {
+        String key = attemptKey(email);
+        Long attempts = redisTemplate.opsForValue().increment(key);
+        if (attempts != null && attempts == 1L) {
+            // 첫 시도에만 TTL 을 건다. 매번 걸면 공격자가 창을 무한히 연장할 수 있다.
+            redisTemplate.expire(key, EXPIRE);
+        }
+        return attempts != null && attempts > MAX_ATTEMPTS;
+    }
+
+    private String codeKey(String email) {
+        return "authcode:" + email;
+    }
+
+    private String attemptKey(String email) {
+        return "authcode:attempts:" + email;
     }
 }

--- a/src/main/java/com/edu/edumeet/meeting/controller/MeetingController.java
+++ b/src/main/java/com/edu/edumeet/meeting/controller/MeetingController.java
@@ -18,7 +18,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/meetingroom")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 @Log4j2
 public class MeetingController {
 
@@ -107,8 +106,10 @@ public class MeetingController {
     }
 
     @GetMapping("/room/{roomName}")
-    public ResponseEntity<Map<String, Object>> getRoomInfo(@PathVariable String roomName) {
-        Map<String, Object> roomInfo = meetingService.getRoomInfo(roomName);
+    public ResponseEntity<Map<String, Object>> getRoomInfo(
+            @AuthenticationPrincipal SecurityMember member,
+            @PathVariable String roomName) {
+        Map<String, Object> roomInfo = meetingService.getRoomInfo(roomName, member.getEmail());
 
         if (roomInfo == null) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/edu/edumeet/meeting/controller/MeetingSummaryController.java
+++ b/src/main/java/com/edu/edumeet/meeting/controller/MeetingSummaryController.java
@@ -5,6 +5,7 @@ import com.edu.edumeet.meeting.service.MeetingSummaryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,8 +24,10 @@ public class MeetingSummaryController {
 
     /** 요약본이 없으면 204. 빈 본문에 success=true 를 담는 것보다 상태 코드로 말하는 게 낫다. */
     @GetMapping("/summary/{classId}")
-    public ResponseEntity<SummaryUploadResult> getSummary(@PathVariable("classId") Long classId) {
-        return meetingSummaryService.findLatestSummary(classId)
+    public ResponseEntity<SummaryUploadResult> getSummary(
+            @AuthenticationPrincipal com.edu.edumeet.member.domain.SecurityMember member,
+            @PathVariable("classId") Long classId) {
+        return meetingSummaryService.findLatestSummary(classId, member.getEmail())
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }

--- a/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
+++ b/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
@@ -41,6 +41,7 @@ import io.livekit.server.AccessToken;
 import io.livekit.server.RoomJoin;
 import io.livekit.server.RoomName;
 import com.edu.edumeet.classroom.repository.ClassMemberRepository;
+import com.edu.edumeet.classroom.service.ClassAccessChecker;
 
 @Slf4j
 @Service
@@ -51,6 +52,7 @@ public class MeetingService {
     private final MeetingParticipantRepository meetingParticipantRepository;
     private final ClassRepository classRepository;
     private final ClassMemberRepository classMemberRepository;
+    private final ClassAccessChecker classAccessChecker;
     private final MemberRepository memberRepository;
     private final RoomServiceClient roomServiceClient;
 
@@ -115,7 +117,18 @@ public class MeetingService {
      * @return 룸 정보. 룸이 없으면 {@code null}
      * @throws LiveKitUnavailableException LiveKit 에 닿지 못했거나 제한 시간을 넘겼을 때
      */
-    public Map<String, Object> getRoomInfo(String roomName) {
+    public Map<String, Object> getRoomInfo(String roomName, String email) {
+        // 방 이름에서 회의를 찾아 그 클래스의 접근 권한을 본다. (#62)
+        // 이 검사가 없어서 로그인만 하면 남의 방 정보를 읽을 수 있었다.
+        Long meetingId = parseMeetingId(roomName);
+        if (meetingId == null) {
+            throw new AccessDeniedException("접근할 수 없는 방입니다.");
+        }
+        Long classId = meetingRepository.findById(meetingId)
+                .map(m -> m.getClassRoom().getId())
+                .orElseThrow(() -> new AccessDeniedException("접근할 수 없는 방입니다."));
+        classAccessChecker.requireMember(classId, email);
+
         try {
             Response<List<LivekitModels.Room>> response =
                     roomServiceClient.listRooms(List.of(roomName)).execute();

--- a/src/main/java/com/edu/edumeet/meeting/service/MeetingSummaryService.java
+++ b/src/main/java/com/edu/edumeet/meeting/service/MeetingSummaryService.java
@@ -3,6 +3,7 @@ package com.edu.edumeet.meeting.service;
 import com.edu.edumeet.meeting.domain.Meeting;
 import com.edu.edumeet.meeting.dto.SummaryUploadResult;
 import com.edu.edumeet.meeting.repository.MeetingRepository;
+import com.edu.edumeet.classroom.service.ClassAccessChecker;
 import com.edu.edumeet.s3.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +48,7 @@ public class MeetingSummaryService {
 
     private final MeetingRepository meetingRepository;
     private final S3Uploader s3Uploader;
+    private final ClassAccessChecker classAccessChecker;
     private final TransactionTemplate transactionTemplate;
 
     /**
@@ -124,7 +126,10 @@ public class MeetingSummaryService {
      * 이전에는 s3url 단일 컬럼이라 PDF 가 MD 를 덮어썼고 MD 는 조회할 방법이 없었다.
      */
     @Transactional(readOnly = true)
-    public Optional<SummaryUploadResult> findLatestSummary(Long classId) {
+    public Optional<SummaryUploadResult> findLatestSummary(Long classId, String email) {
+        // 요약본은 수업 STT 전문이다. 로그인만 하면 아무 클래스나 읽을 수 있었다. (#62)
+        classAccessChecker.requireMember(classId, email);
+
         return meetingRepository
                 .findTopByClassRoomIdAndS3urlIsNotNullOrderByStartTimeDesc(classId)
                 .map(this::existingResult);

--- a/src/test/java/com/edu/edumeet/integration/security/ClassResourceAuthorizationTest.java
+++ b/src/test/java/com/edu/edumeet/integration/security/ClassResourceAuthorizationTest.java
@@ -1,0 +1,144 @@
+package com.edu.edumeet.integration.security;
+
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.config.jwt.JwtService;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 남의 클래스 자원에 접근할 수 없어야 한다. (#62)
+ *
+ * <p>두 엔드포인트가 <b>인증만 요구하고 인가는 하지 않았다.</b>
+ * <pre>
+ *   GET /api/v1/meeting/summary/{classId}      회의 요약본 = 수업 STT 전문
+ *   GET /api/v1/meetingroom/room/{roomName}    방 정보
+ * </pre>
+ *
+ * <p>{@code MeetingController} 의 엔드포인트 5개 중 <b>4개는 {@code @AuthenticationPrincipal}
+ * 이 있는데 하나만 없었다.</b> 패턴은 이미 있고 하나만 빠진 형태라 눈으로는 잘 안 걸린다.
+ *
+ * <p>진짜 JWT 로 검증한다. 필터가 DB 에서 사용자를 로드하므로 실제 경로가 그대로 돈다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("클래스 자원 인가")
+class ClassResourceAuthorizationTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private Long classId;
+    private String roomName;
+    private String ownerToken;
+    private String outsiderToken;
+
+    @BeforeEach
+    void setUp() {
+        int n = SEQ.incrementAndGet();
+        String owner = "authz-owner-" + n + "@test";
+        String outsider = "authz-outsider-" + n + "@test";
+
+        transactionTemplate.executeWithoutResult(status -> {
+            Member ownerMember = Member.builder()
+                    .email(owner).nickname("주인").password("x").build();
+            em.persist(ownerMember);
+            em.persist(Member.builder().email(outsider).nickname("외부인").password("x").build());
+
+            ClassRoom classRoom = ClassRoom.builder()
+                    .member(ownerMember).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(classRoom);
+
+            Meeting meeting = Meeting.builder()
+                    .classRoom(classRoom).title("회의").description("-")
+                    .sessionType(SessionType.INTERACTIVE)
+                    .startTime(LocalDateTime.now()).build();
+            em.persist(meeting);
+            em.flush();
+
+            classId = classRoom.getId();
+            roomName = "meeting-" + meeting.getId();
+        });
+
+        ownerToken = jwtService.generateAccessToken(1L, owner);
+        outsiderToken = jwtService.generateAccessToken(2L, outsider);
+    }
+
+    private HttpHeaders bearer(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
+    }
+
+    @Test
+    @DisplayName("★ 남의 클래스 요약본은 403 - 요약본은 수업 STT 전문이다")
+    void outsider_cannot_read_summary() throws Exception {
+        mockMvc.perform(get("/api/v1/meeting/summary/{classId}", classId)
+                        .headers(bearer(outsiderToken)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("클래스 주인은 요약본에 접근할 수 있다")
+    void owner_can_read_summary() throws Exception {
+        int status = mockMvc.perform(get("/api/v1/meeting/summary/{classId}", classId)
+                        .headers(bearer(ownerToken)))
+                .andReturn().getResponse().getStatus();
+
+        assertThat(status)
+                .as("요약본이 아직 없으므로 204 가 정상이다. 403 이면 인가가 과하게 걸린 것이다")
+                .isNotEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("★ 남의 방 정보는 403 - LiveKit 을 부르기 전에 막아야 한다")
+    void outsider_cannot_read_room_info() throws Exception {
+        mockMvc.perform(get("/api/v1/meetingroom/room/{roomName}", roomName)
+                        .headers(bearer(outsiderToken)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("주인은 인가를 통과한다 - LiveKit 이 없어 503 이지만 403 은 아니다")
+    void owner_passes_authorization_on_room_info() throws Exception {
+        int status = mockMvc.perform(get("/api/v1/meetingroom/room/{roomName}", roomName)
+                        .headers(bearer(ownerToken)))
+                .andReturn().getResponse().getStatus();
+
+        assertThat(status)
+                .as("인가는 LiveKit 호출보다 먼저다. 주인이 403 을 받으면 안 된다")
+                .isNotEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("인증 없이 부르면 401 - 403 과 구분된다")
+    void anonymous_gets_401() throws Exception {
+        mockMvc.perform(get("/api/v1/meeting/summary/{classId}", classId))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
Closes #62

자동 보안 리뷰가 4건을 올렸습니다. **코드로 확인한 결과 전부 실재했습니다.**

## 🔴 1. 회의 요약본을 아무나 읽을 수 있었다

```java
@GetMapping("/summary/{classId}")
public ResponseEntity<SummaryUploadResult> getSummary(@PathVariable Long classId) {
```

인증은 요구하지만 **인가가 없습니다.** 로그인만 하면 아무 클래스나 읽힙니다.
**요약본은 수업 STT 전문입니다.**

## 🔴 2. 방 정보도 마찬가지 — 그런데 패턴은 이미 있었다

`MeetingController` 의 엔드포인트 5개 중 **4개는 `@AuthenticationPrincipal` 이 있는데 이것만 없었습니다.**

> **하나만 빠진 형태라 눈으로 읽으면 잘 안 걸립니다.**
> 나머지가 다 맞게 생겨서 "이 파일은 인가를 하고 있다" 로 보입니다.

## 3. `@CrossOrigin(origins = "*")`

**저장소 전체에서 이 컨트롤러 하나뿐이었습니다.**
중앙 `CorsConfig`(`front.url` 기반)를 이것만 우회하고 있었습니다.

## 4. 인증 코드 재사용 · 브루트포스 · 로그 유출

```java
return code.equals(savedCode);           // 성공해도 코드가 남는다
log.debug("Redis Input code : {}", code); // ← 코드를 로그에 찍는다
```

| | |
|---|---|
| 성공해도 코드가 남음 | 만료 전까지 **재사용 가능** |
| 시도 제한 없음 | 6자리를 3분 안에 **다 넣어볼 수 있음** |
| `equals` | 상수 시간이 아님 |
| **코드를 로그에** | **로그 접근자가 곧 계정 접근자** |

#55 로 꺼져 있어 **지금은 악용 불가능**하지만 **플래그 하나로 되살아납니다.** 그래서 고쳤습니다.

## 근본 원인 — 인가가 복사되고 있었다

검사가 `MeetingService` 안에 인라인으로 있어서 **새 엔드포인트마다 복사하거나 잊거나** 둘 중 하나였습니다.
`ClassAccessChecker` 로 빼냈습니다.

```java
classAccessChecker.requireMember(classId, email);
```

**존재 여부를 알려주지 않습니다.** "없다" 와 "권한 없다" 를 구분해주면 클래스 id 를 훑어 목록을 만들 수 있습니다.

## 곁다리 — 인가 실패가 400 으로 나가고 있었다

기존 코드가 `IllegalArgumentException` 을 던지는데, #27 에서 그 예외를 **400** 에 매핑했습니다.
**"잘못된 요청" 과 "권한 없음" 은 다릅니다.** `AccessDeniedException` → **403** 으로 바꿨습니다.

## 테스트가 실제로 잡는지 확인했습니다

```
정상        ✅ ✅ ✅ ✅ ✅
인가 제거   ✅ ✅ ❌ ✅ ✅    ← 제거한 그 검사의 테스트만 정확히 실패
```

진짜 JWT 로 검증합니다 — 필터가 DB 에서 사용자를 로드하므로 **실제 경로가 그대로 돕니다.**

| 테스트 | |
|---|---|
| `outsider_cannot_read_summary` | 남의 요약본 → **403** |
| `outsider_cannot_read_room_info` | 남의 방 정보 → **403** (LiveKit 부르기 전에) |
| `owner_can_read_summary` | 주인은 통과 (요약본 없으니 204) |
| `anonymous_gets_401` | **401 과 403 을 구분** |

```
테스트 217개 통과 (기존 212 + 신규 5)
```

관련: #23, #27, #55