### PR TITLE
feat: 오디오 전용 방송에서 서버가 비디오 발행을 막는다 (#72)

### DIFF
--- a/src/main/java/com/edu/edumeet/meeting/domain/SessionType.java
+++ b/src/main/java/com/edu/edumeet/meeting/domain/SessionType.java
@@ -1,5 +1,7 @@
 package com.edu.edumeet.meeting.domain;
 
+import java.util.List;
+
 /**
  * 세션 형태.
  *
@@ -54,6 +56,28 @@ public enum SessionType {
     /** 비디오 트랙 없이 오디오만 다루는가. */
     public boolean isAudioOnly() {
         return this == AUDIO_BROADCAST;
+    }
+
+    /**
+     * 발행자에게 허용할 미디어 소스. 비어 있으면 <b>제한하지 않는다</b>는 뜻이다. (#72)
+     *
+     * <p>LiveKit 은 토큰에 {@code canPublishSources} 가 없으면 모든 소스를 허용한다.
+     * 그래서 비디오 세션은 의도적으로 비워 둔다 -
+     * <b>여기에 카메라·마이크·화면공유를 나열해 봐야 표현되는 정책이 없다.</b>
+     * 오늘의 소스 목록을 얼려서, LiveKit 이 소스를 추가하면 화상 세션이 조용히 막히게 만들 뿐이다.
+     *
+     * <p>반대로 오디오 방송에는 <b>표현할 정책이 있다.</b> 마이크만이다.
+     * 이 목록은 서명된 JWT 안에 들어가므로 SFU 가 강제한다 -
+     * 클라이언트를 고쳐도, 토큰을 다른 SDK 에 넣어도 비디오는 올라가지 않는다.
+     *
+     * <p><b>왜 서버가 막아야 하는가.</b> 실측한 egress 는 시청자당 1.42 Mbps 였고 비디오 기준이다.
+     * 오디오 전용의 비용 모델은 그 전제 위에 서 있는데,
+     * 전제를 서버가 지키지 않으면 <b>비용 계산이 근거를 잃는다.</b>
+     */
+    public List<String> publishableSources() {
+        // screen_share_audio 는 뺐다. 라디오에서 시스템 오디오(음원 재생)를 허용할지는
+        // 기술 문제가 아니라 저작권·편성 문제라, 필요해지면 그때 정한다.
+        return this == AUDIO_BROADCAST ? List.of("microphone") : List.of();
     }
 
     /**

--- a/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
+++ b/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.livekit.server.AccessToken;
+import io.livekit.server.CanPublishSources;
 import io.livekit.server.RoomJoin;
 import io.livekit.server.RoomName;
 import com.edu.edumeet.classroom.repository.ClassMemberRepository;
@@ -407,10 +408,20 @@ public class MeetingService {
                 new CanPublish(canPublish),
                 new CanSubscribe(true)
         );
+
+        // 오디오 전용 방송에서 비디오를 막는다. (#72)
+        // 이 제한이 없으면 "오디오 전용" 은 클라이언트 UI 관례일 뿐이라,
+        // 수정된 클라이언트나 다른 SDK 가 카메라를 올릴 수 있다.
+        List<String> sources = meeting.getSessionType().publishableSources();
+        if (canPublish && !sources.isEmpty()) {
+            token.addGrants(new CanPublishSources(sources));
+        }
+
         token.setTtl(Duration.ofHours(6).toMillis());
 
-        log.info("입장 토큰 발급 - meetingId={}, type={}, participant={}, canPublish={}",
-                meeting.getId(), meeting.getSessionType(), participantName, canPublish);
+        log.info("입장 토큰 발급 - meetingId={}, type={}, participant={}, canPublish={}, sources={}",
+                meeting.getId(), meeting.getSessionType(), participantName, canPublish,
+                sources.isEmpty() ? "제한없음" : sources);
 
         Map<String, Object> response = new HashMap<>();
         response.put("token", token.toJwt());
@@ -419,6 +430,7 @@ public class MeetingService {
         response.put("participantName", participantName);
         response.put("sessionType", meeting.getSessionType());
         response.put("canPublish", canPublish);
+        response.put("publishableSources", sources);
         return response;
     }
 }

--- a/src/test/java/com/edu/edumeet/integration/meeting/AudioOnlyTokenTest.java
+++ b/src/test/java/com/edu/edumeet/integration/meeting/AudioOnlyTokenTest.java
@@ -1,0 +1,137 @@
+package com.edu.edumeet.integration.meeting;
+
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.meeting.service.MeetingService;
+import com.edu.edumeet.member.domain.Member;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 오디오 전용 방송에서 서버가 비디오 발행을 막는가. (#72)
+ *
+ * <p><b>{@code isAudioOnly()} 는 선언만 되어 있고 프로덕션에서 아무도 쓰지 않았다.</b>
+ * "오디오 전용" 이 클라이언트 UI 관례로만 존재했다는 뜻이다 -
+ * 클라이언트를 고치거나 토큰을 그대로 다른 SDK 에 넣으면 카메라가 올라간다.
+ *
+ * <p><b>왜 중요한가.</b> 측정한 egress 는 시청자당 1.42 Mbps 였고 이건 비디오 기준이다.
+ * 오디오 전용의 비용 모델은 여기서 출발하는데, <b>전제를 서버가 지키지 않으면
+ * 그 비용 계산 자체가 근거를 잃는다.</b>
+ *
+ * <p>토큰(JWT)의 {@code video} 클레임을 직접 열어서 본다.
+ * 서비스가 무엇을 "의도했는지" 가 아니라 <b>SFU 에게 실제로 무엇을 말했는지</b> 를 봐야 한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("오디오 전용 방송은 서버가 비디오 발행을 막는다")
+class AudioOnlyTokenTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired MeetingService meetingService;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private Long givenMeeting(SessionType type) {
+        String email = "audio-" + SEQ.incrementAndGet() + "@test";
+        Long[] id = new Long[1];
+        transactionTemplate.executeWithoutResult(status -> {
+            Member owner = Member.builder().email(email).nickname("호스트").password("x").build();
+            em.persist(owner);
+            ClassRoom classRoom = ClassRoom.builder()
+                    .member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(classRoom);
+            Meeting meeting = Meeting.builder()
+                    .classRoom(classRoom).title("세션 " + type).description("-")
+                    .sessionType(type).startTime(LocalDateTime.now()).build();
+            em.persist(meeting);
+            em.flush();
+            id[0] = meeting.getId();
+        });
+        return id[0];
+    }
+
+    /** JWT 의 payload 를 열어 video 그랜트를 꺼낸다. 서명 검증은 목적이 아니다. */
+    private JsonNode videoGrant(String jwt) throws Exception {
+        String payload = jwt.split("\\.")[1];
+        byte[] decoded = Base64.getUrlDecoder().decode(payload);
+        return MAPPER.readTree(new String(decoded, StandardCharsets.UTF_8)).path("video");
+    }
+
+    private JsonNode hostGrantFor(SessionType type) throws Exception {
+        Long meetingId = givenMeeting(type);
+        Map<String, Object> result =
+                meetingService.joinSession(meetingId, "audio-host-" + SEQ.incrementAndGet() + "@test", true);
+        return videoGrant((String) result.get("token"));
+    }
+
+    @Test
+    @DisplayName("★ 오디오 방송 호스트 토큰은 마이크만 허용한다 - 카메라·화면공유는 없다")
+    void audio_broadcast_host_can_publish_microphone_only() throws Exception {
+        JsonNode video = hostGrantFor(SessionType.AUDIO_BROADCAST);
+
+        assertThat(video.path("canPublish").asBoolean())
+                .as("호스트는 발행할 수 있어야 한다. 막으면 방송이 안 된다")
+                .isTrue();
+
+        List<String> sources = MAPPER.convertValue(
+                video.path("canPublishSources"), MAPPER.getTypeFactory()
+                        .constructCollectionType(List.class, String.class));
+
+        assertThat(sources)
+                .as("오디오 전용인데 소스 제한이 없으면 클라이언트 하나로 비디오가 올라간다")
+                .containsExactly("microphone");
+    }
+
+    /**
+     * <b>클레임이 없는 것이 결정이다.</b>
+     *
+     * <p>LiveKit 은 {@code canPublishSources} 가 없으면 모든 소스를 허용한다.
+     * 비디오 세션에 카메라·마이크·화면공유를 나열해도 표현되는 정책이 없고,
+     * <b>오늘의 소스 목록을 얼려서 LiveKit 이 소스를 추가하면 조용히 막히게 만들 뿐이다.</b>
+     * 이 테스트는 "빠뜨린 것" 과 "일부러 안 넣은 것" 을 구분해 고정한다.
+     */
+    @ParameterizedTest
+    @EnumSource(value = SessionType.class, names = {"INTERACTIVE", "BROADCAST"})
+    @DisplayName("비디오 세션은 소스를 제한하지 않는다 - 클레임이 없는 것이 결정이다")
+    void video_sessions_do_not_restrict_sources(SessionType type) throws Exception {
+        JsonNode video = hostGrantFor(type);
+
+        assertThat(video.path("canPublish").asBoolean()).isTrue();
+        assertThat(video.has("canPublishSources"))
+                .as("%s 에 소스 목록을 박으면 LiveKit 이 소스를 추가할 때 화상 세션이 조용히 막힌다", type)
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("오디오 방송 청취자는 애초에 발행 자체를 못 한다")
+    void audio_broadcast_listener_cannot_publish() throws Exception {
+        Long meetingId = givenMeeting(SessionType.AUDIO_BROADCAST);
+        Map<String, Object> result = meetingService.joinSession(meetingId, "listener@test", false);
+
+        assertThat(videoGrant((String) result.get("token")).path("canPublish").asBoolean()).isFalse();
+        assertThat(result.get("canPublish")).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
Closes #72

## 문제

`isAudioOnly()` 는 **선언만 되어 있고 프로덕션에서 아무도 쓰지 않았다.** 참조가 테스트뿐이었다.

토큰에 `canPublishSources` 클레임이 아예 없었고, LiveKit 은 이 클레임이 없으면 **모든 소스를 허용한다.**
즉 **"오디오 전용" 이 클라이언트 UI 관례로만 존재했다** — 토큰을 다른 SDK 에 넣으면 카메라가 올라간다.

> 이 저장소에서 **"설정이 아무것도 안 하고 있었다"** 는 세 번째다.
> `probes.enabled`, `prometheus.export.enabled`, 그리고 이번 `isAudioOnly()`.

## 왜 서버가 막아야 하나

실측 egress 는 **시청자당 1.42 Mbps**, 비디오 기준이다.
오디오 전용의 비용 모델은 그 전제 위에 서 있다.
**전제를 서버가 지키지 않으면 비용 계산이 근거를 잃는다.**

`canPublishSources` 는 **서명된 JWT 안에 들어가므로 SFU 가 강제한다.** 클라이언트를 고쳐도 못 뚫는다.

## 비디오 세션에는 일부러 넣지 않았다

여기가 이 PR 의 판단이다.

`INTERACTIVE`/`BROADCAST` 에 `["camera","microphone","screen_share"]` 를 나열할 수도 있었다.
**하지 않았다** — 표현되는 정책이 없기 때문이다.
그냥 오늘의 소스 목록을 얼려서, LiveKit 이 소스를 추가하면 **화상 세션이 조용히 막히게** 만들 뿐이다.

제한은 **제한이 의도된 곳에만** 건다.

```java
return this == AUDIO_BROADCAST ? List.of("microphone") : List.of();
```

테스트가 `assertThat(video.has("canPublishSources")).isFalse()` 로
**"빠뜨린 것" 과 "일부러 안 넣은 것" 을 구분해 고정한다.**

## 검증

JWT payload 를 직접 열어 `video` 클레임을 본다.
서비스가 무엇을 **의도했는지**가 아니라 **SFU 에게 실제로 무엇을 말했는지**를 봐야 하기 때문이다.

| 테스트 | 검증 |
|---|---|
| 오디오 방송 호스트 | `canPublish=true`, `canPublishSources=["microphone"]` |
| 비디오 세션 (2개) | 클레임 **부재** — 제한하지 않는 것이 결정 |
| 오디오 방송 청취자 | `canPublish=false` |

고치기 전 실행에서 위 3개가 `canPublishSources` 부재로 실패했다. **테스트에 검출력이 있다.**

## 결과

전체 **250 → 254개** 통과.

## 남긴 결정

`screen_share_audio`(시스템 오디오, 음원 재생)는 뺐다.
라디오에서 허용할지는 **기술 문제가 아니라 저작권·편성 문제**라 필요해지면 그때 정한다.