### PR TITLE
fix: Grafana 를 127.0.0.1 에만 묶는다 (#89)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -105,9 +105,21 @@ services:
     container_name: edumeet-grafana
     profiles: [observability]
     restart: unless-stopped
-    # 사람이 봐야 하므로 이것만 publish 한다. 비밀번호는 .env 로 준다.
+    # ★ 127.0.0.1 에만 묶는다. (#89)
+    #
+    #   이 파일은 노출에 일관되게 조심하고 있는데 여기만 예외였다.
+    #     mysql · redis · prometheus   expose 만 (내부망)
+    #     actuator                     10.0.0.11:9091 (사설 IP 전용)
+    #     grafana                      0.0.0.0:3001    <- 여기
+    #
+    #   지금은 OCI 보안 목록이 막아 준다. 그런데 80/443 을 열려고
+    #   그 목록을 편집해야 하는 시점이라, 3001 이 딸려 열리면
+    #   Grafana 로그인 화면이 그대로 인터넷에 뜬다.
+    #   보안 목록이 잘못돼도 바인딩이 막게 한 겹 더 둔다.
+    #
+    #   보는 방법:  ssh -L 3001:localhost:3001 rocky@<host>
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD 를 .env 에 설정해야 한다}
       # 익명 접근을 막는다. 지표는 내부 정보다.


### PR DESCRIPTION
Closes #89

`docker-compose.prod.yml` 은 노출에 일관되게 조심하고 있었는데 **Grafana 만 예외였습니다.**

```
mysql · redis · prometheus   expose 만 (내부망)
actuator                     10.0.0.11:9091 (사설 IP 전용)
grafana                      0.0.0.0:3001    ← 여기만
```

## 왜 지금인가

지금은 OCI 보안 목록이 막아 주고 있습니다.
그런데 **80/443 을 열려고 그 목록을 편집해야 하는 시점**입니다.
거기서 3001 이 딸려 열리면 **Grafana 로그인 화면이 그대로 인터넷에 뜹니다.**

보안 목록이 잘못돼도 바인딩이 막도록 한 겹 더 둡니다.

```diff
- - "3001:3000"
+ - "127.0.0.1:3001:3000"
```

## 보는 방법

```bash
ssh -L 3001:localhost:3001 -i ~/.ssh/edumeet_deploy rocky@<host>
```

노출 0, 추가 설정 0. **"지표를 인터넷에 두지 않는다"(#28) 를 바인딩에서도 지킵니다.**