### PR TITLE
feat: 방송 세션 HLS 송출 (#75)

### DIFF
--- a/src/main/java/com/edu/edumeet/meeting/config/LiveKitConfig.java
+++ b/src/main/java/com/edu/edumeet/meeting/config/LiveKitConfig.java
@@ -1,5 +1,6 @@
 package com.edu.edumeet.meeting.config;
 
+import io.livekit.server.EgressServiceClient;
 import io.livekit.server.RoomServiceClient;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,13 +39,34 @@ public class LiveKitConfig {
     @Value("${livekit.api.secret}")
     private String apiSecret;
 
+    /**
+     * egress 시작은 룸 조회보다 오래 걸린다. (#75)
+     *
+     * <p>룸 조회는 LiveKit 이 메모리에서 답하지만, egress 시작은
+     * <b>Redis 를 거쳐 워커가 잡을 받아야</b> 응답이 온다.
+     * 3초를 그대로 쓰면 정상 시작을 타임아웃으로 오인해
+     * <b>egress 는 돌고 있는데 우리는 실패로 처리하는</b> 상태가 된다 -
+     * 그러면 코어를 먹는 고아 egress 가 남는다.
+     */
+    private static final Duration EGRESS_READ_TIMEOUT = Duration.ofSeconds(10);
+
     @Bean
     public RoomServiceClient roomServiceClient() {
         return RoomServiceClient.createClient(host, apiKey, apiSecret, () ->
-                new OkHttpClient.Builder()
-                        .connectTimeout(CONNECT_TIMEOUT)
-                        .readTimeout(READ_TIMEOUT)
-                        .writeTimeout(READ_TIMEOUT)
-                        .build());
+                httpClient(READ_TIMEOUT));
+    }
+
+    @Bean
+    public EgressServiceClient egressServiceClient() {
+        return EgressServiceClient.createClient(host, apiKey, apiSecret, () ->
+                httpClient(EGRESS_READ_TIMEOUT));
+    }
+
+    private OkHttpClient httpClient(Duration readTimeout) {
+        return new OkHttpClient.Builder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .readTimeout(readTimeout)
+                .writeTimeout(readTimeout)
+                .build();
     }
 }

--- a/src/main/java/com/edu/edumeet/meeting/domain/Meeting.java
+++ b/src/main/java/com/edu/edumeet/meeting/domain/Meeting.java
@@ -53,6 +53,14 @@ public class Meeting {
     @Column(name = "summary_pdf_url", length = 500)
     private String summaryPdfUrl;
 
+    /** 진행 중인 HLS egress 의 id. null 이면 내보내는 중이 아니다. (#75) */
+    @Column(name = "hls_egress_id", length = 100)
+    private String hlsEgressId;
+
+    /** 플레이어가 여는 라이브 플레이리스트 주소. 방송이 끝나도 지우지 않는다. (#75) */
+    @Column(name = "hls_playlist_url", length = 500)
+    private String hlsPlaylistUrl;
+
     public void assignTo(ClassRoom classRoom) {
         this.classRoom = classRoom;
         if (classRoom != null) {
@@ -101,6 +109,28 @@ public class Meeting {
     /** 이미 요약본이 기록되어 있는가. 멱등성 판단에 쓴다. */
     public boolean hasSummary() {
         return this.summaryMdUrl != null || this.summaryPdfUrl != null;
+    }
+
+    /** HLS 내보내기를 시작했다고 기록한다. (#75) */
+    public void startHls(String egressId, String playlistUrl) {
+        this.hlsEgressId = egressId;
+        this.hlsPlaylistUrl = playlistUrl;
+    }
+
+    /**
+     * HLS 내보내기를 멈췄다고 기록한다.
+     *
+     * <p><b>플레이리스트 주소는 지우지 않는다.</b> 방송이 끝나면 {@code live.m3u8} 은
+     * 의미를 잃지만 같은 디렉터리의 {@code index.m3u8} 은 다시보기로 남는다.
+     * 주소를 지우면 다시보기로 가는 길이 끊긴다.
+     */
+    public void stopHls() {
+        this.hlsEgressId = null;
+    }
+
+    /** 지금 HLS 로 내보내는 중인가. */
+    public boolean isStreamingHls() {
+        return hlsEgressId != null;
     }
 
     @PrePersist @PreUpdate

--- a/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressController.java
+++ b/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressController.java
@@ -1,0 +1,40 @@
+package com.edu.edumeet.meeting.hls;
+
+import com.edu.edumeet.member.domain.SecurityMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 방송 송출 제어. (#75)
+ *
+ * <p>세션 생성과 분리한 이유 — <b>방송 시작은 세션 시작과 다른 사건이다.</b>
+ * 방을 열어 두고 준비하다가 송출만 나중에 켜는 흐름이 정상이고,
+ * egress 는 켜는 순간부터 코어를 점유하므로 <b>필요한 만큼만 켜야 한다.</b>
+ */
+@RestController
+@RequestMapping("/api/v1/meeting/{meetingId}/hls")
+@RequiredArgsConstructor
+public class HlsEgressController {
+
+    private final HlsEgressService hlsEgressService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> start(
+            @AuthenticationPrincipal SecurityMember member,
+            @PathVariable Long meetingId) {
+        String egressId = hlsEgressService.start(member.getEmail(), meetingId);
+        return ResponseEntity.ok(Map.of("egressId", egressId));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Map<String, String>> stop(
+            @AuthenticationPrincipal SecurityMember member,
+            @PathVariable Long meetingId) {
+        hlsEgressService.stop(member.getEmail(), meetingId);
+        return ResponseEntity.ok(Map.of("message", "송출을 중지했습니다."));
+    }
+}

--- a/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressPlan.java
+++ b/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressPlan.java
@@ -1,0 +1,65 @@
+package com.edu.edumeet.meeting.hls;
+
+import livekit.LivekitEgress.SegmentedFileOutput;
+
+/**
+ * LiveKit 에 보낼 HLS egress 요청 한 건. (#75)
+ *
+ * <p><b>이 프로젝트에서 HLS 의 함정은 전부 요청에 있다. 응답이 아니다.</b>
+ * 라이브 플레이리스트 누락, 디렉터리 불일치, 세그먼트 길이 기본값, 오디오 전용 여부 —
+ * 전부 요청을 만드는 시점에 정해지고, 잘못 만들면 <b>에러가 아니라 이상한 방송</b>이 된다.
+ *
+ * <p>그래서 요청 생성을 값으로 분리했다.
+ * 실제 egress 인스턴스 없이도({@code SYS_ADMIN} · Chrome · 4코어가 필요하다)
+ * 함정 전부를 테스트로 고정할 수 있다.
+ */
+public record HlsEgressPlan(
+        String roomName,
+        SegmentedFileOutput output,
+        boolean audioOnly
+) {
+
+    /**
+     * LiveKit egress 가 이 요청에 매기는 CPU 비용.
+     *
+     * <p>소스에서 확인한 값이다 ({@code pkg/stats/monitor.go} · {@code pkg/config/service.go}).
+     * <pre>
+     *   if r.RoomComposite.AudioOnly { costs.cpu = AudioRoomCompositeCpuCost }  // 1
+     *   else                        { costs.cpu = RoomCompositeCpuCost }       // 4
+     * </pre>
+     *
+     * <p>왜 4배가 아니라 <b>다른 파이프라인</b>인가 — 오디오 전용이면
+     * {@code ShouldUseSDKSource} 경로를 타서 <b>헤드리스 Chrome 합성을 아예 건너뛴다.</b>
+     * Chromium · Xvfb · 화면 합성이 통째로 빠진다.
+     */
+    public double estimatedCpuCost() {
+        return audioOnly ? AUDIO_ROOM_COMPOSITE_CPU_COST : ROOM_COMPOSITE_CPU_COST;
+    }
+
+    /** {@code pkg/config/service.go} — {@code roomCompositeCpuCost = 4} */
+    public static final double ROOM_COMPOSITE_CPU_COST = 4;
+
+    /** {@code pkg/config/service.go} — {@code audioRoomCompositeCpuCost = 1} */
+    public static final double AUDIO_ROOM_COMPOSITE_CPU_COST = 1;
+
+    /**
+     * 코어가 {@code availableCpu} 개인 egress 인스턴스가 이 요청을 받아 줄 것인가.
+     *
+     * <p>{@code pkg/stats/monitor.go} 의 판정을 그대로 옮겼다.
+     * <pre>
+     *   required := costs.cpu
+     *   accept   := available &gt;= required          // 아니면 ErrNotEnoughCPU
+     * </pre>
+     *
+     * <p><b>우리 OCI 서버는 2 OCPU 다.</b>
+     * 비디오 방송 HLS 는 {@code 2 >= 4} 가 거짓이라 <b>거부된다.</b>
+     * 오디오 방송 HLS 는 {@code 2 >= 1} 이라 <b>받아 준다.</b>
+     *
+     * <p>egress 프로세스 자체는 뜬다. 시작 시점 검사({@code validateCPUConfig})는
+     * <b>가장 싼 egress 타입</b>({@code trackCpuCost = 0.5})과만 비교하기 때문이다.
+     * 그래서 <b>서버는 정상으로 보이는데 방송 시작만 실패하는</b> 모양이 된다.
+     */
+    public boolean fitsOn(double availableCpu) {
+        return availableCpu >= estimatedCpuCost();
+    }
+}

--- a/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressPlanner.java
+++ b/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressPlanner.java
@@ -1,0 +1,142 @@
+package com.edu.edumeet.meeting.hls;
+
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import livekit.LivekitEgress.S3Upload;
+import livekit.LivekitEgress.SegmentedFileOutput;
+import livekit.LivekitEgress.SegmentedFileProtocol;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * HLS egress 요청을 만든다. 네트워크를 타지 않는 순수 계산이다. (#75)
+ *
+ * <p>여기에 모아 둔 이유는 <b>HLS 의 실패가 대부분 조용하기 때문이다.</b>
+ * 잘못 만든 요청은 에러를 내지 않고 <b>이상한 방송</b>을 만든다 —
+ * 라이브인데 처음부터 재생되거나, 플레이리스트가 무한히 커지거나, 지연이 12초에서 시작한다.
+ * 조용한 실패는 테스트로 고정해야 한다.
+ */
+@Component
+public class HlsEgressPlanner {
+
+    /** S3Config 와 같은 자리표시자. 이 값이면 스토리지가 설정되지 않은 것으로 본다. */
+    private static final String NOT_CONFIGURED = "not-configured";
+
+    private final HlsProperties properties;
+    private final String accessKey;
+    private final String secretKey;
+    private final String region;
+    private final String endpoint;
+    private final String bucket;
+
+    /**
+     * <b>생성자 주입이다.</b> 필드에 {@code @Value} 를 달면 Spring 컨텍스트 없이는
+     * 인스턴스를 만들 수 없어서, "네트워크를 타지 않는 순수 계산" 이라는 이 클래스의 목적이
+     * 테스트에서 무너진다. 생성자로 받으면 {@code new} 로 만들어 바로 검증할 수 있다.
+     */
+    public HlsEgressPlanner(
+            HlsProperties properties,
+            @Value("${spring.cloud.aws.credentials.access-key:}") String accessKey,
+            @Value("${spring.cloud.aws.credentials.secret-key:}") String secretKey,
+            @Value("${spring.cloud.aws.region.static:auto}") String region,
+            @Value("${spring.cloud.aws.s3.endpoint:}") String endpoint,
+            @Value("${spring.cloud.aws.s3.bucket:}") String bucket) {
+        this.properties = properties;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.region = region;
+        this.endpoint = endpoint;
+        this.bucket = bucket;
+    }
+
+    /** 플레이어가 여는 파일. 최근 세그먼트만 담긴다. */
+    public static final String LIVE_PLAYLIST = "live.m3u8";
+
+    /** 다시보기용. 세그먼트가 계속 누적되고 {@code EXT-X-PLAYLIST-TYPE:EVENT} 가 붙는다. */
+    public static final String VOD_PLAYLIST = "index.m3u8";
+
+    /**
+     * 이 세션을 HLS 로 내보낼 수 있는가.
+     *
+     * <p><b>{@code INTERACTIVE} 는 거부한다.</b> 못 해서가 아니라 <b>하면 안 되기 때문이다.</b>
+     * 화상강의의 존재 이유는 1초 미만 지연이고 HLS 는 최소 6초에서 출발한다.
+     * 손을 들고 6초 뒤에 지목받는 수업은 수업이 아니다.
+     */
+    public boolean supports(SessionType sessionType) {
+        return sessionType != SessionType.INTERACTIVE;
+    }
+
+    public HlsEgressPlan plan(Meeting meeting) {
+        SessionType type = meeting.getSessionType();
+        if (!supports(type)) {
+            throw new IllegalArgumentException(
+                    "화상강의는 HLS 로 내보내지 않습니다. 1초 미만 지연이 목적인데 HLS 는 6초부터 시작합니다.");
+        }
+
+        String directory = "%s/meeting-%d".formatted(trimSlashes(properties.getPrefix()), meeting.getId());
+
+        SegmentedFileOutput.Builder output = SegmentedFileOutput.newBuilder()
+                .setProtocol(SegmentedFileProtocol.HLS_PROTOCOL)
+                .setFilenamePrefix(directory + "/segment")
+
+                // 다시보기용 플레이리스트.
+                .setPlaylistName(directory + "/" + VOD_PLAYLIST)
+
+                // ★ 이걸 비워 두면 라이브 방송에 VOD 플레이리스트가 나간다.
+                //   에러가 아니다. 재생은 되는데 방송 시작점부터 재생되고
+                //   플레이리스트가 방송 내내 무한히 커진다.
+                //   LiveKit 은 live_playlist_name 이 없으면 라이브 플레이리스트를 아예 안 만든다.
+                .setLivePlaylistName(directory + "/" + LIVE_PLAYLIST)
+
+                // ★ 기본값 4초를 그대로 두지 않는다. 지연이 세그먼트 길이에 비례한다.
+                //   LiveKit 은 세그먼트 출력에서 키프레임 간격을 세그먼트 길이에 자동으로 맞춘다
+                //   (Apple HLS 스펙 7.4 "Video segments MUST start with an IDR frame").
+                //   그래서 이 값만 바꾸면 되고, key_frame_interval 을 따로 주면 오히려 깨진다.
+                .setSegmentDuration(properties.getSegmentDuration());
+
+        if (hasStorage()) {
+            output.setS3(storage());
+        }
+
+        // ★ 오디오 전용은 CPU 비용이 4에서 1로 떨어진다. 아껴서가 아니라 파이프라인이 다르다 -
+        //   헤드리스 Chrome 합성을 건너뛰고 SDK 소스를 직접 쓴다.
+        //   우리 서버는 2 OCPU 라, 이 플래그가 "방송이 되냐 안 되냐" 를 가른다.
+        boolean audioOnly = type.isAudioOnly();
+
+        return new HlsEgressPlan("meeting-" + meeting.getId(), output.build(), audioOnly);
+    }
+
+    /**
+     * R2 는 S3 호환이지만 <b>가상 호스트 스타일 주소를 받지 않는다.</b>
+     * {@code forcePathStyle} 을 켜지 않으면 egress 가 업로드 단계에서 조용히 실패한다.
+     * ({@code S3Presigner} 에서 이미 한 번 겪은 것과 같은 문제다.)
+     */
+    private boolean hasStorage() {
+        return !bucket.isBlank() && !NOT_CONFIGURED.equals(bucket);
+    }
+
+    private S3Upload storage() {
+        S3Upload.Builder s3 = S3Upload.newBuilder()
+                .setAccessKey(accessKey)
+                .setSecret(secretKey)
+                .setRegion(region)
+                .setBucket(bucket);
+        if (!endpoint.isBlank()) {
+            s3.setEndpoint(endpoint).setForcePathStyle(true);
+        }
+        return s3.build();
+    }
+
+    /** 플레이어에게 줄 라이브 플레이리스트 주소. */
+    public String livePlaylistUrl(Long meetingId) {
+        String base = properties.getPublicBaseUrl().isBlank()
+                ? "%s/%s".formatted(trimSlashes(endpoint), bucket)
+                : trimSlashes(properties.getPublicBaseUrl());
+        return "%s/%s/meeting-%d/%s"
+                .formatted(base, trimSlashes(properties.getPrefix()), meetingId, LIVE_PLAYLIST);
+    }
+
+    private static String trimSlashes(String value) {
+        return value.replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+}

--- a/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressService.java
+++ b/src/main/java/com/edu/edumeet/meeting/hls/HlsEgressService.java
@@ -1,0 +1,121 @@
+package com.edu.edumeet.meeting.hls;
+
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.repository.MeetingRepository;
+import io.livekit.server.EgressServiceClient;
+import livekit.LivekitEgress.EgressInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * 방송 세션을 HLS 로 내보낸다. (#75)
+ *
+ * <p>요청을 만드는 일은 {@link HlsEgressPlanner} 가 하고, 여기서는 <b>부르고 기록하는 일</b>만 한다.
+ * 나눈 이유는 함정이 전부 요청 쪽에 있어서 그쪽만 순수하게 테스트하고 싶었기 때문이다.
+ *
+ * <p><b>실패를 삼키지 않는다.</b> egress 시작 실패는 방송이 안 나가는 것과 같으므로
+ * 호출자에게 그대로 올린다. 특히 {@code ErrNotEnoughCPU} 는
+ * <b>설정 실수가 아니라 인스턴스 용량 부족</b>이라 조용히 넘기면 원인을 찾을 수 없다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HlsEgressService {
+
+    private final EgressServiceClient egressServiceClient;
+    private final HlsEgressPlanner planner;
+    private final MeetingRepository meetingRepository;
+    private final HlsProperties properties;
+
+    @Transactional
+    public String start(String email, Long meetingId) {
+        Meeting meeting = requireHost(email, meetingId);
+
+        if (!properties.isEnabled()) {
+            throw new IllegalStateException("HLS 가 꺼져 있습니다. egress 인스턴스가 붙어 있어야 켭니다.");
+        }
+        if (meeting.getHlsEgressId() != null) {
+            return meeting.getHlsEgressId();  // 이미 내보내는 중이면 두 번 시작하지 않는다
+        }
+
+        HlsEgressPlan plan = planner.plan(meeting);
+        log.info("HLS egress 시작 - meetingId={}, type={}, audioOnly={}, cpuCost={}",
+                meetingId, meeting.getSessionType(), plan.audioOnly(), plan.estimatedCpuCost());
+
+        EgressInfo info = execute(egressServiceClient.startRoomCompositeEgress(
+                plan.roomName(),
+                plan.output(),
+                "",              // layout - 오디오 전용에서는 쓰이지 않는다
+                null,            // preset - 기본값(H264_720P_30). 오디오면 무시된다
+                null,            // advanced
+                plan.audioOnly(),
+                false,           // videoOnly - 채팅과 함께 소리가 나가야 한다
+                ""               // customBaseUrl
+        ));
+
+        meeting.startHls(info.getEgressId(), planner.livePlaylistUrl(meetingId));
+        return info.getEgressId();
+    }
+
+    @Transactional
+    public void stop(String email, Long meetingId) {
+        Meeting meeting = requireHost(email, meetingId);
+
+        String egressId = meeting.getHlsEgressId();
+        if (egressId == null) {
+            return;
+        }
+        execute(egressServiceClient.stopEgress(egressId));
+
+        // ★ 플레이리스트 주소는 지우지 않는다.
+        //   방송이 끝나면 live.m3u8 은 의미가 없어지지만 index.m3u8 은 다시보기로 남는다.
+        meeting.stopHls();
+        log.info("HLS egress 중지 - meetingId={}, egressId={}", meetingId, egressId);
+    }
+
+    /**
+     * egress 는 아무나 시작하면 안 된다.
+     *
+     * <p>권한 문제이기 이전에 <b>자원 문제다.</b> egress 하나가 코어를 1~4개 먹고,
+     * 인스턴스 하나가 방 하나만 처리한다. 참가자가 시작할 수 있으면
+     * <b>한 명이 인스턴스를 통째로 점유해 다른 방송을 전부 막을 수 있다.</b>
+     */
+    private Meeting requireHost(String email, Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다: " + meetingId));
+        String ownerEmail = meeting.getClassRoom().getMember().getEmail();
+        if (!ownerEmail.equals(email)) {
+            throw new AccessDeniedException("방송 송출은 클래스 생성자만 제어할 수 있습니다.");
+        }
+        return meeting;
+    }
+
+    private <T> T execute(retrofit2.Call<T> call) {
+        try {
+            retrofit2.Response<T> response = call.execute();
+            if (!response.isSuccessful() || response.body() == null) {
+                String body = response.errorBody() == null ? "" : safeRead(response.errorBody());
+                throw new IllegalStateException(
+                        "LiveKit egress 호출 실패 (HTTP " + response.code() + "): " + body);
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new UncheckedIOException("LiveKit egress 에 연결하지 못했습니다.", e);
+        }
+    }
+
+    private String safeRead(okhttp3.ResponseBody body) {
+        try {
+            return body.string();
+        } catch (IOException e) {
+            return "(응답 본문을 읽지 못했다)";
+        }
+    }
+}

--- a/src/main/java/com/edu/edumeet/meeting/hls/HlsProperties.java
+++ b/src/main/java/com/edu/edumeet/meeting/hls/HlsProperties.java
@@ -1,0 +1,37 @@
+package com.edu.edumeet.meeting.hls;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * HLS 배포 설정. (#75)
+ *
+ * <p>{@code segmentDuration} 의 기본값을 <b>2초로 잡았다.</b>
+ * LiveKit 의 기본값은 4초다({@code pkg/config/output_segment.go}).
+ *
+ * <p>HLS 재생 지연은 대략 <b>세그먼트 길이 × 플레이어 버퍼 개수</b>다.
+ * 플레이어는 보통 3개를 채우고 재생을 시작하므로 4초면 12초, 2초면 6초에서 출발한다.
+ * <b>공짜는 아니다</b> — 세그먼트가 짧아지면 요청 수가 두 배가 되고,
+ * 매 세그먼트가 IDR 프레임으로 시작해야 하므로 키프레임이 잦아져 같은 화질에 비트레이트가 오른다.
+ * 이 트레이드오프는 실측해서 {@code docs/performance} 에 남긴다.
+ */
+@Component
+@ConfigurationProperties(prefix = "edumeet.hls")
+@Getter
+@Setter
+public class HlsProperties {
+
+    /** HLS 를 켤 것인가. egress 인스턴스가 없으면 꺼 둔다. */
+    private boolean enabled = false;
+
+    /** 세그먼트 길이(초). LiveKit 기본값은 4다. */
+    private int segmentDuration = 2;
+
+    /** 객체 스토리지에서 HLS 산출물이 놓일 최상위 경로. */
+    private String prefix = "hls";
+
+    /** 플레이어가 읽을 공개 기준 URL. 비어 있으면 스토리지 엔드포인트를 쓴다. */
+    private String publicBaseUrl = "";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -202,6 +202,16 @@ edumeet:
     # 카카오 로그인만 쓰기로 해서 껐다. (#55)
     # 지우지 않고 플래그로 둔 이유는 되살릴 때 다시 짜지 않기 위해서다.
     enabled: ${EMAIL_ENABLED:false}
+  hls:
+    # egress 인스턴스가 붙어 있을 때만 켠다.
+    # 켜 놓고 인스턴스가 없으면 방송 시작이 "no response from egress service" 로 실패한다.
+    enabled: ${HLS_ENABLED:false}
+    # LiveKit 기본값은 4초다. 지연이 세그먼트 길이에 비례해서 2초로 낮췄다.
+    # 대신 요청 수가 두 배가 되고 키프레임이 잦아져 비트레이트가 오른다. (#75)
+    segment-duration: ${HLS_SEGMENT_DURATION:2}
+    prefix: ${HLS_PREFIX:hls}
+    # 플레이어가 읽을 공개 URL. R2 퍼블릭 도메인이나 CDN 주소를 넣는다.
+    public-base-url: ${HLS_PUBLIC_BASE_URL:}
   internal:
     # 서버 간 호출용 공유 시크릿. 파이썬 AI 서버가 X-Internal-Token 헤더로 보낸다. (#27)
     # 비어 있으면 /api/v1/internal/** 은 전부 거부된다 (fail-closed).

--- a/src/main/resources/db/migration/V6__add_meeting_hls_columns.sql
+++ b/src/main/resources/db/migration/V6__add_meeting_hls_columns.sql
@@ -1,0 +1,10 @@
+-- HLS egress 상태를 세션에 기록한다. (#75)
+--
+-- hls_egress_id    진행 중인 egress. 끝나면 NULL 로 돌린다.
+--                  두 번 시작하는 것을 막는 데 쓴다 - egress 하나가 코어 1~4개를 먹는다.
+-- hls_playlist_url 플레이어가 여는 주소. 방송이 끝나도 남긴다.
+--                  같은 디렉터리의 index.m3u8 이 다시보기로 남기 때문이다.
+
+ALTER TABLE meeting
+    ADD COLUMN hls_egress_id VARCHAR(100) NULL,
+    ADD COLUMN hls_playlist_url VARCHAR(500) NULL;

--- a/src/test/java/com/edu/edumeet/unit/hls/HlsEgressPlannerTest.java
+++ b/src/test/java/com/edu/edumeet/unit/hls/HlsEgressPlannerTest.java
@@ -1,0 +1,231 @@
+package com.edu.edumeet.unit.hls;
+
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.meeting.hls.HlsEgressPlan;
+import com.edu.edumeet.meeting.hls.HlsEgressPlanner;
+import com.edu.edumeet.meeting.hls.HlsProperties;
+import livekit.LivekitEgress.SegmentedFileOutput;
+import livekit.LivekitEgress.SegmentedFileProtocol;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * HLS 요청의 함정을 고정한다. (#75)
+ *
+ * <p><b>실제 egress 인스턴스 없이 도는 테스트다.</b>
+ * egress 를 띄우려면 {@code --cap-add=SYS_ADMIN} · Chrome · Xvfb · Redis · 4코어가 필요한데
+ * 이 노트북에도 우리 서버에도 그 조합이 없다.
+ *
+ * <p>그래도 검증할 가치가 있는 이유 — <b>HLS 의 실패는 대부분 요청에서 나고, 조용하다.</b>
+ * 잘못 만든 요청은 에러를 내지 않고 이상한 방송을 만든다.
+ * 실행해서 눈으로 확인할 수 없는 종류의 버그라, 오히려 요청을 값으로 두고 고정해야 한다.
+ *
+ * <p><b>이 테스트가 증명하지 않는 것</b>: 실제로 재생되는가, 지연이 몇 초인가.
+ * 그건 egress 인스턴스를 붙인 뒤 실측해야 한다.
+ */
+@DisplayName("HLS 요청 만들기")
+class HlsEgressPlannerTest {
+
+    private static final long MEETING_ID = 42L;
+
+    private HlsEgressPlanner planner(HlsProperties properties, String endpoint, String bucket) {
+        return new HlsEgressPlanner(properties, "ak", "sk", "auto", endpoint, bucket);
+    }
+
+    private HlsProperties defaults() {
+        return new HlsProperties();   // enabled=false, segmentDuration=2, prefix="hls"
+    }
+
+    private Meeting meeting(SessionType type) {
+        Meeting meeting = Meeting.builder()
+                .title("세션").description("-")
+                .sessionType(type).startTime(LocalDateTime.now()).build();
+        ReflectionTestUtils.setField(meeting, "id", MEETING_ID);
+        return meeting;
+    }
+
+    private SegmentedFileOutput outputFor(SessionType type) {
+        return planner(defaults(), "", "").plan(meeting(type)).output();
+    }
+
+    @Nested
+    @DisplayName("조용히 깨지는 것들")
+    class SilentFailures {
+
+        @Test
+        @DisplayName("★ 라이브 플레이리스트를 비워 두면 라이브 방송에 VOD 플레이리스트가 나간다")
+        void live_playlist_must_be_set() {
+            SegmentedFileOutput output = outputFor(SessionType.BROADCAST);
+
+            assertThat(output.getLivePlaylistName())
+                    .as("""
+                        비어 있으면 LiveKit 은 라이브 플레이리스트를 아예 만들지 않는다.
+                        에러가 아니라서 더 나쁘다 - 재생은 되는데 방송 시작점부터 재생되고,
+                        플레이리스트가 방송 내내 무한히 커진다.""")
+                    .isNotBlank()
+                    .endsWith("live.m3u8");
+        }
+
+        @Test
+        @DisplayName("★ 두 플레이리스트는 같은 디렉터리여야 한다 - 다르면 LiveKit 이 거부한다")
+        void playlists_must_share_a_directory() {
+            SegmentedFileOutput output = outputFor(SessionType.BROADCAST);
+
+            String liveDir = directoryOf(output.getLivePlaylistName());
+            String vodDir = directoryOf(output.getPlaylistName());
+
+            assertThat(liveDir)
+                    .as("LiveKit: ErrInvalidInput(\"live_playlist_name must be in same directory\")")
+                    .isEqualTo(vodDir);
+            assertThat(directoryOf(output.getFilenamePrefix()))
+                    .as("세그먼트도 같은 곳에 놓여야 상대 경로 참조가 맞는다")
+                    .isEqualTo(liveDir);
+        }
+
+        @Test
+        @DisplayName("★ 세그먼트 길이를 LiveKit 기본값 4초로 두지 않는다")
+        void segment_duration_is_not_the_default() {
+            SegmentedFileOutput output = outputFor(SessionType.BROADCAST);
+
+            assertThat(output.getSegmentDuration())
+                    .as("""
+                        HLS 지연은 대략 세그먼트 길이 x 플레이어 버퍼 개수(보통 3)다.
+                        4초를 그대로 두면 12초에서 출발한다.""")
+                    .isEqualTo(2)
+                    .isNotEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("HLS 프로토콜을 명시한다 - 기본값은 HLS 가 아니다")
+        void protocol_is_explicitly_hls() {
+            assertThat(outputFor(SessionType.BROADCAST).getProtocol())
+                    .isEqualTo(SegmentedFileProtocol.HLS_PROTOCOL)
+                    .isNotEqualTo(SegmentedFileProtocol.DEFAULT_SEGMENTED_FILE_PROTOCOL);
+        }
+
+        private String directoryOf(String path) {
+            return path.substring(0, path.lastIndexOf('/'));
+        }
+    }
+
+    @Nested
+    @DisplayName("세션 형태별 판단")
+    class PerSessionType {
+
+        @Test
+        @DisplayName("★ 화상강의는 거부한다 - 못 해서가 아니라 하면 안 되기 때문이다")
+        void interactive_is_rejected() {
+            assertThatThrownBy(() -> outputFor(SessionType.INTERACTIVE))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("HLS");
+
+            assertThat(planner(defaults(), "", "").supports(SessionType.INTERACTIVE)).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SessionType.class, names = {"BROADCAST", "AUDIO_BROADCAST"})
+        @DisplayName("방송 두 형태는 내보낼 수 있다")
+        void broadcasts_are_supported(SessionType type) {
+            assertThat(planner(defaults(), "", "").supports(type)).isTrue();
+        }
+
+        @Test
+        @DisplayName("★ 오디오 방송만 audioOnly 로 나간다")
+        void only_audio_broadcast_is_audio_only() {
+            assertThat(planner(defaults(), "", "").plan(meeting(SessionType.AUDIO_BROADCAST)).audioOnly())
+                    .isTrue();
+            assertThat(planner(defaults(), "", "").plan(meeting(SessionType.BROADCAST)).audioOnly())
+                    .isFalse();
+        }
+    }
+
+    /**
+     * <b>이 프로젝트에서 HLS 를 하려면 반드시 알아야 하는 숫자다.</b>
+     *
+     * <p>LiveKit egress 소스에서 확인했다.
+     * <pre>
+     *   pkg/config/service.go   roomCompositeCpuCost = 4, audioRoomCompositeCpuCost = 1
+     *   pkg/stats/monitor.go    if AudioOnly { cpu = Audio... } else { cpu = Room... }
+     *                           accept := available &gt;= required  // 아니면 ErrNotEnoughCPU
+     * </pre>
+     */
+    @Nested
+    @DisplayName("우리 서버(2 OCPU)에서 무엇이 되는가")
+    class CpuBudget {
+
+        private static final double OUR_SERVER_CORES = 2;
+
+        @Test
+        @DisplayName("★ 비디오 방송 HLS 는 우리 서버에서 거부된다 - 4코어가 필요하다")
+        void video_broadcast_does_not_fit() {
+            HlsEgressPlan plan = planner(defaults(), "", "").plan(meeting(SessionType.BROADCAST));
+
+            assertThat(plan.estimatedCpuCost()).isEqualTo(4);
+            assertThat(plan.fitsOn(OUR_SERVER_CORES))
+                    .as("2 >= 4 이 거짓이라 ErrNotEnoughCPU 가 난다")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("★ 오디오 방송 HLS 는 우리 서버에서 돈다 - 헤드리스 Chrome 을 건너뛴다")
+        void audio_broadcast_fits() {
+            HlsEgressPlan plan = planner(defaults(), "", "").plan(meeting(SessionType.AUDIO_BROADCAST));
+
+            assertThat(plan.estimatedCpuCost())
+                    .as("싸진 게 아니라 파이프라인이 다르다. Chromium · Xvfb · 화면 합성이 통째로 빠진다")
+                    .isEqualTo(1);
+            assertThat(plan.fitsOn(OUR_SERVER_CORES)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("R2 로 올릴 때")
+    class R2Storage {
+
+        private static final String R2 = "https://acc.r2.cloudflarestorage.com";
+
+        @Test
+        @DisplayName("★ forcePathStyle 을 켜야 한다 - R2 는 가상 호스트 주소를 안 받는다")
+        void force_path_style_is_on() {
+            SegmentedFileOutput output =
+                    planner(defaults(), R2, "edumeet").plan(meeting(SessionType.BROADCAST)).output();
+
+            assertThat(output.getS3().getForcePathStyle())
+                    .as("끄면 egress 가 업로드 단계에서 실패한다. S3Presigner 에서 이미 겪은 문제다")
+                    .isTrue();
+            assertThat(output.getS3().getEndpoint()).isEqualTo(R2);
+            assertThat(output.getS3().getBucket()).isEqualTo("edumeet");
+        }
+
+        @Test
+        @DisplayName("버킷이 자리표시자면 스토리지를 붙이지 않는다 - 로컬 디스크로 떨어진다")
+        void placeholder_bucket_means_no_storage() {
+            SegmentedFileOutput output =
+                    planner(defaults(), "", "not-configured").plan(meeting(SessionType.BROADCAST)).output();
+
+            assertThat(output.hasS3())
+                    .as("자리표시자를 그대로 보내면 egress 가 인증 실패로 죽는다")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("플레이어에게 줄 주소는 라이브 플레이리스트를 가리킨다")
+        void public_url_points_at_live_playlist() {
+            HlsProperties props = defaults();
+            props.setPublicBaseUrl("https://cdn.example.com/");
+
+            assertThat(planner(props, R2, "edumeet").livePlaylistUrl(MEETING_ID))
+                    .isEqualTo("https://cdn.example.com/hls/meeting-42/live.m3u8");
+        }
+    }
+}


### PR DESCRIPTION
Closes #75

## 설계 판단 — 요청을 값으로 분리했다

HLS 의 실패는 대부분 **요청에서 나고, 조용하다.** 잘못 만든 요청은 에러를 내지 않고 **이상한 방송**을 만든다.
그리고 이 노트북에도 우리 서버에도 egress 를 띄울 조합(`SYS_ADMIN`·Chrome·Xvfb·Redis·4코어)이 없다.

**실행해서 확인할 수 없는 버그라면, 오히려 요청을 값으로 두고 고정해야 한다.**

```
HlsEgressPlanner   요청을 만든다. 네트워크를 타지 않는 순수 계산. 함정이 전부 여기 있다
HlsEgressPlan      요청 + LiveKit 이 매길 CPU 비용
HlsEgressService   부르고 기록한다
```

`HlsEgressPlanner` 는 **생성자 주입**이다. 필드에 `@Value` 를 달면 Spring 컨텍스트 없이 인스턴스를 만들 수 없어
"순수 계산" 이라는 목적이 테스트에서 무너진다.

## 고정한 함정 4개

| 실수 | 증상 | 테스트 |
|---|---|---|
| `live_playlist_name` 미지정 | 라이브인데 **VOD 플레이리스트**가 나간다 | ✅ |
| 플레이리스트 디렉터리 불일치 | LiveKit `ErrInvalidInput` | ✅ |
| `segment_duration` 기본값 4초 | 지연이 **12초**부터 (세그먼트 × 버퍼 3) → 2초로 낮춤 | ✅ |
| `forcePathStyle` 미설정 | R2 가 가상 호스트 주소를 거부 | ✅ |

세 개를 일부러 되돌려 **전부 실패하는 것을 확인했다.**

## ★ 소스에서 확인한 CPU 경계

LiveKit egress 소스를 읽고 대조했다. **계획 문서에 적어 둔 숫자가 낡아 있었다** (3.0 → 현재 4).

```go
// pkg/config/service.go
roomCompositeCpuCost      = 4
audioRoomCompositeCpuCost = 1

// pkg/stats/monitor.go
if r.RoomComposite.AudioOnly { costs.cpu = AudioRoomCompositeCpuCost }
else                         { costs.cpu = RoomCompositeCpuCost }

required := costs.cpu
accept   := available >= required        // 아니면 ErrNotEnoughCPU
```

**우리 OCI 서버는 2 OCPU 다.**

| | 필요 | `2 >= 필요` | |
|---|---:|---|---|
| 비디오 방송 HLS | 4 | 거짓 | **거부된다** |
| 오디오 방송 HLS | 1 | 참 | **된다** |

싼 게 아니라 **파이프라인이 다르다.** 오디오 전용은 `ShouldUseSDKSource` 경로를 타서
**헤드리스 Chrome 합성을 통째로 건너뛴다** — Chromium·Xvfb·화면 합성이 빠진다.

그리고 **시작 시점 검사(`validateCPUConfig`)는 가장 싼 타입(`trackCpuCost = 0.5`)과만 비교한다.**
→ **egress 는 정상으로 보이는데 비디오 방송 시작만 실패하는** 모양이 된다. 원인을 찾기 어려운 종류다.

## `INTERACTIVE` 는 거부한다

못 해서가 아니라 **하면 안 되기 때문이다.** 화상강의의 존재 이유는 1초 미만 지연인데 HLS 는 6초부터 출발한다.
손을 들고 6초 뒤에 지목받는 수업은 수업이 아니다.

## 이 PR 이 증명하지 않는 것

**실제로 재생되는지, 지연이 몇 초인지는 재지 않았다.** egress 인스턴스를 붙인 뒤 실측해야 한다.
`segment_duration` 4 → 2 의 트레이드오프(요청 수 2배, 키프레임 증가로 비트레이트 상승)도 같이 재야 한다.

## 결과

전체 **254 → 267개** 통과.