### PR TITLE
feat: 다시보기 채팅 조회 API (#108)

### DIFF
--- a/backend/src/main/java/com/edu/edumeet/chat/controller/ChatReplayController.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/controller/ChatReplayController.java
@@ -1,0 +1,55 @@
+package com.edu.edumeet.chat.controller;
+
+import com.edu.edumeet.chat.dto.ChatReplayResponse;
+import com.edu.edumeet.chat.service.ChatService;
+import com.edu.edumeet.member.domain.SecurityMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 다시보기 채팅 조회. (#108)
+ *
+ * <p><b>{@link ChatController} 와 분리한 이유.</b>
+ * 그쪽은 STOMP 전용({@code @MessageMapping})이라 REST 엔드포인트가 없다.
+ * 실시간 발행과 과거 조회는 프로토콜도 인증 경로도 다르다 —
+ * 실시간은 STOMP CONNECT 에서 JWT 를 보고, 여기는 HTTP 필터 체인이 본다.
+ *
+ * <p>재생 위치({@code offsetMillis}) 기준이다. 절대 시각이 아니다.
+ */
+@RestController
+@RequestMapping("/api/v1/meeting/{meetingId}/chat")
+@RequiredArgsConstructor
+public class ChatReplayController {
+
+    private final ChatService chatService;
+
+    /**
+     * 구간의 대화를 읽는다.
+     *
+     * <pre>
+     *   GET /api/v1/meeting/7/chat/replay?from=0&amp;to=60000
+     * </pre>
+     *
+     * <p>기본 구간을 1분으로 둔 이유 — 다시보기 플레이어는 재생 위치를 따라가며
+     * 조금씩 물어보는 것이 맞다. 한 번에 다 주면 두 시간 방송에서 응답이 수 MB 가 된다.
+     *
+     * @param from 구간 시작(포함), 회의 시작 기준 밀리초
+     * @param to   구간 끝(제외)
+     */
+    @GetMapping("/replay")
+    public ResponseEntity<ChatReplayResponse> replay(
+            @AuthenticationPrincipal SecurityMember member,
+            @PathVariable Long meetingId,
+            @RequestParam(defaultValue = "0") long from,
+            @RequestParam(defaultValue = "60000") long to) {
+
+        return ResponseEntity.ok(
+                chatService.replay(meetingId, member.getEmail(), from, to));
+    }
+}

--- a/backend/src/main/java/com/edu/edumeet/chat/dto/ChatReplayResponse.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/dto/ChatReplayResponse.java
@@ -1,0 +1,27 @@
+package com.edu.edumeet.chat.dto;
+
+import java.util.List;
+
+/**
+ * 다시보기 채팅 한 구간. (#108)
+ *
+ * @param meetingId   회의
+ * @param fromMillis  요청한 구간 시작 (회의 시작 기준)
+ * @param toMillis    요청한 구간 끝
+ * @param messages    그 구간의 대화. offsetMillis 오름차순
+ * @param hasMore     상한에 걸려 잘렸는가.
+ *                    <b>false 를 "이게 전부" 로 읽으면 안 된다</b> - 정확히 상한만큼
+ *                    있을 때도 false 가 된다. 클라이언트는 마지막 offset 부터 다시 물어야 한다.
+ */
+public record ChatReplayResponse(
+        Long meetingId,
+        long fromMillis,
+        long toMillis,
+        List<Message> messages,
+        boolean hasMore
+) {
+    /**
+     * @param offsetMillis 회의 시작 기준 경과 밀리초. 재생 위치와 맞추는 값이다
+     */
+    public record Message(String sender, String content, long offsetMillis) {}
+}

--- a/backend/src/main/java/com/edu/edumeet/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/repository/ChatMessageRepository.java
@@ -15,4 +15,40 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     List<ChatMessage> findRecent(@Param("meetingId") Long meetingId, Pageable pageable);
 
     long countByMeetingId(Long meetingId);
+
+    /**
+     * 다시보기 구간 조회. (#108)
+     *
+     * <p><b>{@code offset_millis} 로 자른다. 절대 시각이 아니다.</b>
+     * 다시보기는 "재생 위치 12분 34초에 무슨 대화가 있었나" 를 묻는다.
+     * {@code sentAt} 으로 자르려면 회의 시작 시각을 매번 빼야 하고,
+     * 시작 시각이 나중에 보정되면 이미 저장된 것이 전부 어긋난다.
+     *
+     * <p>{@code offsetMillis} 가 {@code null} 인 행은 제외한다 -
+     * V7 이전에 저장된 것이라 재생 위치를 모른다. 섞어서 주면
+     * 클라이언트가 그것들을 0초에 몰아 그린다.
+     *
+     * <p><b>이 조건은 지금 기술적으로 중복이다.</b> SQL 3값 논리에서
+     * {@code NULL >= 0} 은 {@code UNKNOWN} 이라 아래 범위 비교가 이미 걸러낸다.
+     * 되돌려 확인했더니 시험이 안 잡혔다.
+     *
+     * <p>그래도 남기는 이유 - <b>의도가 범위 비교의 부작용에 얹혀 있으면 안 된다.</b>
+     * 나중에 누군가 "재생 위치 미상은 0초로 보여주자" 며 {@code COALESCE} 를 넣는 순간
+     * 이 조건이 없으면 조용히 섞인다.
+     *
+     * <p>정렬은 {@code offsetMillis} 다. 배치 저장이라 {@code id} 순서가
+     * 발화 순서와 다를 수 있다 - 큐에서 나온 순서지 말한 순서가 아니다.
+     */
+    @Query("""
+            SELECT m FROM ChatMessage m
+            WHERE m.meeting.id = :meetingId
+              AND m.offsetMillis IS NOT NULL
+              AND m.offsetMillis >= :fromMillis
+              AND m.offsetMillis < :toMillis
+            ORDER BY m.offsetMillis ASC, m.id ASC
+            """)
+    List<ChatMessage> findReplayWindow(@Param("meetingId") Long meetingId,
+                                       @Param("fromMillis") long fromMillis,
+                                       @Param("toMillis") long toMillis,
+                                       Pageable pageable);
 }

--- a/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
@@ -2,6 +2,8 @@ package com.edu.edumeet.chat.service;
 
 import com.edu.edumeet.chat.domain.ChatMessage;
 import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.classroom.service.ClassAccessChecker;
+import com.edu.edumeet.chat.dto.ChatReplayResponse;
 import com.edu.edumeet.chat.repository.ChatMessageRepository;
 import com.edu.edumeet.meeting.domain.Meeting;
 import com.edu.edumeet.meeting.domain.SessionType;
@@ -30,7 +32,16 @@ public class ChatService {
     private static final int MAX_CONTENT_LENGTH = 1000;
     private static final int RECENT_LIMIT = 50;
 
+    /**
+     * 다시보기 한 번에 주는 최대 건수.
+     *
+     * <p>상한이 없으면 두 시간 방송의 채팅을 한 응답에 담게 되고 수 MB 가 된다.
+     * 클라이언트는 재생 위치를 따라가며 조금씩 물어보는 것이 맞다.
+     */
+    private static final int REPLAY_LIMIT = 500;
+
     private final MeetingRepository meetingRepository;
+    private final ClassAccessChecker classAccessChecker;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatArchiveQueue archiveQueue;
 
@@ -76,6 +87,43 @@ public class ChatService {
                         meetingId, m.getSenderEmail(), m.getContent(),
                         m.getSentAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()))
                 .toList();
+    }
+
+    /**
+     * 다시보기 채팅 한 구간을 읽는다. (#108)
+     *
+     * <p><b>{@link #recentMessages} 와 다른 질문이다.</b>
+     * 그쪽은 "지금 들어왔는데 방금 무슨 얘기 했나" 이고, 이쪽은 "그때 무슨 얘기 했나" 다.
+     * 한 메서드로 합치면 둘 다 어정쩡해진다.
+     *
+     * @param fromMillis 구간 시작(포함). 회의 시작 기준
+     * @param toMillis   구간 끝(제외)
+     */
+    @Transactional(readOnly = true)
+    public ChatReplayResponse replay(Long meetingId, String email, long fromMillis, long toMillis) {
+        if (fromMillis < 0 || toMillis <= fromMillis) {
+            throw new IllegalArgumentException(
+                    "구간이 잘못됐습니다. from=%d, to=%d".formatted(fromMillis, toMillis));
+        }
+
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회의입니다: " + meetingId));
+        // 그 클래스의 구성원만 본다. 다시보기도 수업 자료다.
+        classAccessChecker.requireMember(meeting.getClassRoom().getId(), email);
+
+        // 상한보다 하나 더 받아서 "더 있는지" 를 판단한다.
+        // count 쿼리를 따로 날리면 큰 구간에서 두 번 훑게 된다.
+        List<ChatMessage> rows = chatMessageRepository.findReplayWindow(
+                meetingId, fromMillis, toMillis, PageRequest.of(0, REPLAY_LIMIT + 1));
+
+        boolean hasMore = rows.size() > REPLAY_LIMIT;
+        List<ChatReplayResponse.Message> messages = rows.stream()
+                .limit(REPLAY_LIMIT)
+                .map(m -> new ChatReplayResponse.Message(
+                        m.getSenderEmail(), m.getContent(), m.getOffsetMillis()))
+                .toList();
+
+        return new ChatReplayResponse(meetingId, fromMillis, toMillis, messages, hasMore);
     }
 
     /**

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/ChatReplayTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/ChatReplayTest.java
@@ -1,0 +1,185 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.chat.domain.ChatMessage;
+import com.edu.edumeet.chat.dto.ChatReplayResponse;
+import com.edu.edumeet.chat.repository.ChatMessageRepository;
+import com.edu.edumeet.chat.service.ChatService;
+import com.edu.edumeet.classroom.domain.ClassMember;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 다시보기 채팅 조회. (#108)
+ *
+ * <p>#61 에서 저장은 하게 했는데 <b>읽을 길이 없었다.</b>
+ * {@code recentMessages} 는 "지금 들어왔는데 방금 무슨 얘기 했나" 이고,
+ * 다시보기는 <b>"재생 위치 12분 34초에 무슨 대화가 있었나"</b> 다. 다른 질문이다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("다시보기 채팅 조회")
+class ChatReplayTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @Autowired ChatService chatService;
+    @Autowired ChatMessageRepository chatMessageRepository;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private record Fixture(Long meetingId, String ownerEmail, String studentEmail, String outsiderEmail) {}
+
+    /** 회의 하나와 그 안의 채팅을 만든다. offsets 는 각 메시지의 재생 위치다. */
+    private Fixture given(long... offsets) {
+        int n = SEQ.incrementAndGet();
+        String owner = "replay-owner-" + n + "@test";
+        String student = "replay-student-" + n + "@test";
+        String outsider = "replay-outsider-" + n + "@test";
+        Long[] id = new Long[1];
+
+        transactionTemplate.executeWithoutResult(s -> {
+            Member o = Member.builder().email(owner).nickname("강사").password("x").build();
+            Member st = Member.builder().email(student).nickname("학생").password("x").build();
+            Member out = Member.builder().email(outsider).nickname("외부인").password("x").build();
+            em.persist(o); em.persist(st); em.persist(out);
+
+            ClassRoom c = ClassRoom.builder().member(o).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(c);
+            em.persist(ClassMember.builder().classRoom(c).member(st).build());
+
+            Meeting m = Meeting.builder().classRoom(c).title("방송").description("-")
+                    .sessionType(SessionType.BROADCAST)
+                    .startTime(LocalDateTime.now().minusHours(2)).build();
+            em.persist(m);
+
+            for (long off : offsets) {
+                em.persist(ChatMessage.of(m, "viewer@test", "at-" + off, off));
+            }
+            em.flush();
+            id[0] = m.getId();
+        });
+        return new Fixture(id[0], owner, student, outsider);
+    }
+
+    @Test
+    @DisplayName("★ 재생 위치로 자른다 - 구간 밖은 안 준다")
+    void returns_only_the_requested_window() {
+        Fixture f = given(0L, 30_000L, 59_999L, 60_000L, 90_000L);
+
+        ChatReplayResponse r = chatService.replay(f.meetingId(), f.ownerEmail(), 0, 60_000);
+
+        assertThat(r.messages()).hasSize(3);
+        assertThat(r.messages()).extracting(ChatReplayResponse.Message::offsetMillis)
+                .as("끝(to)은 제외다. 60000 이 포함되면 다음 구간과 겹쳐 두 번 보인다")
+                .containsExactly(0L, 30_000L, 59_999L);
+    }
+
+    @Test
+    @DisplayName("★ 재생 순서로 정렬한다 - 배치 저장이라 id 순서는 발화 순서가 아니다")
+    void sorted_by_playback_position() {
+        // 일부러 뒤죽박죽 저장한다. 큐에서 나온 순서지 말한 순서가 아니다.
+        Fixture f = given(50_000L, 10_000L, 30_000L, 20_000L);
+
+        ChatReplayResponse r = chatService.replay(f.meetingId(), f.ownerEmail(), 0, 60_000);
+
+        assertThat(r.messages()).extracting(ChatReplayResponse.Message::offsetMillis)
+                .as("id 순서로 주면 다시보기에서 대화가 뒤섞여 보인다")
+                .containsExactly(10_000L, 20_000L, 30_000L, 50_000L);
+    }
+
+    @Test
+    @DisplayName("★ offsetMillis 가 없는 옛 행은 제외한다 - 섞으면 0초에 몰려 그려진다")
+    void rows_without_offset_are_excluded() {
+        Fixture f = given(10_000L, 20_000L);
+        // V7 이전에 저장된 것을 흉내낸다.
+        transactionTemplate.executeWithoutResult(s -> {
+            Meeting m = em.find(Meeting.class, f.meetingId());
+            em.persist(ChatMessage.of(m, "old@test", "재생위치를 모르는 옛 메시지"));
+            em.flush();
+        });
+
+        ChatReplayResponse r = chatService.replay(f.meetingId(), f.ownerEmail(), 0, 60_000);
+
+        assertThat(r.messages()).hasSize(2);
+        assertThat(r.messages()).extracting(ChatReplayResponse.Message::content)
+                .doesNotContain("재생위치를 모르는 옛 메시지");
+
+        // ★ 이 단언만으로는 IS NOT NULL 조건의 필요성을 증명하지 못한다.
+        //   SQL 3값 논리에서 NULL >= 0 은 UNKNOWN 이라 범위 비교가 이미 걸러낸다.
+        //   되돌려 확인했더니 조건을 빼도 시험이 통과했다.
+        //
+        //   그래서 응답에 담긴 offsetMillis 가 전부 실제 값인지도 본다 -
+        //   누군가 COALESCE 로 null 을 0 으로 바꾸는 순간 여기서 걸린다.
+        assertThat(r.messages()).allSatisfy(m ->
+                assertThat(m.offsetMillis())
+                        .as("재생 위치를 모르는 행이 0초로 둔갑해 들어왔다")
+                        .isIn(10_000L, 20_000L));
+    }
+
+    @Test
+    @DisplayName("★ 상한을 넘으면 hasMore 로 알린다 - 조용히 자르지 않는다")
+    void reports_truncation() {
+        long[] many = new long[600];
+        for (int i = 0; i < many.length; i++) many[i] = i * 10L;
+        Fixture f = given(many);
+
+        ChatReplayResponse r = chatService.replay(f.meetingId(), f.ownerEmail(), 0, 10_000);
+
+        assertThat(r.messages())
+                .as("상한 없이 다 주면 두 시간 방송에서 응답이 수 MB 가 된다")
+                .hasSize(500);
+        assertThat(r.hasMore())
+                .as("잘렸는데 hasMore 가 false 면 클라이언트가 '이게 전부' 로 읽는다")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("잘리지 않았으면 hasMore 는 false 다")
+    void no_truncation_reports_false() {
+        Fixture f = given(0L, 1_000L, 2_000L);
+        ChatReplayResponse r = chatService.replay(f.meetingId(), f.ownerEmail(), 0, 60_000);
+        assertThat(r.hasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("★ 클래스 구성원만 본다 - 다시보기도 수업 자료다")
+    void only_class_members_can_read() {
+        Fixture f = given(0L, 1_000L);
+
+        // 강사와 수강생은 된다
+        assertThat(chatService.replay(f.meetingId(), f.ownerEmail(), 0, 60_000).messages()).hasSize(2);
+        assertThat(chatService.replay(f.meetingId(), f.studentEmail(), 0, 60_000).messages()).hasSize(2);
+
+        // 외부인은 안 된다
+        assertThatThrownBy(() -> chatService.replay(f.meetingId(), f.outsiderEmail(), 0, 60_000))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("구간이 뒤집혀 있으면 거부한다")
+    void rejects_inverted_window() {
+        Fixture f = given(0L);
+        assertThatThrownBy(() -> chatService.replay(f.meetingId(), f.ownerEmail(), 60_000, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> chatService.replay(f.meetingId(), f.ownerEmail(), -1, 1_000))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Closes #108

#61 에서 **저장은 하게 했는데 읽을 길이 없었습니다.**

```
GET /api/v1/meeting/{meetingId}/chat/replay?from=0&to=60000
```

## `recentMessages` 를 고쳐 쓰지 않았습니다

**두 질문이 다릅니다.**

| | |
|---|---|
| `recentMessages` | *"지금 들어왔는데 방금 무슨 얘기 했나"* |
| `replay` | *"재생 위치 12분 34초에 무슨 대화가 있었나"* |

한 메서드로 합치면 둘 다 어정쩡해집니다.

## `offsetMillis` 로 자릅니다

`sentAt` 으로 자르려면 회의 시작 시각을 매번 빼야 하고,
**시작 시각이 나중에 보정되면 이미 저장된 것이 전부 어긋납니다.**

## 정렬도 `offsetMillis` 입니다

**배치 저장이라 `id` 순서가 발화 순서와 다릅니다** — 큐에서 나온 순서지 말한 순서가 아닙니다.

## `hasMore` 로 잘림을 알립니다

상한 없이 다 주면 두 시간 방송에서 응답이 **수 MB** 가 됩니다.
조용히 자르면 클라이언트가 **"이게 전부"** 로 읽습니다.

> 상한보다 **하나 더** 받아서 판단합니다. `count` 를 따로 날리면 큰 구간을 두 번 훑습니다.

## ★ 시험이 못 잡는 조건을 발견하고 적었습니다

검출력을 확인하다 하나가 걸렸습니다.

```sql
AND m.offsetMillis IS NOT NULL   -- 빼도 시험이 통과한다
```

**SQL 3값 논리에서 `NULL >= 0` 은 `UNKNOWN`** 이라 아래 범위 비교가 이미 걸러냅니다.
즉 **이 조건은 지금 아무 일도 하지 않습니다.**

지우지 않고 남겼습니다 — **의도가 범위 비교의 부작용에 얹혀 있으면 안 됩니다.**
나중에 누군가 *"재생 위치 미상은 0초로 보여주자"* 며 `COALESCE` 를 넣는 순간 조용히 섞입니다.

주석과 시험 양쪽에 **"지금은 중복이고 시험이 못 잡는다"** 를 적고, 방어 단언을 추가했습니다.

## 검증

**294개 통과.** 네 가지를 되돌려 확인했습니다.

| 되돌린 것 | 실패 |
|---|---:|
| 정렬을 `id` 순으로 | 1개 |
| 권한 검사 제거 | 1개 |
| `hasMore` 항상 `false` | 1개 |
| `IS NOT NULL` 제거 | **0개** ← 위와 같이 처리 |