### PR TITLE
docs: 방송 모드 3개 정리 + HLS CPU 비용 정정

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 | 채팅 붕괴 | [`plan/01-chat-breaking-points.md`](plan/01-chat-breaking-points.md) |
 | 오디오 방송 (라디오 + 자막) | [`plan/03-audio-broadcast.md`](plan/03-audio-broadcast.md) |
 | HLS | [`plan/02-hls-optional.md`](plan/02-hls-optional.md) — 선택 |
+| **방송 모드 3개 (공통/분기)** | [`plan/04-three-broadcast-modes.md`](plan/04-three-broadcast-modes.md) |
 
 ---
 
@@ -43,6 +44,35 @@ OCI 의 무료 한도는 타 클라우드의 **50~100배**, 초과 요금은 약
 **같은 부하, 같은 힙.** 소비 속도 하나만 달랐다.
 
 → [`performance/07-chat-unbounded-queue-oom.md`](performance/07-chat-unbounded-queue-oom.md)
+
+### 선언은 있는데 아무도 안 쓴다 — 네 번 만났다
+
+같은 모양의 버그를 네 번 만났다. 넷 다 **테스트를 통과하고 있었고, 아무 효과가 없었다.**
+
+```
+probes.enabled                 배포 헬스체크가 계속 unhealthy
+prometheus.export.enabled      /actuator/prometheus 404. 원인을 세 번 잘못 짚었다
+SessionType.isAudioOnly()      참조가 테스트뿐. "오디오 전용" 이 UI 관례로만 존재
+sessionType 이 요청에 없음      기능 네 개가 통째로 도달 불가
+```
+
+**테스트가 부품을 검증했지, 부품이 연결되어 있는지는 검증하지 않았다.**
+테스트가 픽스처를 직접 만들면, 그 픽스처가 실제로 만들어질 수 있는지는 영원히 안 물어보게 된다.
+
+→ [`ops/07-declared-but-unused.md`](ops/07-declared-but-unused.md)
+
+### 우리 서버는 오디오 HLS 만 돌릴 수 있다 — 소스로 확인했다
+
+```
+roomCompositeCpuCost      = 4     비디오 방송   2 >= 4  거짓 → ErrNotEnoughCPU
+audioRoomCompositeCpuCost = 1     오디오 방송   2 >= 1  참   → 된다
+```
+
+싼 게 아니라 **파이프라인이 다르다.** 오디오 전용은 헤드리스 Chrome 합성을 통째로 건너뛴다.
+그리고 시작 시점 검사는 **가장 싼 타입과만** 비교하므로,
+**egress 는 정상으로 보이는데 비디오 방송 시작만 실패한다.**
+
+→ [`plan/04-three-broadcast-modes.md`](plan/04-three-broadcast-modes.md)
 
 ### 언어를 바꾸지 않는다
 

--- a/docs/ops/07-declared-but-unused.md
+++ b/docs/ops/07-declared-but-unused.md
@@ -1,0 +1,95 @@
+# 선언은 있는데 아무도 안 쓴다 — 네 번
+
+> **이 저장소에서 같은 모양의 버그를 네 번 만났다.**
+> 넷 다 코드에 선언이 있었고, 넷 다 테스트를 통과하고 있었고,
+> 넷 다 **아무 효과가 없었다.**
+
+---
+
+## 네 번
+
+| # | 무엇 | 어떻게 드러났나 |
+|---|---|---|
+| 1 | `management.endpoint.health.probes.enabled` | 배포 헬스체크가 계속 unhealthy. 켜져 있는데 그룹을 안 만들었다 |
+| 2 | `management.prometheus.metrics.export.enabled` | `/actuator/prometheus` 404. **원인을 세 번 잘못 짚었다** |
+| 3 | `SessionType.isAudioOnly()` | 참조가 테스트뿐이었다. "오디오 전용" 이 클라이언트 UI 관례로만 존재 |
+| 4 | `MeetingCreateRequestDto` 에 `sessionType` 부재 | **기능 네 개가 통째로 도달 불가** |
+
+---
+
+## 4번이 제일 컸다
+
+`sessionType` 을 요청에서 받지 않으니 `Meeting.builder()` 도 그것을 넣지 않았고,
+**API 로 만든 모든 세션이 필드 기본값 `INTERACTIVE`** 였다.
+
+```
+#43  세션 타입별 정원·발행 정책    도달 불가
+#65  오디오 방송 + 자막            도달 불가
+#72  오디오 전용 토큰 강제         도달 불가
+#75  HLS 송출                      절대 실행 불가 ← INTERACTIVE 를 거부하는데 그것뿐이었다
+```
+
+**HLS 는 특히 고약하다.** `INTERACTIVE` 를 명시적으로 거부하도록 짜 두었는데,
+만들 수 있는 세션이 `INTERACTIVE` 뿐이었으므로 **이 코드는 어떤 입력으로도 성공할 수 없었다.**
+그런데 단위 테스트는 전부 통과했다 — `BROADCAST` 세션을 **테스트 안에서 직접 만들어** 검증했기 때문이다.
+
+---
+
+## 왜 테스트가 못 잡았나
+
+넷의 공통점이 여기 있다.
+
+> **테스트가 부품을 검증했지, 부품이 연결되어 있는지는 검증하지 않았다.**
+
+```
+✓  SessionType.AUDIO_BROADCAST.isAudioOnly() == true      부품은 맞다
+✗  실제 발급된 토큰에 그 정책이 반영되는가                아무도 안 물었다
+
+✓  BROADCAST 세션의 HLS 요청이 올바르게 만들어지는가      부품은 맞다
+✗  BROADCAST 세션을 만들 수 있는가                        아무도 안 물었다
+```
+
+테스트가 픽스처를 **직접 만들면** 그 픽스처가 실제로 만들어질 수 있는지는 영원히 안 물어보게 된다.
+
+### 그래서 바꾼 것
+
+**"의도" 가 아니라 "실제로 나간 것" 을 본다.**
+
+| 전 | 후 |
+|---|---|
+| `service.canPublish == false` 확인 | **발급된 JWT 를 열어 `video.canPublishSources` 를 본다** |
+| 테스트가 `BROADCAST` 엔티티를 만듦 | **생성 API 로 만들고 저장된 타입을 확인** |
+
+그리고 `@EnumSource(SessionType.class)` 를 썼다.
+**모드를 추가하면 그 모드에 대해서도 테스트가 돈다.** 새 모드가 죽어 있는 것을 잊고 넘어갈 수 없다.
+
+---
+
+## 곁다리로 나온 것 — 실패 지점이 원인에서 20줄 떨어져 있었다
+
+4번을 고치려고 `create()` 를 부르자 `LazyInitializationException` 이 났다.
+`@Transactional` 이 없고 `open-in-view: false` 였다.
+
+```java
+ClassRoom classRoom = classRepository.findById(...)   // 세션이 여기서 닫힌다
+boolean isCreator = classRoom.getMember().getId()...  // ← 통과한다
+.email(classRoom.getMember().getEmail())              // ← 20줄 뒤, 여기서 터진다
+```
+
+**`getId()` 는 프록시가 DB 를 타지 않고 답한다.** 식별자는 프록시가 이미 갖고 있다.
+초기화가 필요한 첫 필드는 응답을 만들 때 나오는 `email` 이다.
+
+그리고 `meetingRepository.save()` 는 `SimpleJpaRepository.save` 라 **자기 트랜잭션으로 먼저 커밋된다.**
+
+> **DB 에는 세션이 생기는데 클라이언트는 500 을 받는다.**
+> 아무도 존재를 모르는 세션이 쌓인다.
+
+---
+
+## 남은 질문
+
+**이 패턴을 다음에는 어떻게 먼저 잡나.**
+
+지금 답은 "통합 지점을 테스트가 지나가게 한다" 정도다.
+정적으로 잡을 방법(예: `@Component` 인데 참조가 테스트뿐인 public 메서드 검출)은 아직 안 만들었다.
+만든다면 그때 이 문서에 이어 적는다.

--- a/docs/plan/02-hls-optional.md
+++ b/docs/plan/02-hls-optional.md
@@ -21,6 +21,17 @@ iMBC 에도 라이브스트리밍 직무가 실재한다. **미디어 업계에�
 단 **미디어 코어(코덱·트랜스코딩)는 C/C++ 트랙**이다. 우리가 하는 것은 **그 위 계층**이고,
 서사도 그렇게 잡는다.
 
+## 진행 상태 (2026-08-23 갱신)
+
+| | |
+|---|---|
+| ✅ | LiveKit Egress HLS 요청 생성 + 함정 4개 테스트로 고정 ([#75](https://github.com/dj258255/edumeet/issues/75)) |
+| ✅ | CPU 경계를 소스에서 확인하고 코드에 상수로 박음 |
+| ✅ | 방송 세션 생성 경로 ([#76](https://github.com/dj258255/edumeet/issues/76)) — **없어서 HLS 가 실행될 수 없었다** |
+| ⬜ | egress 인스턴스 붙여 **실제 재생·지연 실측** |
+| ⬜ | `segment_duration` 4 → 2 트레이드오프 실측 |
+| ⬜ | 라이브 창 5 vs Apple 스펙 8.11(6) 검증 |
+
 ## 최소 범위 — 이것만 한다
 
 ```
@@ -177,17 +188,53 @@ v0.8.2가 고정한 protocol 서브모듈에도 `live_playlist_name`(field 11), 
 
 ## 3d. CPU 비용 — 몇 개까지 띄울 수 있나
 
-공식 config 기본값:
+> **⚠ 아래 숫자는 낡았다.** 처음 조사할 때 참고한 config 예시의 값이고,
+> 구현하면서 소스를 직접 읽어 확인하니 달랐다. **정정된 값은 이 절 아래에 있다.**
 
 ```yaml
-room_composite_cpu_cost:       3.0   # 룸 합성 HLS 1개 = 3코어
+# 낡은 값 (조사 시점)
+room_composite_cpu_cost:       3.0
 web_cpu_cost:                  3.0
 track_composite_cpu_cost:      2.0
 track_cpu_cost:                1.0
 audio_room_composite_cpu_cost: 1.0
 ```
 
-**→ 4코어 인스턴스 = RoomComposite HLS 동시 1개.** ABR 3단이면 Egress 3개 = **9코어**.
+### ★ 정정 — 소스에서 확인한 값 (#75)
+
+```go
+// pkg/config/service.go
+roomCompositeCpuCost      = 4      // 3.0 이 아니다
+audioRoomCompositeCpuCost = 1
+webCpuCost                = 4
+audioWebCpuCost           = 1
+participantCpuCost        = 2
+trackCompositeCpuCost     = 1
+trackCpuCost              = 0.5
+```
+
+**비디오 RoomComposite 는 3코어가 아니라 4코어다.** 우리 서버(2 OCPU)와의 격차가 더 크다.
+
+선택 로직도 확인했다.
+
+```go
+// pkg/stats/monitor.go
+if r.RoomComposite.AudioOnly { costs.cpu = AudioRoomCompositeCpuCost }   // 1
+else                         { costs.cpu = RoomCompositeCpuCost }        // 4
+
+required := costs.cpu
+accept   := available >= required        // 아니면 ErrNotEnoughCPU
+```
+
+| | 필요 | 우리 서버(2) | |
+|---|---:|---|---|
+| 비디오 방송 HLS | 4 | `2 >= 4` 거짓 | **거부** |
+| 오디오 방송 HLS | 1 | `2 >= 1` 참 | **가능** |
+
+**그리고 시작 시점 검사(`validateCPUConfig`)는 가장 싼 타입(`trackCpuCost = 0.5`)과만 비교한다.**
+→ egress 프로세스는 정상으로 뜨는데 **비디오 방송 시작만 실패한다.**
+
+→ 구현과 테스트: [`04-three-broadcast-modes.md`](04-three-broadcast-modes.md)
 
 ## 3e. S3 없이 로컬 디스크로 (가장 싼 경로)
 

--- a/docs/plan/04-three-broadcast-modes.md
+++ b/docs/plan/04-three-broadcast-modes.md
@@ -1,0 +1,153 @@
+# 방송 모드 세 개 — 무엇이 공통이고 무엇이 갈리는가
+
+> 모드는 셋이고 **채팅은 셋 모두의 공통 기능**이다.
+> 이 문서는 무엇을 공통으로 두고 무엇을 갈랐는지, 그리고 그 판단의 근거를 적는다.
+
+```
+INTERACTIVE       화상채팅        WebRTC        1초 미만
+BROADCAST         라이브스트리밍   WebRTC / HLS  수 초
+AUDIO_BROADCAST   오디오스트리밍   WebRTC / HLS  수 초
+```
+
+---
+
+## 1. 공통으로 둔 것 — 채팅
+
+채팅 코드에서 세션 타입으로 갈리는 곳은 **저장 정책 하나뿐**이다.
+
+```java
+// 접근 정책 — 모드 무관. 이 방에 참가했는가만 본다
+MeetingParticipant.findActive(meetingId, email)
+
+// 저장 정책 — 모드별
+sessionType.persistsChatInline()
+```
+
+**이 분리가 핵심이다.** 섞으면 모드가 늘 때마다 접근 로직을 건드리게 된다.
+
+`@EnumSource(SessionType.class)` 로 세 모드 전부에 대해 구독 → 발행 → 수신을 검증한다.
+**모드를 추가하면 이 테스트가 그 모드에 대해서도 돈다.**
+
+> 방송이 발행 경로에서 채팅을 저장하지 않는 이유는 저장을 안 한다는 뜻이 아니다.
+> **발행 경로의 DB 쓰기가 브로드캐스트 측정을 가리기 때문**이고,
+> 다시보기용 비동기 저장은 [#61](https://github.com/dj258255/edumeet/issues/61) 에서 다룬다.
+
+---
+
+## 2. 갈라야 했던 것 — 발행 권한
+
+`CanPublish(true)` 만으로는 **"오디오 전용" 이 클라이언트 UI 관례로만 존재한다.**
+토큰을 다른 SDK 에 넣으면 카메라가 그대로 올라간다.
+
+```java
+// 서명된 JWT 안에 들어가므로 SFU 가 강제한다. 클라이언트를 고쳐도 못 뚫는다
+return this == AUDIO_BROADCAST ? List.of("microphone") : List.of();
+```
+
+### 비디오 세션에는 일부러 넣지 않았다
+
+LiveKit 은 `canPublishSources` 가 없으면 모든 소스를 허용한다.
+`INTERACTIVE` 에 `["camera","microphone","screen_share"]` 를 나열해도 **표현되는 정책이 없고**,
+오늘의 소스 목록을 얼려서 **LiveKit 이 소스를 추가하면 화상 세션이 조용히 막히게** 만들 뿐이다.
+
+**제한은 제한이 의도된 곳에만 건다.** 테스트가 "빠뜨린 것" 과 "일부러 안 넣은 것" 을 구분해 고정한다.
+
+### 왜 서버가 막아야 하나
+
+실측 egress 는 **시청자당 1.42 Mbps**, 비디오 기준이다.
+오디오 전용의 비용 모델은 그 전제 위에 서 있으므로,
+**전제를 서버가 지키지 않으면 비용 계산이 근거를 잃는다.**
+
+---
+
+## 3. ★ 우리 서버에서 무엇이 되는가 — 소스로 확인한 경계
+
+LiveKit egress 소스를 읽고 대조했다. (**계획 문서에 적어 둔 3.0 은 낡은 값이었다. 현재 4다.**)
+
+```go
+// pkg/config/service.go
+roomCompositeCpuCost      = 4
+audioRoomCompositeCpuCost = 1
+
+// pkg/stats/monitor.go
+if r.RoomComposite.AudioOnly { costs.cpu = AudioRoomCompositeCpuCost }
+else                         { costs.cpu = RoomCompositeCpuCost }
+
+required := costs.cpu
+accept   := available >= required      // 아니면 ErrNotEnoughCPU
+```
+
+**우리 OCI 서버는 2 OCPU 다.**
+
+| | 필요 코어 | `2 >= 필요` | |
+|---|---:|---|---|
+| 비디오 방송 HLS | 4 | 거짓 | **거부된다** |
+| 오디오 방송 HLS | 1 | 참 | **된다** |
+
+**싼 게 아니라 파이프라인이 다르다.** 오디오 전용은 `ShouldUseSDKSource` 경로를 타서
+**헤드리스 Chrome 합성을 통째로 건너뛴다** — Chromium · Xvfb · 화면 합성이 빠진다.
+
+### 이 사실의 진짜 함의
+
+시작 시점 검사(`validateCPUConfig`)는 **가장 싼 egress 타입**(`trackCpuCost = 0.5`)과만 비교한다.
+
+> **egress 프로세스는 정상으로 뜬다. 비디오 방송 시작만 실패한다.**
+
+헬스체크는 초록이고 로그도 조용한데 특정 기능만 안 되는, 원인 찾기 어려운 모양이다.
+**그래서 이 숫자를 코드에 상수로 박고 테스트로 고정했다** — 문서에만 적으면 잊는다.
+
+```java
+assertThat(plan.fitsOn(2)).isFalse();   // 비디오 방송은 우리 서버에서 안 된다
+```
+
+---
+
+## 4. HLS 요청의 함정 — 조용히 깨지는 것들
+
+HLS 의 실패는 대부분 **요청에서 나고, 에러를 내지 않는다.**
+
+| 실수 | 증상 |
+|---|---|
+| `live_playlist_name` 미지정 | 라이브인데 **VOD 플레이리스트**가 나간다. 방송 시작점부터 재생되고 플레이리스트가 무한 누적 |
+| 두 플레이리스트가 다른 디렉터리 | LiveKit `ErrInvalidInput` |
+| `segment_duration` 기본값 4초 | 지연이 **12초**부터 (세그먼트 × 플레이어 버퍼 3) |
+| `forcePathStyle` 미설정 | R2 가 가상 호스트 주소를 거부해 업로드 실패 |
+
+egress 인스턴스를 띄우려면 `--cap-add=SYS_ADMIN` · Chrome · Xvfb · Redis · 4코어가 필요하고
+**이 노트북에도 우리 서버에도 없다.**
+
+그래서 **요청 생성을 순수 계산으로 분리**했다.
+실행해서 눈으로 확인할 수 없는 버그라면, 오히려 요청을 값으로 두고 고정해야 한다.
+
+```
+HlsEgressPlanner   요청을 만든다. 네트워크를 타지 않는다. 함정이 전부 여기 있다
+HlsEgressPlan      요청 + LiveKit 이 매길 CPU 비용
+HlsEgressService   부르고 기록한다
+```
+
+---
+
+## 5. `INTERACTIVE` 는 HLS 로 내보내지 않는다
+
+**못 해서가 아니라 하면 안 되기 때문이다.**
+화상강의의 존재 이유는 1초 미만 지연인데 HLS 는 6초부터 출발한다.
+손을 들고 6초 뒤에 지목받는 수업은 수업이 아니다.
+
+---
+
+## 6. 그런데 방송 세션을 만들 수가 없었다
+
+여기까지 만들고 **"그럼 방송 세션은 어떻게 만들지?"** 를 따라가 보니,
+`MeetingCreateRequestDto` 에 `sessionType` 이 없었다. **위의 전부가 도달 불가능한 코드였다.**
+
+→ [`../ops/07-declared-but-unused.md`](../ops/07-declared-but-unused.md)
+
+---
+
+## 아직 안 한 것
+
+- [ ] **실제로 재생되는가, 지연이 몇 초인가** — egress 인스턴스를 붙여야 잰다
+- [ ] `segment_duration` 4 → 2 트레이드오프 실측 (요청 수 2배, 키프레임 증가로 비트레이트 상승)
+- [ ] 라이브 창 5 vs Apple 스펙 8.11(6) 위반 검증
+- [ ] 자막 vs 채팅 부하 특성 비교
+- [ ] 다시보기 채팅 비동기 저장 ([#61](https://github.com/dj258255/edumeet/issues/61))


### PR DESCRIPTION
## 새로 쓴 것

**[`plan/04-three-broadcast-modes.md`](../blob/docs/80-three-modes/docs/plan/04-three-broadcast-modes.md)**
무엇을 공통으로 두고 무엇을 갈랐는지, 그 판단의 근거.

**[`ops/07-declared-but-unused.md`](../blob/docs/80-three-modes/docs/ops/07-declared-but-unused.md)**
같은 모양의 버그를 네 번 만났다. 넷 다 테스트를 통과하고 있었고, 아무 효과가 없었다.

> **테스트가 부품을 검증했지, 부품이 연결되어 있는지는 검증하지 않았다.**
> 테스트가 픽스처를 직접 만들면, 그 픽스처가 실제로 만들어질 수 있는지는 영원히 안 물어보게 된다.

## ★ 정정

`plan/02-hls-optional.md` 에 적어 둔 CPU 비용이 **낡아 있었다.**

| | 문서 | 소스 확인 |
|---|---:|---:|
| `room_composite_cpu_cost` | 3.0 | **4** |
| `track_cpu_cost` | 1.0 | **0.5** |

조사 시점의 config 예시 값이었고, 구현하면서 `pkg/config/service.go` 를 직접 읽어 확인하니 달랐다.
**우리 서버(2 OCPU)와의 격차가 문서보다 크다.**

낡은 값을 지우지 않고 남긴 뒤 정정을 붙였다 — **무엇을 잘못 알고 있었는지가 기록의 일부**라서.

## 링크

깨진 링크 0개.