### PR TITLE
fix: 관측 스택이 배포에서 켜지지 않고 있었다 (#83)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,8 +104,25 @@ jobs:
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
             export APP_IMAGE=ghcr.io/${{ github.repository }}:${{ github.sha }}
-            docker compose -f docker-compose.prod.yml pull app
-            docker compose -f docker-compose.prod.yml up -d
+
+            # ★ --profile observability 를 붙인다. (#83)
+            #   prometheus·grafana 는 profiles: [observability] 라
+            #   프로필 없이 up 하면 "정의는 되어 있는데 뜨지 않는다".
+            #   에러도 경고도 안 난다 - compose 는 프로필이 꺼진 서비스를 조용히 건너뛴다.
+            #   그래서 관측 스택을 만들고 배포까지 하고도 한 번도 켜진 적이 없었다.
+            COMPOSE="docker compose -f docker-compose.prod.yml --profile observability"
+            $COMPOSE pull app
+            $COMPOSE up -d
+
+            # 관측 스택이 실제로 떴는지 확인한다. 프로필을 붙였다는 사실만으로는 모른다.
+            for c in edumeet-prometheus edumeet-grafana; do
+              if [ -z "$(docker ps -q -f name=^${c}$)" ]; then
+                echo "관측 컨테이너가 뜨지 않았다: $c"
+                $COMPOSE logs --tail=50 "${c#edumeet-}"
+                exit 1
+              fi
+            done
+            echo "관측 스택 기동 확인"
 
             # ★ 호스트에서 curl 하지 않는다.
             #   actuator 는 관리 포트(9090)로 옮겨갔고 그 포트는 publish 하지 않는다.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,11 @@ services:
     networks: [edumeet]
 
   app:
-    image: ${APP_IMAGE:-ghcr.io/dj258255/edumeet:latest}
+    # ★ 기본값을 두지 않는다. (#83)
+    #   :latest 로 두면 APP_IMAGE export 를 잊은 채 compose up 을 했을 때
+    #   운영이 핀 태그에서 떠다니는 태그로 조용히 바뀐다. 경고도 없다.
+    #   같은 파일의 GRAFANA_PASSWORD 와 같은 기준으로 맞춘다.
+    image: ${APP_IMAGE:?APP_IMAGE 를 지정해야 한다. 기본값을 :latest 로 두면 export 를 잊었을 때 운영이 조용히 떠다니는 태그로 바뀐다}
     container_name: edumeet-app
     env_file: .env
     restart: unless-stopped

--- a/docs/ops/04-observability.md
+++ b/docs/ops/04-observability.md
@@ -197,8 +197,46 @@ String getClientInboundExecutorStatsInfo()   // "pool size = 8, active threads =
 | 세션 버퍼 / 강제 종료 수 | 느린 클라이언트 (붕괴 ③) — Phase 3 |
 | Redis Pub/Sub 전파 지연 | 다중 인스턴스 (붕괴 ⑤) — Phase 5 |
 
-## 8. 미확인
+## 8. ★ 정정 — 관측 스택이 한 번도 켜진 적이 없었다 (2026-08-24)
+
+OCI 서버에 붙어 컨테이너를 세어 보니 EduMeet 것은 **3개(app·mysql·redis)뿐**이었다.
+`prometheus` 와 `grafana` 는 `docker-compose.prod.yml` 에 **정의되어 있는데 떠 있지 않았다.**
+
+```yaml
+prometheus:
+  profiles: [observability]     # ← 프로필이 켜져야만 뜬다
+grafana:
+  profiles: [observability]
+```
+
+```bash
+docker compose -f docker-compose.prod.yml up -d      # 배포 워크플로가 하던 것
+```
+
+**Compose 는 프로필이 꺼진 서비스를 조용히 건너뛴다.** 에러도 경고도 없다.
+그래서 만들고, 커밋하고, 배포까지 하고도 **한 번도 켜진 적이 없었다.**
+
+막는 것은 없었다. `GRAFANA_PASSWORD` 는 서버 `.env` 에 있고,
+Grafana 가 쓰는 3001 도 Prometheus 의 내부 9090 도 다른 것과 겹치지 않는다.
+**그냥 프로필을 안 붙였을 뿐이다.**
+
+> 이 저장소에서 **"만들었는데 동작하지 않는다" 의 다섯 번째**다.
+> → [`07-declared-but-unused.md`](07-declared-but-unused.md)
+>
+> 앞의 넷은 **설정값**이었는데 이건 **컨테이너 두 개**다.
+> 그리고 아래 9절의 "실제 화면으로 확인하지 않았다" 는 게으름이 아니라
+> **확인할 화면이 없었다**는 뜻이었다. 그때는 그걸 몰랐다.
+
+### 왜 지금 드러났나
+
+부하 측정을 노트북에서 OCI 로 옮기려고 서버 상태를 조사하다가 나왔다.
+**관측이 없으면 부하 측정을 밖에서 눈감고 하는 셈이다** —
+앱 안에서 큐가 쌓이는지, 세션이 끊기는지, GC 가 도는지를 못 본다.
+그래서 측정보다 이것이 먼저다.
+
+## 9. 미확인
 
 - **Grafana 대시보드를 실제 화면으로 확인하지 않았다.** PromQL 이 값을 내는 것까지만 검증했다
+  (8절 참고 — 애초에 떠 있지 않았다)
 - 알림(Alertmanager) 없음. 기준선을 잡기 전에는 임계값을 정할 수 없다
 - Prometheus 보존 15일은 임의값. 디스크 사용량을 보고 조정한다

--- a/docs/ops/07-declared-but-unused.md
+++ b/docs/ops/07-declared-but-unused.md
@@ -14,6 +14,7 @@
 | 2 | `management.prometheus.metrics.export.enabled` | `/actuator/prometheus` 404. **원인을 세 번 잘못 짚었다** |
 | 3 | `SessionType.isAudioOnly()` | 참조가 테스트뿐이었다. "오디오 전용" 이 클라이언트 UI 관례로만 존재 |
 | 4 | `MeetingCreateRequestDto` 에 `sessionType` 부재 | **기능 네 개가 통째로 도달 불가** |
+| 5 | `docker compose up -d` 에 `--profile observability` 부재 | **관측 스택이 한 번도 켜진 적 없음** |
 
 ---
 
@@ -34,6 +35,31 @@
 그런데 단위 테스트는 전부 통과했다 — `BROADCAST` 세션을 **테스트 안에서 직접 만들어** 검증했기 때문이다.
 
 ---
+
+## 5번은 종류가 다르다
+
+앞의 넷은 **코드 안**이라 테스트로 잡을 수 있는 것이었다. 5번은 **배포 스크립트**다.
+
+```yaml
+prometheus:
+  profiles: [observability]     # 프로필이 켜져야만 뜬다
+```
+
+```bash
+docker compose -f docker-compose.prod.yml up -d     # 배포가 하던 것
+```
+
+**Compose 는 프로필이 꺼진 서비스를 조용히 건너뛴다.** 에러도 경고도 없다.
+`docker ps` 를 보지 않는 한 알 방법이 없고, 배포는 초록으로 끝난다.
+
+그래서 배포 스크립트에 **"떴는지 확인하는 줄"** 을 넣었다.
+프로필을 붙였다는 사실만으로는 떴는지 모른다 — 이건 코드에서 `assertThat` 을 쓰는 것과 같은 이유다.
+
+```bash
+for c in edumeet-prometheus edumeet-grafana; do
+  if [ -z "$(docker ps -q -f name=^${c}$)" ]; then exit 1; fi
+done
+```
 
 ## 왜 테스트가 못 잡았나
 


### PR DESCRIPTION
Closes #83

부하 측정을 OCI 로 옮기려고 서버를 조사하다가 나왔습니다.

## 문제

```
서버에 떠 있던 EduMeet 컨테이너: app, mysql, redis   ← 3개
docker-compose.prod.yml 이 정의한 것:  + prometheus, grafana
```

```yaml
prometheus:
  profiles: [observability]     # 프로필이 켜져야만 뜬다
```

```bash
docker compose -f docker-compose.prod.yml up -d      # 배포가 하던 것
```

**Compose 는 프로필이 꺼진 서비스를 조용히 건너뜁니다.** 에러도 경고도 없습니다.
만들고, 커밋하고, 배포까지 하고도 **한 번도 켜진 적이 없었습니다.**

막는 것은 아무것도 없었습니다 — `GRAFANA_PASSWORD` 는 서버 `.env` 에 있고,
Grafana 의 3001 도 Prometheus 의 내부 9090 도 안 겹칩니다. **그냥 프로필을 안 붙였을 뿐입니다.**

> `docs/ops/04-observability.md` 8절의 *"Grafana 대시보드를 실제 화면으로 확인하지 않았다"* 는
> 게으름이 아니라 **확인할 화면이 없었다**는 뜻이었습니다. 그때는 몰랐습니다.

## 프로필만 붙이면 안 됩니다

붙였다는 사실이 **떴다는 뜻은 아닙니다.** 배포 스크립트에 확인하는 줄을 넣었습니다.

```bash
for c in edumeet-prometheus edumeet-grafana; do
  if [ -z "$(docker ps -q -f name=^${c}$)" ]; then
    echo "관측 컨테이너가 뜨지 않았다: $c"; exit 1
  fi
done
```

코드에서 `assertThat` 을 쓰는 것과 같은 이유입니다.

## 곁다리 — `APP_IMAGE` 기본값이 `:latest` 였습니다

```diff
- image: ${APP_IMAGE:-ghcr.io/dj258255/edumeet:latest}
+ image: ${APP_IMAGE:?APP_IMAGE 를 지정해야 한다. ...}
```

**제가 직접 밟았습니다.** 서버에서 프로필 동작을 검증하느라 `APP_IMAGE` 없이 `compose up` 을 했더니
운영이 핀 태그에서 `:latest` 로 **조용히 바뀌었습니다.** (같은 이미지였어서 피해는 없었고 바로 되돌렸습니다.)

같은 파일의 `GRAFANA_PASSWORD:?` 는 안 주면 실패하게 해 뒀는데 정작 이미지 태그는 아니었습니다.

## 검증 — 푸시 전에 서버에서 직접 확인했습니다

배포 스크립트에 `exit 1` 을 넣었으므로 **안 되면 배포가 깨집니다.** 그래서 먼저 확인했습니다.

```
prometheus targets   edumeet-app   health=up   http://app:9090/actuator/prometheus
query up{service="edumeet"}        = 1
grafana :3001                      -> 200
edumeet-app                        healthy, SHA 핀 복귀
```

## 다섯 번째

| # | 무엇 | |
|---|---|---|
| 1 | `probes.enabled` | 설정값 |
| 2 | `prometheus.export.enabled` | 설정값 |
| 3 | `SessionType.isAudioOnly()` | 코드 |
| 4 | `sessionType` 요청 필드 부재 | 코드 |
| **5** | **`--profile observability` 부재** | **배포 스크립트 — 컨테이너 2개** |

앞의 넷은 코드 안이라 테스트로 잡을 수 있었습니다. **5번은 `docker ps` 를 보지 않는 한 알 방법이 없고, 배포는 초록으로 끝납니다.**