### PR TITLE
fix: Grafana 를 127.0.0.1 에만 묶는다 (#89)

### DIFF
--- a/deploy/nginx/edumeet.conf
+++ b/deploy/nginx/edumeet.conf
@@ -1,0 +1,108 @@
+# EduMeet 리버스 프록시. (#87)
+#
+#   /etc/nginx/conf.d/edumeet.conf 로 배치한다.
+#   인증서는 certbot 이 넣는다:
+#     certbot --nginx -d edumeet.studywithtymee.com
+#
+# ── 왜 리버스 프록시가 필요한가 ────────────────────────────────
+#   프론트가 https 인데 API 가 http 면 브라우저가 mixed content 로 막는다.
+#   CORS 이전 단계라 서버에서 헤더를 아무리 손봐도 소용없다.
+#   ws:// 도 마찬가지다. https 페이지에서는 wss:// 여야 한다.
+#   즉 TLS 는 구색이 아니라 "채팅이 도느냐" 의 문제다.
+
+upstream edumeet_app {
+    server 127.0.0.1:8080;
+    keepalive 32;              # 업스트림 커넥션 재사용. 매 요청 TCP 핸드셰이크를 없앤다
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name edumeet.studywithtymee.com;
+
+    # certbot 갱신용 경로만 열어 두고 나머지는 https 로 보낸다.
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name edumeet.studywithtymee.com;
+
+    # certbot --nginx 가 아래 두 줄을 채운다.
+    # ssl_certificate     /etc/letsencrypt/live/edumeet.studywithtymee.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/edumeet.studywithtymee.com/privkey.pem;
+
+    # 업로드(과제 첨부)가 있으므로 기본값 1m 보다 키운다.
+    client_max_body_size 50m;
+
+    # ══════════════════════════════════════════════════════════
+    #  ★ WebSocket - 여기가 조용히 깨지는 자리다
+    # ══════════════════════════════════════════════════════════
+    #
+    #  nginx 기본값 그대로 두면 세 가지가 동시에 잘못된다.
+    #
+    #    proxy_http_version  기본 1.0  -> Upgrade 헤더가 안 넘어가 업그레이드 자체가 실패
+    #    proxy_read_timeout  기본 60s  -> 60초마다 연결이 끊긴다. 에러 로그도 안 남는다
+    #    proxy_buffering     기본 on   -> 메시지가 버퍼에 고여 지연이 늘어난다
+    #
+    #  특히 두 번째가 고약하다. 개발할 때는 60초 안에 새로고침하니까 안 보이고,
+    #  실제 수업이 시작돼야 드러난다. "가끔 끊겨요" 로 보고되는 종류다.
+    location /ws {
+        proxy_pass http://edumeet_app;
+
+        # 1.1 이어야 Upgrade 를 전달한다. 이게 없으면 핸드셰이크가 400 으로 끝난다.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        # $connection_upgrade 는 /etc/nginx/conf.d/00-maps.conf 에 이미 정의돼 있다.
+        # 여기서 map 을 다시 선언하면 nginx 가 duplicate parameter 로 기동 자체를 거부한다.
+        # (같은 map 을 두 파일에 두는 실수는 "설정이 틀린" 게 아니라 "서버가 안 뜨는" 문제다.)
+        proxy_set_header Connection $connection_upgrade;
+
+        # 채팅은 조용한 구간이 길다. 기본 60초면 그 구간마다 끊긴다.
+        # 애플리케이션 하트비트를 켜면 짧아도 되지만, 지금은 STOMP heart-beat 0,0 이다.
+        proxy_read_timeout  3600s;
+        proxy_send_timeout  3600s;
+
+        # 버퍼링을 끄지 않으면 서버가 보낸 프레임이 nginx 버퍼에 머문다.
+        # 실시간에서는 처리량보다 지연이 중요하다.
+        proxy_buffering off;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://edumeet_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";     # keepalive 를 쓰려면 비워야 한다
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 5s;
+        proxy_read_timeout   30s;
+    }
+
+    # 관리 포트(9090)는 프록시하지 않는다.
+    # 지표를 인터넷에 두지 않는다는 #28 의 결정을 여기서도 지킨다.
+    location /actuator { return 404; }
+
+    # ── 프론트엔드를 여기 붙일 자리 ────────────────────────────
+    #   지금은 백엔드 전용 저장소라 정적 파일이 없다. 필요해지면 아래를 켠다.
+    #   SPA 는 try_files 폴백이 없으면 새로고침에서 404 가 난다 -
+    #   라우팅이 브라우저 안에 있어서 서버는 그 경로를 모르기 때문이다.
+    #
+    #   root /var/www/edumeet;
+    #   location / { try_files $uri $uri/ /index.html; }
+    #
+    #   그러면 위의 location / 프록시 블록은 /api/ 로 좁혀야 한다.
+    #   지금 미리 만들어 두지 않는 이유: 붙일 것이 없는 설정은
+    #   이 저장소에서 다섯 번 겪은 '있는데 아무것도 안 하는 설정' 이 된다.
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -107,7 +107,12 @@ services:
     restart: unless-stopped
     # 사람이 봐야 하므로 이것만 publish 한다. 비밀번호는 .env 로 준다.
     ports:
-      - "3001:3000"
+      # ★ 127.0.0.1 에만 묶는다. (#88)
+      #   0.0.0.0 이면 OCI 보안 목록 하나만 잘못 열려도 Grafana 가 인터넷에 뜬다.
+      #   이 파일의 나머지(mysql·redis·prometheus)는 전부 expose 로 내부망에만 두고 있고
+      #   actuator 도 사설 IP(10.0.0.11)에만 묶여 있는데 여기만 예외였다.
+      #   보는 방법: ssh -L 3001:localhost:3001 rocky@<host> 뒤 localhost:3001
+      - "127.0.0.1:3001:3000"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD 를 .env 에 설정해야 한다}
       # 익명 접근을 막는다. 지표는 내부 정보다.


### PR DESCRIPTION
Closes #89

`docker-compose.prod.yml` 은 노출에 일관되게 조심하고 있었는데 **Grafana 만 예외였습니다.**

```
mysql · redis · prometheus   expose 만 (내부망)
actuator                     10.0.0.11:9091 (사설 IP 전용)
grafana                      0.0.0.0:3001    ← 여기만
```

## 왜 지금인가

지금은 OCI 보안 목록이 막아 주고 있습니다. 그런데 **80/443 을 열려고 그 목록을 편집해야 하는 시점**입니다.
거기서 3001 이 딸려 열리면 **Grafana 로그인 화면이 그대로 인터넷에 뜹니다.**

방어를 한 겹 더 둡니다 — 보안 목록이 잘못돼도 바인딩이 막습니다.

```diff
- - "3001:3000"
+ - "127.0.0.1:3001:3000"
```

## 보는 방법

```bash
ssh -L 3001:localhost:3001 -i ~/.ssh/edumeet_deploy rocky@<host>
# 브라우저에서 localhost:3001
```

노출 0, 추가 설정 0. **"지표를 인터넷에 두지 않는다"(#28) 는 결정을 바인딩에서도 지킵니다.**