### PR TITLE
fix: 방송 세션을 만들 수 있게 한다 (#76, #77)

### DIFF
--- a/src/main/java/com/edu/edumeet/meeting/dto/request/MeetingCreateRequestDto.java
+++ b/src/main/java/com/edu/edumeet/meeting/dto/request/MeetingCreateRequestDto.java
@@ -1,6 +1,8 @@
 package com.edu.edumeet.meeting.dto.request;
 
 
+import com.edu.edumeet.meeting.domain.SessionType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +16,20 @@ public class MeetingCreateRequestDto {
     private String title;
     private String description;
     private Long classId;
+
+    /**
+     * 방송 형태. 비워 두면 화상강의다. (#76)
+     *
+     * <p>이 필드가 없어서 <b>API 로 만든 모든 세션이 화상강의였다.</b>
+     * 세션 타입별 정책도, 오디오 방송도, HLS 도 만들어 두고 도달할 수 없었다.
+     *
+     * <p>기본값을 두는 이유는 기존 클라이언트가 이 필드를 보내지 않기 때문이다.
+     * 필수로 만들면 <b>지금 돌고 있는 화상강의가 전부 깨진다.</b>
+     */
+    private SessionType sessionType;
+
+    /** 요청한 형태. 없으면 화상강의로 본다. */
+    public SessionType sessionTypeOrDefault() {
+        return sessionType == null ? SessionType.INTERACTIVE : sessionType;
+    }
 }

--- a/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
+++ b/src/main/java/com/edu/edumeet/meeting/service/MeetingService.java
@@ -18,6 +18,7 @@ import com.edu.edumeet.classroom.repository.ClassRepository;
 import com.edu.edumeet.member.domain.Member;
 import com.edu.edumeet.member.repository.MemberRepository;
 import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
 import com.edu.edumeet.meeting.dto.request.MeetingCreateRequestDto;
 import com.edu.edumeet.meeting.dto.response.ClassMeetingInfoResponseDto;
 import com.edu.edumeet.meeting.dto.response.MeetingCreateResponseDto;
@@ -168,6 +169,23 @@ public class MeetingService {
         return result;
     }
 
+    /**
+     * 세션을 만든다.
+     *
+     * <p><b>{@code @Transactional} 이 없었다.</b> {@code open-in-view: false} 라
+     * 조회한 {@code ClassRoom} 이 준영속 상태로 돌아오고,
+     * 응답을 만들며 {@code classRoom.getMember().getEmail()} 을 부르는 순간
+     * {@code LazyInitializationException} 이 난다.
+     *
+     * <p>왜 지금까지 안 드러났나 — 권한 검사의 {@code getMember().getId()} 는
+     * <b>프록시가 DB 를 타지 않고 답할 수 있어서</b> 그냥 통과한다.
+     * 초기화가 필요한 첫 필드는 응답을 만들 때 나오는 {@code email} 이다.
+     *
+     * <p>더 나쁜 것은 <b>{@code meetingRepository.save()} 가 자기 트랜잭션으로 먼저 커밋된다</b>는 점이다.
+     * 그래서 <b>DB 에는 세션이 생기는데 클라이언트는 500 을 받는다</b> - 아무도 못 쓰는 세션이 쌓인다.
+     * 트랜잭션으로 묶으면 응답을 못 만들 때 세션도 남지 않는다.
+     */
+    @Transactional
     public MeetingCreateResponseDto create(Long memberId, MeetingCreateRequestDto meetingCreateRequestDto) {
         log.info("📝 미팅 생성 시작 - memberId: {}, classId: {}, title: {}", 
                 memberId, meetingCreateRequestDto.getClassId(), meetingCreateRequestDto.getTitle());
@@ -194,15 +212,27 @@ public class MeetingService {
             throw new IllegalArgumentException("해당 클래스의 생성자 또는 참여자가 아닙니다.");
         }
 
+        // ★ 방송은 클래스 생성자만 연다. (#76)
+        //   권한 문제이기 이전에 자원 문제다 - 방송은 egress 인스턴스를 점유하고
+        //   (코어 1~4개, 인스턴스 하나가 방 하나) 클래스를 대표해서 외부로 나간다.
+        //   화상강의는 참가자도 연다. 스터디 모임을 막을 이유가 없다.
+        SessionType sessionType = meetingCreateRequestDto.sessionTypeOrDefault();
+        if (sessionType != SessionType.INTERACTIVE && !isCreator) {
+            throw new AccessDeniedException("방송 세션은 클래스 생성자만 만들 수 있습니다.");
+        }
+
         Meeting meeting = Meeting.builder()
                 .title(meetingCreateRequestDto.getTitle())
                 .description(meetingCreateRequestDto.getDescription())
                 .startTime(LocalDateTime.now())
                 .classRoom(classRoom)
+                // 이 한 줄이 없어서 세션 타입 기능 전체가 도달할 수 없는 코드였다. (#76)
+                .sessionType(sessionType)
                 .build();
 
         meetingRepository.save(meeting);
-        log.info("✅ 미팅 생성 완료 - meetingId: {}, title: {}", meeting.getId(), meeting.getTitle());
+        log.info("✅ 미팅 생성 완료 - meetingId: {}, title: {}, type: {}",
+                meeting.getId(), meeting.getTitle(), meeting.getSessionType());
         
         return MeetingCreateResponseDto.builder()
                 .title(meeting.getTitle())

--- a/src/test/java/com/edu/edumeet/integration/meeting/SessionTypeCreationTest.java
+++ b/src/test/java/com/edu/edumeet/integration/meeting/SessionTypeCreationTest.java
@@ -1,0 +1,176 @@
+package com.edu.edumeet.integration.meeting;
+
+import com.edu.edumeet.classroom.domain.ClassMember;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.classroom.repository.ClassRepository;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.meeting.dto.request.MeetingCreateRequestDto;
+import com.edu.edumeet.meeting.repository.MeetingRepository;
+import com.edu.edumeet.meeting.service.MeetingService;
+import com.edu.edumeet.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 방송 모드 세 개를 실제로 만들 수 있는가. (#76)
+ *
+ * <p><b>만들 수 없었다.</b> {@code MeetingCreateRequestDto} 에 {@code sessionType} 이 없고
+ * {@code Meeting.builder()} 도 그것을 넣지 않아서,
+ * <b>API 로 만든 모든 세션이 필드 기본값인 {@code INTERACTIVE} 였다.</b>
+ *
+ * <p>그래서 아래가 전부 <b>도달할 수 없는 코드</b>였다.
+ * <pre>
+ *   #43  세션 타입별 정원·발행 정책
+ *   #65  오디오 방송 + 자막
+ *   #72  오디오 전용 토큰 강제
+ *   #75  HLS 송출          ← INTERACTIVE 를 거부하므로 절대 실행될 수 없었다
+ * </pre>
+ *
+ * <p>이 저장소에서 <b>"선언은 있는데 아무도 안 쓴다" 의 네 번째</b>이고 제일 크다.
+ * 앞의 셋({@code probes.enabled} · {@code prometheus.export.enabled} · {@code isAudioOnly})은
+ * 기능 하나가 죽어 있었지만, 이건 <b>기능 네 개가 통째로 죽어 있었다.</b>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("방송 모드 세 개를 만들 수 있다")
+class SessionTypeCreationTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @Autowired MeetingService meetingService;
+    @Autowired MeetingRepository meetingRepository;
+    @Autowired ClassRepository classRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private record Fixture(Long ownerId, Long studentId, Long classId) {}
+
+    private Fixture given() {
+        int n = SEQ.incrementAndGet();
+        Long[] ids = new Long[3];
+        transactionTemplate.executeWithoutResult(status -> {
+            Member owner = Member.builder()
+                    .email("owner-" + n + "@test").nickname("강사").password("x").build();
+            Member student = Member.builder()
+                    .email("student-" + n + "@test").nickname("학생").password("x").build();
+            em.persist(owner);
+            em.persist(student);
+            ClassRoom classRoom = ClassRoom.builder()
+                    .member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(classRoom);
+            em.persist(ClassMember.builder().classRoom(classRoom).member(student).build());
+            em.flush();
+            ids[0] = owner.getId();
+            ids[1] = student.getId();
+            ids[2] = classRoom.getId();
+        });
+        return new Fixture(ids[0], ids[1], ids[2]);
+    }
+
+    private MeetingCreateRequestDto request(Long classId, SessionType type) {
+        return MeetingCreateRequestDto.builder()
+                .title("세션 " + SEQ.incrementAndGet())
+                .description("-")
+                .classId(classId)
+                .sessionType(type)
+                .build();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SessionType.class)
+    @DisplayName("★ 세 모드 전부 요청한 대로 만들어진다")
+    void every_mode_is_creatable(SessionType type) {
+        Fixture fixture = given();
+
+        Long meetingId = meetingService.create(fixture.ownerId(), request(fixture.classId(), type))
+                .getMeetingId();
+
+        Meeting saved = meetingRepository.findById(meetingId).orElseThrow();
+        assertThat(saved.getSessionType())
+                .as("요청한 모드가 아니라 %s 로 저장되면, 그 모드의 정책이 전부 죽는다", saved.getSessionType())
+                .isEqualTo(type);
+    }
+
+    @Test
+    @DisplayName("모드를 안 주면 화상강의다 - 기존 클라이언트가 그대로 돈다")
+    void missing_type_defaults_to_interactive() {
+        Fixture fixture = given();
+
+        Long meetingId = meetingService.create(fixture.ownerId(),
+                request(fixture.classId(), null)).getMeetingId();
+
+        assertThat(meetingRepository.findById(meetingId).orElseThrow().getSessionType())
+                .isEqualTo(SessionType.INTERACTIVE);
+    }
+
+    @Test
+    @DisplayName("★ 참가자는 방송을 열 수 없다 - egress 코어를 먹고 클래스를 대표한다")
+    void participant_cannot_open_a_broadcast() {
+        Fixture fixture = given();
+
+        assertThatThrownBy(() -> meetingService.create(
+                fixture.studentId(), request(fixture.classId(), SessionType.BROADCAST)))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThatThrownBy(() -> meetingService.create(
+                fixture.studentId(), request(fixture.classId(), SessionType.AUDIO_BROADCAST)))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    /**
+     * 이 테스트가 없으면 아래 버그가 <b>세션 타입 테스트에 얹혀서 우연히</b>만 잡힌다.
+     * 원인이 다르므로 따로 이름을 붙여 고정한다.
+     */
+    @Test
+    @DisplayName("★ 세션 생성은 한 트랜잭션이다 - 응답에 소유자 이메일이 담긴다")
+    void creation_runs_in_one_transaction() {
+        Fixture fixture = given();
+        long before = meetingRepository.count();
+
+        var response = meetingService.create(fixture.ownerId(),
+                request(fixture.classId(), SessionType.BROADCAST));
+
+        assertThat(response.getEmail())
+                .as("""
+                    @Transactional 이 없으면 여기서 LazyInitializationException 이 난다.
+                    open-in-view=false 라 ClassRoom 이 준영속으로 돌아오고,
+                    권한 검사의 getMember().getId() 는 프록시가 DB 없이 답해서 통과하지만
+                    email 은 초기화가 필요하다.""")
+                .isNotBlank()
+                .startsWith("owner-").endsWith("@test");
+
+        assertThat(meetingRepository.count())
+                .as("""
+                    save() 가 자기 트랜잭션으로 먼저 커밋되면
+                    응답이 터져도 세션은 DB 에 남는다 - 아무도 못 쓰는 세션이 쌓인다.""")
+                .isEqualTo(before + 1);
+    }
+
+    @Test
+    @DisplayName("참가자도 화상강의는 연다 - 스터디 모임을 막을 이유가 없다")
+    void participant_can_still_open_an_interactive_session() {
+        Fixture fixture = given();
+
+        Long meetingId = meetingService.create(
+                fixture.studentId(), request(fixture.classId(), SessionType.INTERACTIVE)).getMeetingId();
+
+        assertThat(meetingRepository.findById(meetingId).orElseThrow().getSessionType())
+                .isEqualTo(SessionType.INTERACTIVE);
+    }
+}


### PR DESCRIPTION
Closes #76
Closes #77

HLS 를 붙이고 나서 **"그럼 방송 세션은 어떻게 만들지?" 를 따라가 보다가** 두 개를 찾았다.

---

## #76 세션 타입이 API 에 없었다

`MeetingCreateRequestDto` 에 `sessionType` 이 없고, `Meeting.builder()` 도 그것을 넣지 않았다.
**API 로 만든 모든 세션이 필드 기본값 `INTERACTIVE` 였다.**

| 이슈 | 기능 | 상태 |
|---|---|---|
| #43 | 세션 타입별 정원·발행 정책 | 도달 불가 |
| #65 | 오디오 방송 + 자막 | 도달 불가 |
| #72 | 오디오 전용 토큰 강제 | 도달 불가 |
| #75 | HLS 송출 | **절대 실행 불가** — `INTERACTIVE` 를 거부하는데 그것뿐이었으니까 |

> 이 저장소에서 **"선언은 있는데 아무도 안 쓴다" 의 네 번째**다.
> 앞의 셋(`probes.enabled` · `prometheus.export.enabled` · `isAudioOnly`)은 **기능 하나**가 죽어 있었지만,
> 이건 **기능 네 개가 통째로** 죽어 있었다.
>
> 공통점이 있다. 넷 다 **테스트는 통과하고 있었다.** 단위로는 맞는데 **연결이 없었다.**

### 방송은 클래스 생성자만 연다

권한 문제이기 이전에 **자원 문제다.** 방송은 egress 인스턴스를 점유하고(코어 1~4개, 인스턴스 하나가 방 하나)
클래스를 대표해서 외부로 나간다. `HlsEgressService.requireHost` 도 이미 클래스 생성자만 허용하고 있었다.

**화상강의는 참가자도 연다.** 스터디 모임을 막을 이유가 없다.

### 기본값을 둔다

`sessionType` 이 없으면 `INTERACTIVE`. 필수로 만들면 **지금 돌고 있는 화상강의가 전부 깨진다.**

---

## #77 세션 생성이 트랜잭션 밖에서 돌고 있었다

`create()` 에 `@Transactional` 이 없다. 클래스 레벨에도 없다. 그리고 `open-in-view: false` 다.

```java
ClassRoom classRoom = classRepository.findById(...)      // 여기서 세션이 닫힌다
boolean isCreator = classRoom.getMember().getId()...     // ← 통과한다
.email(classRoom.getMember().getEmail())                 // ← LazyInitializationException
```

### 왜 지금까지 안 드러났나

**`getMember().getId()` 는 프록시가 DB 를 타지 않고 답한다.** 식별자는 프록시가 이미 갖고 있다.
초기화가 필요한 첫 필드는 **20줄 뒤 응답을 만들 때 나오는 `email`** 이다.

### 더 나쁜 것

`meetingRepository.save()` 는 `SimpleJpaRepository.save` 라 **자기 트랜잭션으로 먼저 커밋된다.**

> **DB 에는 세션이 생기는데 클라이언트는 500 을 받는다.**
> 아무도 존재를 모르는 세션이 계속 쌓인다.

컨트롤러가 `catch (Exception e)` 로 삼키므로 로그에도 원인이 흐리게 남는다.

---

## 검증

`@EnumSource(SessionType.class)` — **모드를 추가하면 이 테스트가 그 모드에 대해서도 돈다.**

| 테스트 | |
|---|---|
| 세 모드 전부 요청한 대로 만들어진다 | ✅ |
| 모드를 안 주면 화상강의 | ✅ |
| 참가자는 방송을 열 수 없다 | ✅ |
| 참가자도 화상강의는 연다 | ✅ |
| 세션 생성은 한 트랜잭션이다 | ✅ |

세 가지를 되돌려 검출력을 확인했다.

| 되돌린 것 | 잡힌 테스트 |
|---|---:|
| `@Transactional` 제거 | 6개 |
| `.sessionType(...)` 제거 | 2개 (`BROADCAST`, `AUDIO_BROADCAST` — `INTERACTIVE` 는 기본값이라 안 잡힌다) |
| 방송 권한 검사 제거 | 1개 |

**`INTERACTIVE` 가 안 잡히는 것이 정확히 이 버그가 숨어 있던 이유다.** 기본값과 같으면 아무도 눈치채지 못한다.

## 결과

전체 **267 → 274개** 통과.