### PR TITLE
ci: 모노레포에 맞게 CI/CD 를 채운다 (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ★ 무엇이 바뀌었는지 먼저 본다. (#99)
+  #
+  #   모노레포다. 문서만 고쳐도 백엔드 전체를 빌드·테스트하는 것은 낭비다.
+  #   반대로 경로 필터를 워크플로의 on: 에 걸면 "돌지 않은 잡" 이 pending 으로
+  #   남아 필수 체크가 영원히 안 끝난다. 그래서 잡 단위로 나눈다 -
+  #   해당 없는 잡은 skip 되고 체크는 초록으로 끝난다.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      ai: ${{ steps.filter.outputs.ai }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'contracts/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+            ai:
+              - 'ai/**'
+              - 'contracts/**'
+              - '.github/workflows/ci.yml'
+
   build-and-test:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    name: 백엔드 테스트
     # ARM 러너를 쓴다. 배포 대상(OCI A1.Flex)이 aarch64 라 같은 아키텍처에서 테스트한다.
     # public 저장소는 ARM 러너가 무료다.
     runs-on: ubuntu-24.04-arm
@@ -62,6 +96,8 @@ jobs:
   #   계약 파일(contracts/internal-api.json)을 Java 와 파이썬이 함께 읽으므로
   #   한쪽만 돌리면 갈라진 것을 못 잡는다. 실제로 그래서 오래 안 잡혔다.
   ai-tests:
+    needs: changes
+    if: needs.changes.outputs.ai == 'true'
     name: AI 서비스 테스트
     runs-on: ubuntu-latest
     steps:
@@ -83,3 +119,43 @@ jobs:
       - name: 테스트
         working-directory: ai
         run: pytest -q
+
+  # ★ 프론트도 CI 에 넣는다. (#99)
+  #   지금까지 프론트는 빌드조차 검증되지 않았다. 깨진 채로 머지돼도 알 수 없었고,
+  #   실제로 배포할 때가 되어서야 알게 된다. 그때가 제일 나쁘다.
+  frontend-build:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    name: 프론트 빌드
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # 팀 Dockerfile 과 같은 버전. 다른 버전에서는 vite-plugin-vue-devtools 가
+          # 설정 로드 시점에 죽는다(Node 25 의 localStorage 는 객체인데 getItem 이 없다).
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: 의존성 설치
+        working-directory: frontend
+        run: npm ci
+
+      - name: 빌드
+        working-directory: frontend
+        run: npm run build
+
+      - name: 산출물에 죽은 주소가 남았는지
+        working-directory: frontend
+        run: |
+          # i13c205 는 없어진 SSAFY 서버다. 새로 들어오면 막는다.
+          # DocumentSummaryView 의 2곳은 우리 백엔드에 없는 경로라 의도적으로 남겼다.
+          COUNT=$(grep -roh "i13c205" dist/ 2>/dev/null | wc -l)
+          echo "죽은 주소 등장: $COUNT 회 (허용 상한 20)"
+          if [ "$COUNT" -gt 20 ]; then
+            echo "::error::없어진 SSAFY 서버 주소가 늘었다. 새 하드코딩을 확인할 것."
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,3 +149,84 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
+
+  # ★ 프론트 배포. (#99)
+  #
+  #   지금까지 손으로 올렸다. master 에 프론트를 고쳐 push 해도
+  #   서버의 /var/www/edumeet 은 그대로였다 - "머지했는데 왜 안 바뀌지" 가 된다.
+  #
+  #   백엔드와 분리한 이유: 프론트는 정적 파일이라 컨테이너가 필요 없고,
+  #   빌드 산출물만 nginx 아래로 옮기면 된다. 이미지를 굽지 않으니 훨씬 빠르다.
+  deploy-frontend:
+    name: 프론트 배포
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'      # 팀 Dockerfile 과 같은 버전
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: 빌드
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+          # Vite 는 빌드 시점에 .env.production 값을 코드에 박는다.
+          # 도메인이 실제로 들어갔는지 여기서 확인한다 - 안 들어갔으면
+          # 배포는 성공하는데 화면에서 API 호출만 전부 실패한다.
+          grep -q "api.studywithtymee.com" dist/assets/*.js \
+            || { echo "::error::빌드 산출물에 API 도메인이 없다. .env.production 확인"; exit 1; }
+
+      - name: 산출물 압축
+        working-directory: frontend
+        run: tar -C dist -czf /tmp/fe-dist.tgz .
+
+      - name: 서버로 전송
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          source: "/tmp/fe-dist.tgz"
+          target: "/tmp"
+          strip_components: 1
+
+      - name: 원자적 교체
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            sudo rm -rf /var/www/edumeet.new
+            sudo mkdir -p /var/www/edumeet.new
+            sudo tar -C /var/www/edumeet.new -xzf /tmp/fe-dist.tgz
+
+            # 반쯤 복사된 상태가 서비스되지 않게 mv 로 바꾼다.
+            sudo rm -rf /var/www/edumeet.old
+            [ -d /var/www/edumeet ] && sudo mv /var/www/edumeet /var/www/edumeet.old
+            sudo mv /var/www/edumeet.new /var/www/edumeet
+
+            # ★ SELinux. 규칙은 등록돼 있으므로 restorecon 만 하면 된다.
+            #   이게 없으면 파일 권한은 멀쩡한데 nginx 가 403 을 낸다.
+            sudo restorecon -R /var/www/edumeet
+
+            rm -f /tmp/fe-dist.tgz
+            test -f /var/www/edumeet/index.html
+            echo "배치 완료: $(sudo find /var/www/edumeet -type f | wc -l) 파일"
+
+      - name: 실제로 뜨는지 확인
+        run: |
+          for i in $(seq 1 10); do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 https://studywithtymee.com/ || echo 000)
+            [ "$CODE" = "200" ] && { echo "확인: 200"; exit 0; }
+            echo "  ${i}회차: $CODE"; sleep 6
+          done
+          echo "::error::배포 후 사이트가 200 을 주지 않는다"
+          exit 1

--- a/docs/ops/01-cicd-and-deploy.md
+++ b/docs/ops/01-cicd-and-deploy.md
@@ -304,3 +304,69 @@ MANAGEMENT_BIND=10.0.0.11
         labels:
           service: edumeet
 ```
+
+---
+
+## ★ 모노레포가 되면서 절반만 자동화돼 있었다 (2026-08-24, #99)
+
+프론트·AI 를 합친 뒤 상태를 세어 보니 이랬다.
+
+| | CI | Deploy |
+|---|---|---|
+| backend | ✅ | ✅ |
+| ai | ✅ | ❌ |
+| **frontend** | **❌ 빌드조차 안 함** | **❌ 손으로 올림** |
+
+**프론트를 손으로 올리고 있었다.** master 에 프론트를 고쳐 push 해도
+서버의 `/var/www/edumeet` 은 그대로다 — *"머지했는데 왜 안 바뀌지"* 가 된다.
+
+그리고 **경로 필터가 없어서** 문서만 고쳐도 백엔드 전체를 빌드·테스트했다.
+
+### 경로 필터를 `on:` 이 아니라 잡 단위로 걸었다
+
+```yaml
+on:
+  push:
+    paths: ['backend/**']     # ← 이렇게 하지 않는다
+```
+
+**워크플로의 `on:` 에 걸면 "돌지 않은 잡" 이 pending 으로 남는다.**
+필수 체크로 지정했다면 PR 이 영원히 머지되지 않는다.
+
+잡 단위로 나누면 해당 없는 잡은 **skip** 되고 체크는 초록으로 끝난다.
+
+```yaml
+jobs:
+  changes:                      # 무엇이 바뀌었는지 먼저 판별
+    outputs: {backend, frontend, ai}
+  build-and-test:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+```
+
+### 빌드 산출물을 검증한다
+
+Vite 는 **빌드 시점에** `.env.production` 값을 코드에 박는다.
+값이 안 들어가도 빌드는 성공하고, **배포도 성공하고, 화면에서 API 호출만 전부 실패한다.**
+
+```bash
+grep -q "api.studywithtymee.com" dist/assets/*.js || exit 1
+```
+
+죽은 SSAFY 주소(`i13c205`)가 늘어나는 것도 막는다.
+(`DocumentSummaryView` 의 2곳은 우리 백엔드에 없는 경로라 의도적으로 남겨 둔 것이므로 상한을 둔다)
+
+### 배포는 원자적으로, SELinux 는 잊지 않게
+
+```bash
+sudo mv /var/www/edumeet.new /var/www/edumeet   # 반쯤 복사된 상태가 서비스되지 않게
+sudo restorecon -R /var/www/edumeet             # 없으면 파일 권한은 멀쩡한데 403
+```
+
+배포 뒤 **실제로 200 을 주는지 확인**한다. 배포 성공과 서비스 정상은 다른 말이다.
+
+## 아직 자동화되지 않은 것
+
+- **AI 서비스 배포.** 테스트는 CI 에서 돌지만 서버에 올리는 경로가 없다.
+  `/STT/{class_id}` 를 부르는 곳이 아직 없어서 급하지 않다
+- 롤백. 지금은 이전 이미지 태그로 수동 재배포한다


### PR DESCRIPTION
Closes #99

합친 뒤 세어 보니 **절반만 자동화**돼 있었습니다.

| | CI | Deploy |
|---|---|---|
| backend | ✅ | ✅ |
| ai | ✅ | ❌ |
| **frontend** | **❌** | **❌ 손으로 올림** |

## ★ 경로 필터를 `on:` 이 아니라 잡 단위로

```yaml
on:
  push:
    paths: ['backend/**']     # ← 이렇게 하지 않습니다
```

**워크플로의 `on:` 에 걸면 "돌지 않은 잡" 이 pending 으로 남습니다.**
필수 체크로 지정했다면 **PR 이 영원히 머지되지 않습니다.**

잡 단위로 나누면 해당 없는 잡은 **skip** 되고 체크는 초록으로 끝납니다.

```yaml
jobs:
  changes:
    outputs: {backend, frontend, ai}
  build-and-test:
    needs: changes
    if: needs.changes.outputs.backend == 'true'
```

## 프론트 빌드를 CI 에 넣습니다

지금까지 프론트는 **빌드조차 검증되지 않았습니다.**
깨진 채 머지돼도 알 수 없고, **배포할 때가 되어서야 압니다.** 그때가 제일 나쁩니다.

## ★ 빌드 산출물을 검증합니다

**Vite 는 빌드 시점에 `.env.production` 값을 코드에 박습니다.**
값이 안 들어가도 **빌드는 성공하고, 배포도 성공하고, 화면에서 API 호출만 전부 실패합니다.**

```bash
grep -q "api.studywithtymee.com" dist/assets/*.js || exit 1
```

죽은 SSAFY 주소(`i13c205`)가 늘어나는 것도 막습니다.
(`DocumentSummaryView` 의 2곳은 백엔드에 없는 경로라 의도적으로 남긴 것이므로 상한을 둡니다)

## 배포는 원자적으로 + `restorecon`

```bash
sudo mv /var/www/edumeet.new /var/www/edumeet   # 반쯤 복사된 상태가 서비스되지 않게
sudo restorecon -R /var/www/edumeet             # 없으면 권한은 멀쩡한데 403
```

그리고 배포 뒤 **실제로 200 을 주는지 확인**합니다.
**배포 성공과 서비스 정상은 다른 말입니다.**

## 아직 자동화되지 않은 것

- **AI 서비스 배포.** 테스트는 CI 에서 돌지만 서버에 올리는 경로가 없습니다.
  `/STT/{class_id}` 를 부르는 곳이 아직 없어 급하지 않습니다
- 롤백. 지금은 이전 이미지 태그로 수동 재배포합니다