### PR TITLE
feat: 다시보기 채팅 — 발행 경로 밖에서 저장한다 (#61)

### DIFF
--- a/backend/src/main/java/com/edu/edumeet/EduMeetApplication.java
+++ b/backend/src/main/java/com/edu/edumeet/EduMeetApplication.java
@@ -2,8 +2,13 @@ package com.edu.edumeet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+// 다시보기 채팅 배치 flush 에 필요하다. (#61)
+// 이게 없으면 @Scheduled 가 등록되지 않고, 큐는 차기만 하다 버린다 -
+// 에러도 안 나고 지표(chat.archive.dropped)만 조용히 오른다.
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing //BaseEntity
 public class EduMeetApplication {

--- a/backend/src/main/java/com/edu/edumeet/chat/domain/ChatMessage.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/domain/ChatMessage.java
@@ -43,6 +43,15 @@ public class ChatMessage {
     @Column(name = "sent_at", nullable = false)
     private LocalDateTime sentAt;
 
+    /**
+     * 회의 시작 시각 기준 경과 밀리초. 다시보기 재생 위치와 맞추는 데 쓴다. (#61)
+     *
+     * <p>{@code sentAt} 에서 계산할 수도 있지만 저장 시점에 넣어 둔다.
+     * 방송 시작 시각이 나중에 보정되면 이미 저장된 채팅의 재생 위치가 전부 어긋난다.
+     */
+    @Column(name = "offset_millis")
+    private Long offsetMillis;
+
     public static ChatMessage of(Meeting meeting, String senderEmail, String content) {
         return ChatMessage.builder()
                 .meeting(meeting)
@@ -50,5 +59,17 @@ public class ChatMessage {
                 .content(content)
                 .sentAt(LocalDateTime.now())
                 .build();
+    }
+
+    /**
+     * 다시보기용 상대 시각을 함께 담아 만든다. (#61)
+     *
+     * @param offsetMillis 회의 시작 기준 경과 밀리초. 시작 시각을 모르면 {@code null}
+     */
+    public static ChatMessage of(Meeting meeting, String senderEmail, String content,
+                                 Long offsetMillis) {
+        ChatMessage message = of(meeting, senderEmail, content);
+        message.offsetMillis = offsetMillis;
+        return message;
     }
 }

--- a/backend/src/main/java/com/edu/edumeet/chat/service/ChatArchiveQueue.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/service/ChatArchiveQueue.java
@@ -1,0 +1,172 @@
+package com.edu.edumeet.chat.service;
+
+import com.edu.edumeet.chat.domain.ChatMessage;
+import com.edu.edumeet.chat.repository.ChatMessageRepository;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.repository.MeetingRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * 방송 채팅을 발행 경로 밖에서 저장한다. (#61)
+ *
+ * <pre>
+ *   전    발행 -> DB write(동기) -> 브로드캐스트     쓰기가 지연에 직접 들어간다
+ *   후    발행 -> 브로드캐스트                       즉시
+ *              ↘ 큐 -> 배치 flush -> DB             비동기
+ * </pre>
+ *
+ * <p><b>왜 저장을 되살리나.</b> 다시보기에서 라이브 채팅이 필요하다.
+ * 트위치·치지직·유튜브가 모두 하는 것이고 없으면 VOD 가 반쪽이 된다.
+ *
+ * <p><b>왜 발행 경로에서 빼나.</b> #43 에서 확인했듯 발행 경로의 DB 쓰기는
+ * 브로드캐스트 측정을 가린다. 그건 제품 문제가 아니라 측정 문제다.
+ * 그래서 <b>"저장하지 않는다" 가 아니라 "발행 경로에서 저장하지 않는다"</b> 다.
+ *
+ * <p><b>★ 큐에 상한이 있다.</b> #43 에서 무한 큐로 84초 만에 OOM 을 냈다
+ * (느린 소비자 조건, 큐 최대 1,077,906). 같은 실수를 다시 하지 않는다.
+ * 가득 차면 <b>버린다</b> — 다시보기 채팅은 유실돼도 서비스가 죽지 않지만,
+ * 힙이 터지면 방송 자체가 죽는다. <b>무엇을 지킬지 먼저 정한다.</b>
+ */
+@Component
+@Slf4j
+public class ChatArchiveQueue {
+
+    /**
+     * 큐 상한. 초당 100건이 들어와도 20초를 버틴다.
+     *
+     * <p>이 값의 근거는 "얼마나 버틸까" 가 아니라 <b>"터지면 무엇을 잃는가"</b> 다.
+     * 2,000건 × 메시지당 대략 1KB = 2MB 남짓이라 힙에 부담이 없다.
+     * 배치가 이보다 오래 밀리면 DB 쪽에 다른 문제가 있는 것이고,
+     * 그때는 채팅을 더 쌓는 것보다 버리고 지표로 알리는 편이 낫다.
+     */
+    private static final int CAPACITY = 2_000;
+
+    /** 한 번에 저장할 최대 건수. 너무 크면 트랜잭션이 길어지고 락을 오래 잡는다. */
+    private static final int BATCH_SIZE = 200;
+
+    private final BlockingQueue<Pending> queue = new ArrayBlockingQueue<>(CAPACITY);
+
+    private final MeetingRepository meetingRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final Counter enqueued;
+    private final Counter dropped;
+    private final Counter persisted;
+
+    private final boolean enabled;
+
+    public ChatArchiveQueue(MeetingRepository meetingRepository,
+                            ChatMessageRepository chatMessageRepository,
+                            MeterRegistry registry,
+                            @Value("${edumeet.chat.archive.enabled:true}") boolean enabled) {
+        this.meetingRepository = meetingRepository;
+        this.chatMessageRepository = chatMessageRepository;
+        this.enabled = enabled;
+
+        Gauge.builder("chat.archive.queued", queue, java.util.Collection::size)
+                .description("저장 대기 중인 방송 채팅 수")
+                .register(registry);
+        Gauge.builder("chat.archive.capacity", this, q -> CAPACITY)
+                .description("큐 상한. queued 가 여기 붙으면 버리고 있다")
+                .register(registry);
+        this.enqueued = Counter.builder("chat.archive.enqueued")
+                .description("큐에 넣은 수").register(registry);
+        this.dropped = Counter.builder("chat.archive.dropped")
+                .description("큐가 가득 차 버린 수. 0 이 아니면 배치가 못 따라가고 있다")
+                .register(registry);
+        this.persisted = Counter.builder("chat.archive.persisted")
+                .description("실제로 저장한 수").register(registry);
+    }
+
+    /** 큐에 넣는다. <b>가득 차면 버리고 false 를 준다. 절대 막지 않는다.</b> */
+    public boolean offer(Long meetingId, String senderEmail, String content, Long offsetMillis) {
+        if (!enabled) {
+            return false;
+        }
+        boolean accepted = queue.offer(new Pending(meetingId, senderEmail, content, offsetMillis));
+        if (accepted) {
+            enqueued.increment();
+        } else {
+            dropped.increment();
+            // 건건이 로그를 남기면 큐가 넘칠 때 로그가 먼저 시스템을 잡아먹는다.
+            // 지표(chat.archive.dropped)로 보고, 로그는 남기지 않는다.
+        }
+        return accepted;
+    }
+
+    /**
+     * 배치로 저장한다.
+     *
+     * <p>주기 1초는 시작값이다. 다시보기는 실시간이 아니므로 몇 초 늦어도 된다.
+     * 짧게 잡으면 트랜잭션이 잦아지고 길게 잡으면 큐가 길어진다 —
+     * {@code chat.archive.queued} 와 {@code dropped} 를 보고 조정한다.
+     */
+    @Scheduled(fixedDelayString = "${edumeet.chat.archive.flush-interval-ms:1000}")
+    public void flush() {
+        List<Pending> batch = new ArrayList<>(BATCH_SIZE);
+        queue.drainTo(batch, BATCH_SIZE);
+        if (batch.isEmpty()) {
+            return;
+        }
+        try {
+            persist(batch);
+        } catch (Exception e) {
+            // 저장 실패로 브로드캐스트가 멈추면 안 된다. 다시보기가 반쪽이 되는 것과
+            // 방송이 죽는 것 중 무엇이 나쁜지는 분명하다.
+            log.warn("다시보기 채팅 배치 저장 실패 - {}건 유실. {}", batch.size(), e.toString());
+        }
+    }
+
+    @Transactional
+    protected void persist(List<Pending> batch) {
+        // 회의는 배치 안에서 몇 개 안 된다. 건마다 조회하면 N+1 이다.
+        Map<Long, Meeting> meetings = new HashMap<>();
+        List<ChatMessage> rows = new ArrayList<>(batch.size());
+
+        for (Pending p : batch) {
+            Meeting meeting = meetings.computeIfAbsent(
+                    p.meetingId(), id -> meetingRepository.findById(id).orElse(null));
+            if (meeting == null) {
+                continue;   // 회의가 지워졌다. 채팅만 남길 이유가 없다
+            }
+            rows.add(ChatMessage.of(meeting, p.senderEmail(), p.content(), p.offsetMillis()));
+        }
+        if (!rows.isEmpty()) {
+            chatMessageRepository.saveAll(rows);
+            persisted.increment(rows.size());
+        }
+    }
+
+    /** 종료 시 남은 것을 한 번 더 비운다. 있는 것을 버릴 이유는 없다. */
+    @PreDestroy
+    public void drainOnShutdown() {
+        int remaining = queue.size();
+        if (remaining > 0) {
+            log.info("종료 - 다시보기 채팅 {}건 남아 있어 비운다", remaining);
+            while (!queue.isEmpty()) {
+                flush();
+            }
+        }
+    }
+
+    /** 테스트에서 배치를 기다리지 않고 확인할 때 쓴다. */
+    public int queuedCount() {
+        return queue.size();
+    }
+
+    private record Pending(Long meetingId, String senderEmail, String content, Long offsetMillis) {}
+}

--- a/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
@@ -32,6 +32,7 @@ public class ChatService {
 
     private final MeetingRepository meetingRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatArchiveQueue archiveQueue;
 
     /**
      * 메시지를 받아 브로드캐스트할 형태로 만든다. 저장 여부는 세션 형태가 정한다.
@@ -51,7 +52,14 @@ public class ChatService {
         }
 
         if (shouldPersist(meeting.getSessionType())) {
+            // 화상강의는 그대로 동기 저장한다. 정원 30명이라 발행량이 작아
+            // 측정을 가리지 않고, 무엇보다 수업 기록은 유실되면 안 된다.
             chatMessageRepository.save(ChatMessage.of(meeting, senderEmail, trimmed));
+        } else {
+            // 방송은 발행 경로에서 저장하지 않는다. 큐에 넣고 배치가 가져간다. (#61)
+            // 가득 차면 버린다 - 다시보기 채팅은 유실돼도 방송은 살아 있어야 한다.
+            archiveQueue.offer(meetingId, senderEmail, trimmed,
+                    offsetFrom(meeting));
         }
 
         return new ChatMessageResponse(
@@ -71,10 +79,34 @@ public class ChatService {
     }
 
     /**
-     * BROADCAST 는 저장하지 않는다.
+     * 회의 시작 기준 경과 밀리초. 다시보기 재생 위치와 맞추는 데 쓴다. (#61)
      *
-     * <p>시청자 수천 명 × 초당 수십 메시지면 쓰기가 폭증한다. 방송 채팅은 원래 휘발성이고,
-     * 무엇보다 <b>이 분기가 없으면 브로드캐스트 성능 측정이 DB 쓰기에 묻힌다.</b>
+     * <p>시작 시각이 없으면 {@code null} 이다. 그런 회의는 다시보기가 없으므로
+     * 여기서 예외를 던질 이유가 없다.
+     */
+    private Long offsetFrom(Meeting meeting) {
+        if (meeting.getStartTime() == null) {
+            return null;
+        }
+        long started = meeting.getStartTime().atZone(ZoneId.systemDefault())
+                .toInstant().toEpochMilli();
+        return Math.max(0, System.currentTimeMillis() - started);
+    }
+
+    /**
+     * 발행 경로에서 동기로 저장하는가.
+     *
+     * <p><b>"저장하지 않는다" 가 아니라 "발행 경로에서 저장하지 않는다" 이다.</b> (#61)
+     * 방송 채팅도 다시보기에 필요해서 저장한다. 다만 큐를 거쳐 배치로 넣는다.
+     *
+     * <p>처음에는 <i>"시청자 수천 명 × 초당 수십 메시지면 쓰기가 폭증한다"</i> 를
+     * 근거로 아예 저장하지 않았다. <b>그 근거는 틀렸다</b> —
+     * 쓰기는 fan-out 이 아니라 발행량이고, 시청자가 3,000명이어도
+     * 메시지 1건은 <b>DB write 1건</b>이다. fan-out 은 읽기(전송) 쪽이다.
+     *
+     * <p>유효했던 근거는 다른 하나다. #43 에서 확인했듯
+     * <b>발행 경로의 DB 쓰기는 브로드캐스트 측정을 가린다.</b>
+     * 그건 제품 문제가 아니라 측정 문제이므로, 저장을 없애는 대신 경로를 옮긴다.
      */
     private boolean shouldPersist(SessionType sessionType) {
         // 정책을 여기서 비교하지 않는다. 세션 타입이 늘 때 이 자리를 빠뜨리면

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -202,6 +202,14 @@ edumeet:
     # 카카오 로그인만 쓰기로 해서 껐다. (#55)
     # 지우지 않고 플래그로 둔 이유는 되살릴 때 다시 짜지 않기 위해서다.
     enabled: ${EMAIL_ENABLED:false}
+  chat:
+    archive:
+      # 방송 채팅을 다시보기용으로 저장한다. (#61)
+      # 끄면 큐에 넣지 않는다 - 부하 측정에서 저장을 배제하고 싶을 때 쓴다.
+      enabled: ${CHAT_ARCHIVE_ENABLED:true}
+      # 다시보기는 실시간이 아니므로 몇 초 늦어도 된다.
+      # 짧으면 트랜잭션이 잦고 길면 큐가 길어진다. queued/dropped 를 보고 조정한다.
+      flush-interval-ms: ${CHAT_ARCHIVE_FLUSH_MS:1000}
   hls:
     # egress 인스턴스가 붙어 있을 때만 켠다.
     # 켜 놓고 인스턴스가 없으면 방송 시작이 "no response from egress service" 로 실패한다.

--- a/backend/src/main/resources/db/migration/V7__add_chat_message_offset_millis.sql
+++ b/backend/src/main/resources/db/migration/V7__add_chat_message_offset_millis.sql
@@ -1,0 +1,15 @@
+-- 다시보기용 상대 시각. (#61)
+--
+-- 다시보기는 재생 위치(0:12:34)에 맞춰 그때의 채팅을 보여준다.
+-- 절대 시각(sent_at)에서 Meeting.startTime 을 빼서 계산할 수도 있지만
+-- 저장 시점에 넣어 둔다 - 방송 시작 시각이 나중에 보정되면
+-- 이미 저장된 채팅의 재생 위치가 전부 어긋난다.
+--
+-- NULL 을 허용하는 이유: 이 컬럼이 생기기 전에 저장된 행이 있다.
+-- 그것들은 계산으로 메울 수 있고, 못 메워도 실시간 채팅에는 지장이 없다.
+
+ALTER TABLE chat_message
+    ADD COLUMN offset_millis BIGINT NULL COMMENT '회의 시작 시각 기준 경과 밀리초';
+
+-- 다시보기는 "이 회의의 채팅을 재생 순서대로" 읽는다.
+CREATE INDEX idx_chat_message_replay ON chat_message (meeting_id, offset_millis);

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/ChatAcrossModesTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/ChatAcrossModesTest.java
@@ -145,14 +145,25 @@ class ChatAcrossModesTest {
 
         session.send("/app/rooms/" + fixture.meetingId() + "/send", new ChatSendRequest("저장 확인"));
         received.get(5, TimeUnit.SECONDS);
-        Thread.sleep(200);
 
-        long stored = chatMessageRepository.countByMeetingId(fixture.meetingId());
+        // ★ 이 시험이 재는 것은 "저장되느냐" 가 아니라 "발행 경로에서 저장되느냐" 다. (#61)
+        //
+        //   #61 이 오기 전에는 방송이 아예 저장되지 않아서 "0건" 으로 확인할 수 있었다.
+        //   지금은 배치가 1초마다 큐를 비우므로, 잠시 기다렸다 세면
+        //   들어와 있을 수도 없을 수도 있다 - 경합이다.
+        //
+        //   구독자가 메시지를 받은 직후(= 발행이 끝난 직후)에 세면
+        //   동기 저장인지 아닌지가 갈린다. 기다리지 않는 것이 핵심이다.
+        long storedRightAfterPublish = chatMessageRepository.countByMeetingId(fixture.meetingId());
         if (type.persistsChatInline()) {
-            assertThat(stored).as("%s 는 수업 기록이라 저장한다", type).isEqualTo(1);
+            assertThat(storedRightAfterPublish)
+                    .as("%s 는 수업 기록이라 발행 경로에서 동기 저장한다", type).isEqualTo(1);
         } else {
-            assertThat(stored)
-                    .as("%s 는 발행 경로에서 저장하지 않는다. 다시보기용 비동기 저장은 #61", type)
+            assertThat(storedRightAfterPublish)
+                    .as("""
+                        %s 가 발행 직후 이미 저장돼 있다면 동기 쓰기다.
+                        발행 경로에서 DB 쓰기를 뺀 의미가 없어진다. (#43 측정이 가려진다)
+                        다시보기용 비동기 저장은 ChatArchiveTest 가 따로 본다.""", type)
                     .isZero();
         }
         session.disconnect();

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/ChatArchiveTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/ChatArchiveTest.java
@@ -1,0 +1,193 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.chat.domain.ChatMessage;
+import com.edu.edumeet.chat.repository.ChatMessageRepository;
+import com.edu.edumeet.chat.service.ChatArchiveQueue;
+import com.edu.edumeet.chat.service.ChatService;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.member.domain.Member;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static java.time.Duration.ofSeconds;
+
+/**
+ * 다시보기 채팅 - 발행 경로 밖에서 저장한다. (#61)
+ *
+ * <pre>
+ *   전    발행 -> DB write(동기) -> 브로드캐스트
+ *   후    발행 -> 브로드캐스트
+ *              ↘ 큐 -> 배치 flush -> DB
+ * </pre>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("다시보기 채팅")
+class ChatArchiveTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @Autowired ChatService chatService;
+    @Autowired ChatArchiveQueue archiveQueue;
+    @Autowired ChatMessageRepository chatMessageRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @Autowired MeterRegistry registry;
+    @PersistenceContext EntityManager em;
+
+    /**
+     * 큐는 애플리케이션 컨텍스트를 공유하는 싱글턴이다.
+     *
+     * <p>홍수 시험이 6,000건을 밀어 넣고 나면 큐가 가득 찬 채로 남아,
+     * <b>다음 시험의 메시지가 그 뒤에 밀리거나 버려진다.</b>
+     * JUnit 은 메서드 순서를 보장하지 않으므로 <b>실행마다 다른 시험이 실패한다</b> -
+     * 실제로 BROADCAST 만 실패하고 AUDIO_BROADCAST 는 통과하는 모양으로 나왔다.
+     * 같은 코드 경로인데 결과가 갈리면 그건 제품이 아니라 시험 탓이다.
+     *
+     * <p>공유 상태를 쓰면 명시적으로 치운다.
+     */
+    @AfterEach
+    void drainQueue() {
+        for (int i = 0; i < 100 && archiveQueue.queuedCount() > 0; i++) {
+            archiveQueue.flush();
+        }
+    }
+
+    private Long givenMeeting(SessionType type, LocalDateTime startedAt) {
+        int n = SEQ.incrementAndGet();
+        Long[] id = new Long[1];
+        transactionTemplate.executeWithoutResult(s -> {
+            Member owner = Member.builder()
+                    .email("archive-" + n + "@test").nickname("호스트").password("x").build();
+            em.persist(owner);
+            ClassRoom c = ClassRoom.builder().member(owner)
+                    .title("클래스").description("-").participantLimit(30).isDeleted(false).build();
+            em.persist(c);
+            Meeting m = Meeting.builder().classRoom(c)
+                    .title("세션").description("-").sessionType(type)
+                    .startTime(startedAt).build();
+            em.persist(m);
+            em.flush();
+            id[0] = m.getId();
+        });
+        return id[0];
+    }
+
+    private double counter(String name) {
+        var c = registry.find(name).counter();
+        return c == null ? 0 : c.count();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SessionType.class, names = {"BROADCAST", "AUDIO_BROADCAST"})
+    @DisplayName("★ 방송 채팅도 저장된다 - 다시보기가 반쪽이 되지 않게")
+    void broadcast_chat_is_archived(SessionType type) {
+        Long meetingId = givenMeeting(type, LocalDateTime.now().minusMinutes(3));
+
+        chatService.handle(meetingId, "viewer@test", "다시보기에서 보일 메시지");
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            List<ChatMessage> saved = chatMessageRepository.findAll().stream()
+                    .filter(m -> m.getMeeting().getId().equals(meetingId)).toList();
+            assertThat(saved)
+                    .as("%s 채팅이 저장되지 않았다. 다시보기에서 채팅이 사라진다", type)
+                    .hasSize(1);
+            assertThat(saved.get(0).getContent()).isEqualTo("다시보기에서 보일 메시지");
+        });
+    }
+
+    @Test
+    @DisplayName("★ 발행이 저장을 기다리지 않는다 - 반환 시점에는 아직 DB 에 없다")
+    void publish_does_not_wait_for_the_write() {
+        Long meetingId = givenMeeting(SessionType.BROADCAST, LocalDateTime.now().minusMinutes(1));
+
+        chatService.handle(meetingId, "viewer@test", "즉시 반환되어야 한다");
+
+        // 반환 직후에는 큐에만 있고 DB 에는 없다.
+        // 이게 이 작업의 요점이다 - 발행 경로에서 DB 쓰기를 뺐다.
+        long persistedNow = chatMessageRepository.findAll().stream()
+                .filter(m -> m.getMeeting().getId().equals(meetingId)).count();
+        assertThat(persistedNow)
+                .as("반환 시점에 이미 저장돼 있다면 동기 쓰기다. 발행 경로에서 뺀 의미가 없다")
+                .isZero();
+
+        // 그리고 잠시 뒤에는 들어와 있다.
+        await().atMost(ofSeconds(10)).untilAsserted(() ->
+                assertThat(chatMessageRepository.findAll().stream()
+                        .filter(m -> m.getMeeting().getId().equals(meetingId)).count())
+                        .isEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("★ 재생 위치(offsetMillis)가 담긴다 - 없으면 다시보기에서 순서를 못 맞춘다")
+    void offset_is_recorded() {
+        LocalDateTime startedAt = LocalDateTime.now().minusMinutes(5);
+        Long meetingId = givenMeeting(SessionType.BROADCAST, startedAt);
+
+        chatService.handle(meetingId, "viewer@test", "5분쯤 지난 시점");
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            var saved = chatMessageRepository.findAll().stream()
+                    .filter(m -> m.getMeeting().getId().equals(meetingId)).findFirst();
+            assertThat(saved).isPresent();
+            Long offset = saved.get().getOffsetMillis();
+            assertThat(offset)
+                    .as("offsetMillis 가 없으면 재생 위치에 맞춰 보여줄 수 없다")
+                    .isNotNull();
+            // 5분 = 300,000ms. 테스트 실행 지연을 감안해 넉넉히 본다.
+            assertThat(offset).isBetween(300_000L - 5_000L, 300_000L + 60_000L);
+        });
+    }
+
+    @Test
+    @DisplayName("★ 큐가 가득 차면 버린다 - 무한 큐를 다시 만들지 않는다")
+    void full_queue_drops_instead_of_growing() {
+        Long meetingId = givenMeeting(SessionType.BROADCAST, LocalDateTime.now());
+        double droppedBefore = counter("chat.archive.dropped");
+
+        // 상한(2,000)보다 훨씬 많이 밀어 넣는다. 배치가 동시에 빼가므로
+        // "정확히 몇 개가 버려지는가" 는 재현되지 않는다. 재현되는 것은
+        // (1) 큐가 상한을 넘지 않는다 (2) 넘친 만큼 dropped 가 오른다 이다.
+        for (int i = 0; i < 6_000; i++) {
+            archiveQueue.offer(meetingId, "flood@test", "m" + i, (long) i);
+            assertThat(archiveQueue.queuedCount())
+                    .as("큐가 상한을 넘었다. #43 의 OOM 을 다시 만드는 길이다")
+                    .isLessThanOrEqualTo(2_000);
+        }
+
+        assertThat(counter("chat.archive.dropped"))
+                .as("상한의 3배를 밀어 넣었는데 버린 게 없다면 어딘가 무한히 쌓이고 있다")
+                .isGreaterThan(droppedBefore);
+    }
+
+    @Test
+    @DisplayName("화상강의는 그대로 동기 저장한다 - 수업 기록은 유실되면 안 된다")
+    void interactive_still_persists_inline() {
+        Long meetingId = givenMeeting(SessionType.INTERACTIVE, LocalDateTime.now().minusMinutes(1));
+
+        chatService.handle(meetingId, "student@test", "수업 중 질문");
+
+        // 대기 없이 즉시 있어야 한다.
+        assertThat(chatMessageRepository.findAll().stream()
+                .filter(m -> m.getMeeting().getId().equals(meetingId)).count())
+                .as("화상강의는 동기 저장이다. 비동기로 바꾸면 수업 기록이 유실될 수 있다")
+                .isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Closes #61

```
전    발행 → DB write(동기) → 브로드캐스트     쓰기가 지연에 직접 들어간다
후    발행 → 브로드캐스트                       즉시
           ↘ 큐 → 배치 flush → DB              비동기
```

## 원래 근거 하나가 틀렸습니다

방송 채팅을 저장하지 않기로 했을 때 근거가 둘이었는데, **하나는 틀렸습니다.**

> *"시청자 수천 명 × 초당 수십 메시지면 쓰기가 폭증한다"*

**쓰기는 fan-out 이 아니라 발행량입니다.** 메시지 1건 = DB write 1건이고,
시청자가 3,000명이어도 **쓰기는 1건**입니다. fan-out 은 읽기(전송) 쪽입니다. **두 축을 섞어 썼습니다.**

나머지 하나는 여전히 유효합니다.

> *"이 분기가 없으면 브로드캐스트 성능 측정이 DB 쓰기에 묻힌다"* — #43 에서 실제로 그랬습니다.

**그건 제품 문제가 아니라 측정 문제입니다.**
그래서 *"저장하지 않는다"* 가 아니라 **"발행 경로에서 저장하지 않는다"** 로 바꿉니다.

## ★ 큐에 상한이 있습니다

#43 에서 **무한 큐로 84초 만에 OOM** 을 냈습니다 (느린 소비자, 큐 최대 **1,077,906**).
**같은 실수를 다시 하지 않습니다.**

```java
private static final int CAPACITY = 2_000;   // ArrayBlockingQueue
```

가득 차면 **버립니다.** 다시보기 채팅은 유실돼도 서비스가 살지만,
힙이 터지면 **방송 자체가 죽습니다.** 무엇을 지킬지 먼저 정합니다.

상한의 근거는 "얼마나 버틸까" 가 아니라 **"터지면 무엇을 잃는가"** 입니다.
2,000건 × 대략 1KB = 2MB 남짓이라 힙에 부담이 없습니다.

## `offset_millis` (V7)

다시보기는 **재생 위치(0:12:34)에 맞춰** 그때의 채팅을 보여줍니다.
`sent_at` 에서 계산할 수도 있지만 **저장 시점에 넣어 둡니다** —
방송 시작 시각이 나중에 보정되면 **이미 저장된 채팅의 재생 위치가 전부 어긋납니다.**

## 화상강의는 그대로 동기 저장입니다

정원 30명이라 발행량이 작아 측정을 가리지 않고, **수업 기록은 유실되면 안 됩니다.**

## 지표

```
chat.archive.queued / capacity / enqueued / dropped / persisted
```

**`dropped` 가 0 이 아니면 배치가 못 따라가고 있다는 뜻입니다.**

## 곁다리 — `@EnableScheduling` 이 없었습니다

이게 없으면 `@Scheduled` 가 등록되지 않고 **큐는 차기만 하다 버립니다.**
에러도 안 나고 `chat.archive.dropped` 만 조용히 오릅니다.

## 시험이 시험을 오염시켰습니다

`BROADCAST` 는 실패하는데 `AUDIO_BROADCAST` 는 통과했습니다. **같은 코드 경로인데.**

원인은 큐가 **싱글턴 공유 상태**라는 것이었습니다. 홍수 시험이 6,000건을 밀어 넣고 나면
큐가 가득 찬 채로 남아 다음 시험의 메시지가 밀리거나 버려집니다.
JUnit 은 메서드 순서를 보장하지 않으므로 **실행마다 다른 시험이 실패합니다.**

> **같은 코드 경로에서 결과가 갈리면 제품이 아니라 시험 탓입니다.**

`@AfterEach` 로 큐를 비웁니다.

## #71 의 단언도 정정했습니다

그때 이렇게 써 뒀습니다 — *"방송은 발행 경로에서 저장하지 않는다. **다시보기용 비동기 저장은 #61**"*.
그 #61 이 지금 왔습니다.

배치가 1초마다 돌므로 **기다렸다 세면 경합**입니다.
재야 할 것은 *"저장되느냐"* 가 아니라 **"발행 경로에서 저장되느냐"** 이므로,
구독자가 받은 직후에 셉니다.

## 검증

**284개 통과** (278 → +6). 네 가지를 되돌려 검출력을 확인했습니다.

| 되돌린 것 | 실패 |
|---|---:|
| 방송 저장 제거 | 4개 |
| `offsetMillis` 제거 | 1개 |
| 큐 상한 제거 (무한 큐) | 1개 |
| 화상강의 비동기화 | 1개 |

## 남는 것

- 배치 크기·주기는 **시작값**입니다. `queued`/`dropped` 를 보고 조정합니다
- 다시보기 **조회 API 는 아직** 없습니다. 저장까지만 했습니다