### PR TITLE
fix: ssh-action 에 없는 입력을 지운다 (#99)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,10 @@ jobs:
           host: ${{ secrets.OCI_HOST }}
           username: ${{ secrets.OCI_USER }}
           key: ${{ secrets.OCI_SSH_KEY }}
-          script_stop: true    # 한 줄이라도 실패하면 즉시 중단
+          # script_stop 은 ssh-action@v1 에 없는 입력이라 조용히 무시된다.
+          # (실행 로그에 Unexpected input(s) 경고로만 남는다)
+          # 중간 실패에서 멈추는 것은 아래 set -euo pipefail 이 한다 -
+          # 그동안 그게 실제로 일을 하고 있었고 script_stop 은 장식이었다.
           script: |
             set -euo pipefail
             cd ~/edumeet
@@ -203,7 +206,9 @@ jobs:
           host: ${{ secrets.OCI_HOST }}
           username: ${{ secrets.OCI_USER }}
           key: ${{ secrets.OCI_SSH_KEY }}
-          script_stop: true
+          # script_stop 은 ssh-action@v1 에 없는 입력이다. 주면 조용히 무시된다.
+          # (워크플로 실행 로그에 Unexpected input(s) 경고로만 남는다)
+          # 중간 실패에서 멈추는 것은 스크립트 안의 set -euo pipefail 이 한다.
           script: |
             set -euo pipefail
             sudo rm -rf /var/www/edumeet.new


### PR DESCRIPTION
배포 로그의 경고에서 나왔습니다.

```
Unexpected input(s) 'script_stop', valid inputs are ['host', 'port', ...]
```

`script_stop` 은 `appleboy/ssh-action@v1` 에 **없는 입력**입니다. 주면 조용히 무시됩니다.

## 실제 동작에는 문제가 없었습니다

두 스크립트 다 `set -euo pipefail` 을 갖고 있고 **그게 일을 하고 있었습니다.**
`script_stop` 은 장식이었습니다.

## 문제는 주석이 사실과 다르다는 것입니다

```yaml
script_stop: true    # 한 줄이라도 실패하면 즉시 중단   ← 이 줄은 아무것도 안 한다
```

**다음 사람이 그 줄을 믿고 `set -e` 를 지우면 그때 조용히 깨집니다.**
"동작은 하는데 이유가 틀린" 코드가 제일 오래 삽니다.