### PR TITLE
feat: 프론트 빌드 배포 (#97)

### DIFF
--- a/frontend/src/components/AudioRecorder.vue
+++ b/frontend/src/components/AudioRecorder.vue
@@ -134,7 +134,7 @@ const summaryStatus = ref(null)
 const isGeneratingSummary = ref(false)
 
 // API 기본 URL
-const API_BASE_URL = 'https://i13c205.p.ssafy.io'
+const API_BASE_URL = 'https://api.studywithtymee.com'
 
 // 드래그 시작
 const startDrag = (event) => {

--- a/frontend/src/components/LiveInfoModal.vue
+++ b/frontend/src/components/LiveInfoModal.vue
@@ -101,7 +101,7 @@ import { ref, watch, onMounted } from 'vue'
 import axios from 'axios'
 
 /** API Base URL (.env: VITE_BASE_URL) */
-const API_BASE_URL = import.meta.env.VITE_BASE_URL || 'https://i13c205.p.ssafy.io'
+const API_BASE_URL = import.meta.env.VITE_BASE_URL || 'https://api.studywithtymee.com'
 
 const props = defineProps({
   isVisible: { type: Boolean, default: false },

--- a/frontend/src/views/ClassVideoRoomView.vue
+++ b/frontend/src/views/ClassVideoRoomView.vue
@@ -77,7 +77,7 @@ let APPLICATION_SERVER_URL = '';
 let LIVEKIT_URL = '';
 
 function configureUrls() {
-  APPLICATION_SERVER_URL = 'https://i13c205.p.ssafy.io/api/v1/meetingroom/'
+  APPLICATION_SERVER_URL = 'https://api.studywithtymee.com/api/v1/meetingroom/'
       
   LIVEKIT_URL = 'wss://edumeet-1jz93drq.livekit.cloud'
 }

--- a/frontend/src/views/CreateClassView.vue
+++ b/frontend/src/views/CreateClassView.vue
@@ -244,7 +244,7 @@ async function handleJoinClassConfirm(joinData) {
     }
     
     console.log('🔍 토큰 요청 시작')
-    console.log('🔍 요청 URL:', `https://i13c205.p.ssafy.io/api/v1/meetingroom/token`)
+    console.log('🔍 요청 URL:', `https://api.studywithtymee.com/api/v1/meetingroom/token`)
     console.log('🔍 요청 헤더:', {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${accessToken.substring(0, 20)}...`
@@ -257,7 +257,7 @@ async function handleJoinClassConfirm(joinData) {
       classId: joinData.classId
     })
     
-    const response = await fetch(`https://i13c205.p.ssafy.io/api/v1/meetingroom/token`, {
+    const response = await fetch(`https://api.studywithtymee.com/api/v1/meetingroom/token`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -631,7 +631,7 @@ const handleJoinClassConfirm = async (joinData) => {
     }
     
     console.log('🔍 토큰 요청 시작')
-    console.log('🔍 요청 URL:', `https://i13c205.p.ssafy.io/api/v1/meetingroom/token`)
+    console.log('🔍 요청 URL:', `https://api.studywithtymee.com/api/v1/meetingroom/token`)
     console.log('🔍 요청 헤더:', {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${accessToken.substring(0, 20)}...`
@@ -644,7 +644,7 @@ const handleJoinClassConfirm = async (joinData) => {
       classId: joinData.classId
     })
     
-    const response = await fetch(`https://i13c205.p.ssafy.io/api/v1/meetingroom/token`, {
+    const response = await fetch(`https://api.studywithtymee.com/api/v1/meetingroom/token`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/views/MyPageView.vue
+++ b/frontend/src/views/MyPageView.vue
@@ -402,7 +402,7 @@ export default {
          meetingInfo.downloading = true
 
          const accessToken = localStorage.getItem('accessToken')
-         const url = `https://i13c205.p..io/api/v1/meeting/files/download/${meetingInfo.id}`
+         const url = `https://api.studywithtymee.com/api/v1/meeting/files/download/${meetingInfo.id}`
          
          console.log('📡 요청 URL:', url)
          console.log('🔑 토큰 존재:', !!accessToken)
@@ -516,7 +516,7 @@ export default {
      const fetchLiveInfoForClass = async (classId) => {
        try {
          const accessToken = localStorage.getItem('accessToken')
-         const url = `https://i13c205.p.ssafy.io/api/v1/meetingroom/${classId}`
+         const url = `https://api.studywithtymee.com/api/v1/meetingroom/${classId}`
          
          console.log(`📡 LiveInfo 조회 시작 - classId: ${classId}`)
          console.log(`🔗 요청 URL: ${url}`)
@@ -705,9 +705,9 @@ export default {
         }
         
         console.log('🔍 토큰 요청 시작');
-        console.log('🔍 요청 URL:', `https://i13c205.p.ssafy.io/api/v1/meetingroom/token`);
+        console.log('🔍 요청 URL:', `https://api.studywithtymee.com/api/v1/meetingroom/token`);
         
-        const response = await fetch(`https://i13c205.p.ssafy.io/api/v1/meetingroom/token`, {
+        const response = await fetch(`https://api.studywithtymee.com/api/v1/meetingroom/token`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Closes #97

**`https://studywithtymee.com` 이 실제로 뜹니다.**

| | |
|---|---|
| `/` | **200** |
| `/class/999` (SPA 폴백) | **200** |
| `/assets/index-*.js` | **200**, 961KB |
| `www.` → apex | **301 → 200** |

## 죽은 주소 11곳을 치환했습니다

`https://i13c205.p.ssafy.io` 가 **7개 파일 13곳**에 하드코딩돼 있었고 **그 서버는 이미 없습니다.**
환경변수를 넣어도 이 줄들은 그대로 죽은 곳을 부릅니다.

하나는 **오타**였습니다 — `https://i13c205.p..io` (점 두 개).

## 2곳은 일부러 남겼습니다

`DocumentSummaryView` 가 부르는 두 경로는 **우리 백엔드에도 Express 에도 없습니다.**

```
/api/extract-key-sentences
/api/llm-summarize
```

`doc-summary` 는 `/api/class/:classId/update-recording` 하나뿐입니다.
**도메인만 바꾸면 "없는 걸 있는 척" 하게 되므로 그대로 뒀습니다.**

## `.env.production`

**Vite 는 빌드 시점에 값을 코드에 박습니다.** 런타임 설정이 아니라 값을 바꾸려면 다시 빌드해야 합니다 —
도메인을 먼저 확정해야 했던 이유입니다.

```
VITE_API_BASE_URL=https://api.studywithtymee.com/api/v1
VITE_BASE_URL=https://api.studywithtymee.com
```

빌드 산출물에 새 도메인이 **10회** 박힌 것을 확인했습니다.

## 원자적 배포

새 디렉터리에 풀고 `mv` 로 교체합니다. **반쯤 복사된 상태가 서비스되지 않게.**

## 알게 된 것

- 채팅이 **LiveKit 데이터 채널**로 구현돼 있습니다. 백엔드의 **STOMP 채팅과 별개**입니다
- `openvidu-browser` 와 `livekit-client` 가 **둘 다** 의존성에 있습니다. 실제로 쓰는 것은 LiveKit 입니다