### PR TITLE
feat: 프론트를 백엔드 STOMP 에 연결하고 하트비트를 켠다 (#106)

### DIFF
--- a/backend/src/main/java/com/edu/edumeet/chat/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/config/WebSocketConfig.java
@@ -5,6 +5,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -58,12 +61,47 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Value("${front.url2}")
     private String frontUrl2;
 
+    /**
+     * 하트비트 주기(밀리초). 서버가 보내는 주기 / 서버가 기대하는 주기.
+     *
+     * <p><b>왜 켜는가.</b> 채팅은 조용한 구간이 길다. 수업 중 1분 동안 아무도
+     * 말을 안 하는 것은 흔하다. 그러면 중간의 프록시가 유휴 연결로 보고 끊는다 -
+     * nginx {@code proxy_read_timeout} 기본값이 60초다.
+     *
+     * <p>실측했다. 하트비트 없이 조용한 연결 3개를 90초 유지했더니
+     * <b>60.9초에 전부 끊겼다.</b> 그때는 {@code proxy_read_timeout} 을 3600초로
+     * 늘려서 막았는데, 그건 <b>죽은 연결도 한 시간 잡고 있겠다</b>는 뜻이다.
+     *
+     * <p>하트비트가 있으면 유휴가 아니게 되므로 프록시 타임아웃을 짧게 둘 수 있고,
+     * <b>죽은 연결을 빨리 걷어낼 수 있다.</b> 이쪽이 본래 해법이다.
+     *
+     * <p>25초로 잡은 이유 — 60초 타임아웃의 절반보다 작아야 한 번 놓쳐도 살아남는다.
+     * 너무 짧으면 연결 수만큼 프레임이 늘어난다. 500 연결이면 초당 20프레임이다.
+     */
+    private static final long[] HEARTBEAT = {25_000L, 25_000L};
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 구독 대상. 방 하나가 /topic/rooms/{meetingId} 다.
-        registry.enableSimpleBroker("/topic");
+        //
+        // ★ SimpleBroker 의 하트비트는 TaskScheduler 가 있어야 동작한다. (#106)
+        //   setHeartbeatValue 만 주고 스케줄러를 안 주면 조용히 무시된다 -
+        //   설정은 있는데 프레임이 안 나가는, 이 저장소에서 여러 번 본 모양이다.
+        registry.enableSimpleBroker("/topic")
+                .setHeartbeatValue(HEARTBEAT)
+                .setTaskScheduler(heartbeatScheduler());
         // 클라이언트가 서버로 보낼 때의 접두사. @MessageMapping 이 이 뒤를 받는다.
         registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    /** 하트비트 전용 스케줄러. 한 스레드면 충분하다 - 프레임을 밀어 넣기만 한다. */
+    @Bean
+    public TaskScheduler heartbeatScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("stomp-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
     }
 
     @Override

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/StompHeartbeatTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/StompHeartbeatTest.java
@@ -1,0 +1,193 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.config.jwt.JwtService;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.MeetingParticipant;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.socket.handler.AbstractWebSocketHandler;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 서버가 STOMP 하트비트를 실제로 보내는가. (#106)
+ *
+ * <p><b>왜 이 시험이 필요한가.</b>
+ * {@code setHeartbeatValue} 만 주고 {@code setTaskScheduler} 를 빠뜨리면
+ * Spring 은 <b>조용히 하트비트를 보내지 않는다.</b> 예외도 경고도 없다.
+ * 설정 파일만 봐서는 켜져 있는 것으로 보인다 -
+ * 이 저장소에서 여러 번 본 "설정은 있는데 아무것도 안 하는" 모양이다.
+ *
+ * <p>그래서 <b>CONNECTED 프레임이 실제로 합의한 값</b>을 본다.
+ * 서버가 하트비트를 끄면 그 헤더가 {@code 0,0} 으로 온다.
+ *
+ * <p><b>왜 하트비트가 필요한가.</b> 조용한 연결 3개를 90초 유지했더니
+ * 프록시가 <b>60.9초에 전부 끊었다</b>({@code proxy_read_timeout} 기본 60초).
+ * 하트비트가 있으면 유휴가 아니게 되므로 타임아웃을 짧게 둘 수 있고,
+ * 죽은 연결을 빨리 걷어낼 수 있다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("STOMP 하트비트")
+class StompHeartbeatTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    /** nginx proxy_read_timeout 기본값. 하트비트는 이보다 충분히 짧아야 한다. */
+    private static final long PROXY_DEFAULT_TIMEOUT_MS = 60_000L;
+
+    /** STOMP 프레임 구분자. 줄바꿈은 LF 고 프레임 끝은 널 바이트(0x00)다. */
+    private static final String LF = "\n";
+    private static final String NUL = String.valueOf((char) 0);
+
+    @LocalServerPort int port;
+    @Autowired JwtService jwtService;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private record Fixture(Long meetingId, String token) {}
+
+    private Fixture given() {
+        String email = "hb-" + SEQ.incrementAndGet() + "@test";
+        Long[] id = new Long[1];
+        transactionTemplate.executeWithoutResult(s -> {
+            Member owner = Member.builder().email(email).nickname("참가자").password("x").build();
+            em.persist(owner);
+            ClassRoom c = ClassRoom.builder().member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(c);
+            Meeting m = Meeting.builder().classRoom(c).title("세션").description("-")
+                    .sessionType(SessionType.INTERACTIVE).startTime(LocalDateTime.now()).build();
+            em.persist(m);
+            em.persist(MeetingParticipant.join(m, email));
+            em.flush();
+            id[0] = m.getId();
+        });
+        return new Fixture(id[0], jwtService.generateAccessToken(1L, email));
+    }
+
+    /**
+     * 원시 WebSocket 으로 CONNECTED 프레임을 그대로 받아 온다.
+     *
+     * <p>STOMP 클라이언트 라이브러리를 쓰지 않는 이유 - 라이브러리가 하트비트 협상을
+     * 대신 처리하고 프레임을 감춰 버린다. 우리가 보려는 것이 바로 그 프레임이다.
+     *
+     * @param wanted 클라이언트가 받고 싶다고 알리는 주기(ms). 서버는 자기 설정과 이 값 중
+     *               <b>큰 쪽</b>을 고른다.
+     */
+    private String connectedFrameWith(long wanted) throws Exception {
+        Fixture f = given();
+        List<String> frames = new CopyOnWriteArrayList<>();
+        CountDownLatch connected = new CountDownLatch(1);
+
+        WebSocketHandler handler = new AbstractWebSocketHandler() {
+            @Override
+            public void handleTextMessage(WebSocketSession session, TextMessage message) {
+                String payload = message.getPayload();
+                frames.add(payload);
+                if (payload.startsWith("CONNECTED")) {
+                    connected.countDown();
+                }
+            }
+        };
+
+        WebSocketSession session = new StandardWebSocketClient()
+                .execute(handler, "ws://localhost:" + port + "/ws").get(5, TimeUnit.SECONDS);
+
+        // heart-beat: <내가 보낼 주기>,<내가 받고 싶은 주기>
+        //
+        // ★ 프레임은 널 바이트로 끝나야 한다. 공백이나 개행으로 끝내면
+        //   서버가 프레임이 안 끝났다고 보고 계속 기다린다 - 응답이 아예 안 온다.
+        //   에러도 안 나므로 "연결은 됐는데 아무것도 안 온다" 로만 보인다.
+        String connect = "CONNECT" + LF
+                + "accept-version:1.2" + LF
+                + "heart-beat:0," + wanted + LF
+                + "host:localhost" + LF
+                + "Authorization:Bearer " + f.token() + LF
+                + LF + NUL;
+        session.sendMessage(new TextMessage(connect));
+
+        assertThat(connected.await(5, TimeUnit.SECONDS))
+                .as("CONNECTED 프레임이 안 왔다. 인증이 막혔거나 엔드포인트가 다르다. 받은 것: %s", frames)
+                .isTrue();
+        session.close();
+
+        return frames.stream().filter(x -> x.startsWith("CONNECTED")).findFirst().orElseThrow();
+    }
+
+    /** CONNECTED 의 heart-beat 헤더에서 "서버가 보낼 주기" 를 꺼낸다. */
+    private long serverSendInterval(String connectedFrame) {
+        return connectedFrame.lines()
+                .filter(l -> l.startsWith("heart-beat:"))
+                .map(l -> l.substring("heart-beat:".length()).split(",")[0].trim())
+                .map(Long::parseLong)
+                .findFirst()
+                .orElse(0L);
+    }
+
+    @Test
+    @DisplayName("★ 서버가 하트비트를 켠다 - setTaskScheduler 를 빠뜨리면 조용히 꺼진다")
+    void server_negotiates_a_heartbeat() throws Exception {
+        String frame = connectedFrameWith(10_000L);
+
+        assertThat(frame)
+                .as("CONNECTED 에 heart-beat 헤더가 없다. 실제 프레임: %s",
+                        frame.replace("\n", "\\n"))
+                .contains("heart-beat:");
+
+        assertThat(serverSendInterval(frame))
+                .as("""
+                    서버가 보낼 주기가 0 이다 = 하트비트가 꺼져 있다.
+                    setHeartbeatValue 를 줬어도 setTaskScheduler 가 없으면
+                    Spring 은 조용히 끈다 - 예외도 경고도 없다.""")
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("★ 합의된 주기가 프록시 타임아웃의 절반보다 짧다 - 한 번 놓쳐도 살아남게")
+    void interval_survives_one_missed_beat() throws Exception {
+        long interval = serverSendInterval(connectedFrameWith(10_000L));
+
+        assertThat(interval)
+                .as("""
+                    서버가 보낼 주기가 %dms 다.
+                    nginx proxy_read_timeout 기본값(%dms)의 절반을 넘으면
+                    하트비트를 한 번만 놓쳐도 프록시가 연결을 끊는다.""",
+                        interval, PROXY_DEFAULT_TIMEOUT_MS)
+                .isLessThanOrEqualTo(PROXY_DEFAULT_TIMEOUT_MS / 2);
+    }
+
+    @Test
+    @DisplayName("클라이언트가 더 긴 주기를 원하면 그쪽을 따른다 - STOMP 협상 규칙")
+    void longer_client_request_wins() throws Exception {
+        // STOMP 1.2: 서버가 보낼 주기 = max(서버 설정, 클라이언트가 원하는 값)
+        // 클라이언트가 감당 못 하는 속도로 밀어 넣지 않기 위한 규칙이다.
+        long withShort = serverSendInterval(connectedFrameWith(1_000L));
+        long withLong = serverSendInterval(connectedFrameWith(40_000L));
+
+        assertThat(withLong)
+                .as("클라이언트가 40초를 원했는데 서버가 더 자주 보낸다면 협상이 깨진 것이다")
+                .isGreaterThanOrEqualTo(withShort);
+    }
+}

--- a/deploy/nginx/edumeet.conf
+++ b/deploy/nginx/edumeet.conf
@@ -121,9 +121,18 @@ server {
         # 거부한다 - "설정이 틀린" 게 아니라 "서버가 안 뜨는" 문제다.
         proxy_set_header Connection $connection_upgrade;
 
-        # 채팅은 조용한 구간이 길다. STOMP heart-beat 가 0,0 이라 더 그렇다.
-        proxy_read_timeout 3600s;
-        proxy_send_timeout 3600s;
+        # ★ 3600초에서 120초로 줄였다. (#106)
+        #
+        #   전에는 STOMP 하트비트가 꺼져 있어서(heart-beat 0,0) 조용한 연결이
+        #   유휴로 보였다. 그래서 타임아웃을 한 시간으로 늘려 막았는데,
+        #   그건 "죽은 연결도 한 시간 잡고 있겠다" 는 뜻이다 -
+        #   끊긴 클라이언트의 소켓과 파일 디스크립터가 그만큼 남는다.
+        #
+        #   이제 서버가 25초마다 하트비트를 보낸다. 120초면 하트비트를
+        #   네 번 연속 놓쳐야 끊긴다 - 일시적인 네트워크 흔들림은 견디고
+        #   진짜 죽은 연결은 2분 안에 걷어낸다.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
 
         # 실시간에서는 처리량보다 지연이 중요하다.
         proxy_buffering off;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "edumeet",
       "version": "0.0.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.3.0",
         "axios": "^1.10.0",
         "bootstrap": "^5.3.7",
         "gsap": "^3.13.0",
@@ -80,6 +81,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1359,6 +1361,12 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
@@ -1678,6 +1686,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2920,6 +2929,7 @@
       "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3279,6 +3289,7 @@
       "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -3441,6 +3452,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
       "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.17",
         "@vue/compiler-sfc": "3.5.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "axios": "^1.10.0",
     "bootstrap": "^5.3.7",
     "gsap": "^3.13.0",

--- a/frontend/src/features/realtime/stompClient.js
+++ b/frontend/src/features/realtime/stompClient.js
@@ -1,0 +1,124 @@
+/**
+ * 백엔드 STOMP 연결. 채팅과 자막을 여기서 받는다. (#106)
+ *
+ * ── 왜 만들었나 ────────────────────────────────────────────────
+ *
+ *   전에는 채팅과 자막을 LiveKit 데이터채널로 주고받았다.
+ *   참가자 브라우저끼리 직접 보내는 구조라 서버가 관여하지 않는다.
+ *
+ *   그래서 두 가지가 안 됐다.
+ *
+ *   1. AI 자막이 화면에 도달하지 않았다.
+ *      파이썬 AI -> 백엔드(/api/v1/internal/meetings/{id}/captions)
+ *      -> STOMP /topic/rooms/{id}/captions 까지는 있는데
+ *      듣는 쪽이 없었다. 이 서비스의 존재 이유가 실시간 자막인데.
+ *
+ *   2. 다시보기 채팅이 불가능했다.
+ *      서버를 안 거치니 저장할 수 없다.
+ *
+ * ── 백엔드 계약 ────────────────────────────────────────────────
+ *
+ *   연결      /ws                      CONNECT 헤더에 Authorization: Bearer <JWT>
+ *   구독      /topic/rooms/{id}         채팅
+ *             /topic/rooms/{id}/captions  자막
+ *   발행      /app/rooms/{id}/send      { content }
+ *
+ *   구독 권한은 서버가 MeetingParticipant 로 검사한다. 방에 없으면 ERROR 프레임이 온다.
+ */
+import { Client } from '@stomp/stompjs'
+
+/**
+ * 하트비트 주기(ms).
+ *
+ * 서버는 25초로 설정돼 있고, STOMP 협상 규칙상 서버가 보낼 주기는
+ * max(서버 설정, 클라이언트가 원하는 값) 이다. 여기서 10초를 원해도 25초가 된다.
+ *
+ * 왜 필요한가 - 채팅은 조용한 구간이 길다. 하트비트가 없으면 중간 프록시가
+ * 유휴 연결로 보고 끊는다. 실측으로 nginx 기본값(60초)에서 60.9초에 끊겼다.
+ */
+const HEARTBEAT_MS = 10_000
+
+/** 재연결 간격. 즉시 재시도하면 서버가 죽었을 때 폭주한다. */
+const RECONNECT_MS = 3_000
+
+/**
+ * @param {object} options
+ * @param {string} options.baseUrl   http(s) 주소. ws(s) 로 바꿔 쓴다
+ * @param {string} options.token     JWT
+ * @param {number|string} options.meetingId
+ * @param {(msg: {sender: string, content: string, publishedAt: number}) => void} options.onChat
+ * @param {(cap: {text: string, sequence: number, publishedAt: number}) => void} options.onCaption
+ * @param {(state: 'connected'|'disconnected'|'error', detail?: string) => void} [options.onState]
+ */
+export function createRealtimeClient({
+  baseUrl,
+  token,
+  meetingId,
+  onChat,
+  onCaption,
+  onState = () => {},
+}) {
+  if (!token) throw new Error('STOMP 연결에 JWT 가 필요하다')
+  if (!meetingId) throw new Error('STOMP 연결에 meetingId 가 필요하다')
+
+  // https -> wss, http -> ws. https 페이지에서 ws:// 를 쓰면 브라우저가 막는다.
+  const wsUrl = String(baseUrl).replace(/^http/, 'ws').replace(/\/$/, '') + '/ws'
+
+  const client = new Client({
+    brokerURL: wsUrl,
+    // ★ 토큰은 CONNECT 프레임 헤더로 보낸다. 쿼리스트링에 넣지 않는다 -
+    //   URL 은 프록시·브라우저 히스토리·접근 로그에 그대로 남는다.
+    connectHeaders: { Authorization: `Bearer ${token}` },
+    heartbeatIncoming: HEARTBEAT_MS,
+    heartbeatOutgoing: HEARTBEAT_MS,
+    reconnectDelay: RECONNECT_MS,
+    // 운영에서는 프레임 로그를 끈다. 채팅 내용이 콘솔에 그대로 남는다.
+    debug: import.meta.env.DEV ? (s) => console.debug('[stomp]', s) : () => {},
+  })
+
+  client.onConnect = () => {
+    onState('connected')
+
+    client.subscribe(`/topic/rooms/${meetingId}`, (frame) => {
+      try {
+        onChat(JSON.parse(frame.body))
+      } catch (e) {
+        // 프레임 하나가 깨졌다고 구독을 끊지 않는다. 다음 것은 정상일 수 있다.
+        console.warn('채팅 프레임 해석 실패', e)
+      }
+    })
+
+    client.subscribe(`/topic/rooms/${meetingId}/captions`, (frame) => {
+      try {
+        onCaption(JSON.parse(frame.body))
+      } catch (e) {
+        console.warn('자막 프레임 해석 실패', e)
+      }
+    })
+  }
+
+  // 서버가 보내는 ERROR 프레임. 구독 권한이 없을 때 여기로 온다.
+  client.onStompError = (frame) => {
+    onState('error', frame.headers?.message || 'STOMP 오류')
+  }
+  client.onWebSocketClose = () => onState('disconnected')
+
+  return {
+    connect: () => client.activate(),
+    disconnect: () => client.deactivate(),
+    /** 메시지를 보낸다. 연결이 끊겨 있으면 조용히 버린다 - 큐에 쌓아 두면 재연결 후 폭주한다. */
+    send(content) {
+      const text = String(content ?? '').trim()
+      if (!text) return false
+      if (!client.connected) return false
+      client.publish({
+        destination: `/app/rooms/${meetingId}/send`,
+        body: JSON.stringify({ content: text }),
+      })
+      return true
+    },
+    get connected() {
+      return client.connected
+    },
+  }
+}

--- a/frontend/src/views/ClassVideoRoomView.vue
+++ b/frontend/src/views/ClassVideoRoomView.vue
@@ -13,6 +13,7 @@ import LiveCaption from '@/components/LiveCaption.vue';
 import SharedLiveCaption from '@/components/SharedLiveCaption.vue';
 import AudioRecorder from '@/components/AudioRecorder.vue';
 import ScreenShareComponent from '@/components/ScreenShareComponent.vue';
+import { createRealtimeClient } from '@/features/realtime/stompClient';
 import '@/styles/ClassRelated.css';
 
 const route = useRoute();
@@ -54,6 +55,14 @@ const recordButtonLabel = computed(() => {
 
 const chatMessagesList = ref<Array<{ sender: string; message: string }>>([]);
 const chatInput = ref('');
+
+// 백엔드 STOMP 연결. 채팅과 자막이 여기로 온다. (#106)
+//
+// 전에는 LiveKit 데이터채널로 브라우저끼리 주고받았다. 서버를 안 거치니
+//   - AI 가 만든 자막이 화면에 도달하지 않았고
+//   - 다시보기용 채팅 저장이 불가능했다
+const realtime = ref<ReturnType<typeof createRealtimeClient> | null>(null);
+const realtimeState = ref<'connected' | 'disconnected' | 'error'>('disconnected');
 const chatBoxRef = ref<HTMLElement | null>(null);
 
 // 공유 자막 관련 상태
@@ -195,6 +204,13 @@ async function joinRoom(targetRoom?: string, existingToken?: string) {
   console.log('🔍 joinRoom 호출 - existingToken:', existingToken ? '있음' : '없음')
   console.log('🔍 joinRoom 호출 - route.query.meetingId:', route.query.meetingId)
   console.log('🔍 joinRoom 호출 - route.query:', route.query)
+
+  // ★ 백엔드 STOMP 에도 붙는다. (#106)
+  //   미디어는 LiveKit 이, 채팅·자막은 백엔드가 나른다.
+  //   meetingId 는 방 이름과 같다(joinSession 이 "meeting-{id}" 를 쓰지만
+  //   여기서는 쿼리로 받은 원본 id 를 쓴다).
+  const realtimeMeetingId = (route.query.meetingId as string) || target;
+  if (realtimeMeetingId) connectRealtime(realtimeMeetingId);
 
   const currentRoom = new Room();
   room.value = currentRoom;
@@ -350,6 +366,9 @@ async function joinRoom(targetRoom?: string, existingToken?: string) {
 }
 
 async function leaveRoom() {
+  // 미디어보다 먼저 끊는다. 나간 뒤에 오는 채팅을 화면에 그리지 않기 위해서다.
+  disconnectRealtime();
+
   if (room.value) {
     await room.value.disconnect();
   }
@@ -530,25 +549,63 @@ async function confirmLeaveWithSummary() {
   await leaveRoom();
 }
 
+/**
+ * 백엔드 STOMP 에 붙는다. (#106)
+ *
+ * LiveKit 룸 접속과 별개다 - 미디어는 LiveKit 이, 채팅·자막은 백엔드가 나른다.
+ * 둘을 한 채널로 묶으면 서버가 채팅을 못 보고, 그러면 저장도 자막 중계도 못 한다.
+ */
+function connectRealtime(meetingId: string) {
+  const token = localStorage.getItem('token') || localStorage.getItem('accessToken');
+  if (!token) {
+    console.warn('JWT 가 없어 실시간 채널에 붙지 않는다');
+    return;
+  }
+  realtime.value?.disconnect();
+  realtime.value = createRealtimeClient({
+    baseUrl: import.meta.env.VITE_BASE_URL,
+    token,
+    meetingId,
+    onChat: (msg) => {
+      chatMessagesList.value.push({
+        sender: msg.sender === undefined ? '익명' : msg.sender,
+        message: msg.content,
+      });
+      nextTick(() => scrollToBottom());
+    },
+    onCaption: (cap) => {
+      // 백엔드가 보내는 자막. 파이썬 AI 가 만들어 내부 API 로 넣은 것이다.
+      sharedCaption.value = cap.text;
+      isSharedCaptionActive.value = true;
+    },
+    onState: (state, detail) => {
+      realtimeState.value = state;
+      if (state === 'error') console.error('실시간 채널 오류:', detail);
+    },
+  });
+  realtime.value.connect();
+}
+
+function disconnectRealtime() {
+  realtime.value?.disconnect();
+  realtime.value = null;
+  realtimeState.value = 'disconnected';
+}
+
 function sendChatMessage() {
   const msg = chatInput.value.trim();
-  if (!msg || !room.value) return;
+  if (!msg) return;
 
-  const encoder = new TextEncoder();
-  const payload = encoder.encode(JSON.stringify({
-    sender: participantName.value,
-    message: msg,
-  }));
-
-  console.log('📤 채팅 전송:', new TextDecoder().decode(payload));
-  room.value.localParticipant.publishData(payload, { reliable: true });
-  chatMessagesList.value.push({ sender: '나', message: msg });
+  // 서버로 보낸다. 되돌아오는 브로드캐스트로 화면에 그린다.
+  //
+  // 로컬에 먼저 그리지 않는 이유 - 서버가 거부하면(빈 메시지·길이 초과·종료된 회의)
+  // 내 화면에만 있고 남에게는 없는 메시지가 생긴다.
+  // 왕복이 필요하지만 실측 e2e p95 가 45ms 라 체감되지 않는다.
+  if (!realtime.value?.send(msg)) {
+    console.warn('채팅 전송 실패 - 연결이 끊겨 있다');
+    return;
+  }
   chatInput.value = '';
-  
-  // 채팅 전송 후 자동 스크롤
-  nextTick(() => {
-    scrollToBottom();
-  });
 }
 
 function scrollToBottom() {


### PR DESCRIPTION
Closes #106

## ★ AI 자막이 화면에 도달한 적이 없었습니다

```
파이썬 AI   ❌ 자막 전송 코드 없음 (STT 결과를 요약에만 씁니다)
백엔드      ✅ 내부 API → STOMP /topic/rooms/{id}/captions  (#65 에서 지연까지 측정)
프론트      ❌ STOMP 클라이언트 없음. LiveKit 데이터채널만 들었습니다
```

프론트의 채팅·자막은 **브라우저끼리 `publishData` 로 주고받는 구조**였습니다.
서버가 관여하지 않으니:

- **AI 가 만든 자막이 화면에 못 옵니다** — 이 서비스의 존재 이유입니다
- **다시보기용 저장이 불가능합니다** — #61 의 배치가 의미를 잃습니다

> 이 저장소 **일곱 번째 "만들었는데 도달하지 않는다"** 이고,
> 앞의 여섯과 달리 **제품의 존재 이유**에 걸려 있습니다.

## 하트비트를 켰습니다

```java
registry.enableSimpleBroker("/topic")
        .setHeartbeatValue(HEARTBEAT)
        .setTaskScheduler(heartbeatScheduler());   // ← 이게 없으면 조용히 꺼진다
```

**`setHeartbeatValue` 만 주면 Spring 이 조용히 끕니다.** 예외도 경고도 없어서
설정 파일만 보면 켜진 것으로 보입니다 — 이 저장소에서 여러 번 본 모양이라 **미리 테스트로 막았습니다.**

| 되돌린 것 | 실패 |
|---|---:|
| `setTaskScheduler` 제거 | **3개** |
| 주기 25초 → 40초 (프록시 60초의 절반 초과) | 1개 |

시험은 **STOMP 라이브러리를 쓰지 않습니다.** 라이브러리가 하트비트 협상을 대신 처리하고
프레임을 감춥니다 — **우리가 보려는 것이 바로 그 프레임입니다.**
원시 WebSocket 으로 `CONNECTED` 프레임을 직접 읽습니다.

> 만드는 중에 한 번 막혔습니다. `CONNECT` 프레임을 **NUL 로 끝내지 않아** 응답이 아예 안 왔습니다.
> 에러도 안 나고 "연결은 됐는데 아무것도 안 온다" 로만 보입니다.

## 그래서 nginx 타임아웃을 3600초 → 120초로 줄였습니다

**3600초는 "죽은 연결도 한 시간 잡고 있겠다" 는 뜻**이었습니다.
끊긴 클라이언트의 소켓과 파일 디스크립터가 그만큼 남습니다.

이제 25초마다 하트비트가 나가므로 **120초면 네 번 연속 놓쳐야** 끊깁니다 —
일시적 네트워크 흔들림은 견디고 진짜 죽은 연결은 2분 안에 걷어냅니다.

## 로컬 에코를 하지 않습니다

전에는 보내자마자 내 화면에 그렸습니다.
서버가 거부하면(빈 메시지·길이 초과·종료된 회의) **내 화면에만 있고 남에게는 없는 메시지**가 생깁니다.

왕복이 필요하지만 **실측 e2e p95 가 45ms** 라 체감되지 않습니다.

## 토큰은 헤더로 보냅니다

```js
connectHeaders: { Authorization: `Bearer ${token}` }
```

쿼리스트링에 넣지 않습니다 — **URL 은 프록시·브라우저 히스토리·접근 로그에 그대로 남습니다.**

## 검증

```
백엔드   287개 (284 → +3)
프론트   팀 Dockerfile 로 빌드 성공
```

## 남는 것

- **파이썬이 자막을 백엔드로 보내는 경로**가 아직 없습니다. STT 스트리밍 설계가 필요해 별도 이슈로 둡니다
- LiveKit 데이터채널의 **로컬 STT 자막**은 남겨 뒀습니다. 백엔드 자막이 오기 전까지의 대체 경로입니다