### PR TITLE
feat: 자막 전송 경로를 잇는다 — 실시간은 아니다 (#113)

### DIFF
--- a/ai/config.env
+++ b/ai/config.env
@@ -12,3 +12,8 @@ DEFAULT_SIMILARITY_THRESHOLD=0.3
 
 # 최소 문장 길이
 MIN_SENTENCE_LENGTH=15
+
+# 자막 전송 대상. (#113)
+#   계약은 contracts/internal-api.json 의 captionIngest 다.
+#   {meetingId} 는 파이썬이 치환한다 - 문자 그대로 두면 Java 가 400 을 낸다.
+CAPTION_INGEST_URL=http://app:8080/api/v1/internal/meetings/{meetingId}/captions

--- a/ai/main.py
+++ b/ai/main.py
@@ -923,6 +923,113 @@ def send_summary_to_api(class_id: str, meetingId: str | None,
     except Exception as e:
         return {"ok": False, "detail": f"업로드 실패: {e}"}
 
+def _split_into_captions(text: str, max_chars: int = 60) -> list[str]:
+    """전체 텍스트를 자막 조각으로 나눈다. (#113)
+
+    한 화면에 60자가 넘으면 읽기 전에 다음 것으로 넘어간다.
+    문장 부호를 우선 경계로 삼고, 한 문장이 너무 길면 그 안에서 다시 자른다.
+    """
+    import re as _re
+    if not text or not text.strip():
+        return []
+    sentences = [x.strip() for x in _re.split(r"(?<=[.!?。！？])\s+|\n+", text) if x.strip()]
+
+    chunks: list[str] = []
+    for sentence in sentences:
+        if len(sentence) <= max_chars:
+            chunks.append(sentence)
+            continue
+        # 긴 문장은 공백 경계로 자른다. 단어 중간에서 끊으면 읽기 어렵다.
+        current = ""
+        for word in sentence.split(" "):
+            if current and len(current) + 1 + len(word) > max_chars:
+                chunks.append(current)
+                current = word
+            else:
+                current = f"{current} {word}".strip()
+        if current:
+            chunks.append(current)
+    return chunks
+
+
+def send_captions_to_api(meeting_id, text: str, started_at_ms: int | None = None) -> dict:
+    """STT 결과를 자막으로 백엔드에 보낸다. (#113)
+
+    Java 계약 (contracts/internal-api.json 의 captionIngest)
+        POST /api/v1/internal/meetings/{meetingId}/captions
+        헤더  X-Internal-Token
+        본문  {"text": ..., "sequence": ..., "spokenAt": ...}
+
+    ★ 이것은 실시간 자막이 아니다.
+
+      CLOVA STT 를 녹음이 끝난 뒤 파일 하나로 부르므로 전체 텍스트가
+      한 덩어리로 나온다. 회의가 끝나야 텍스트가 나오는데 실시간일 수 없다.
+      실시간으로 하려면 CLOVA 스트리밍 API 로 바꿔야 하고 그것은 별도 작업이다.
+
+      그럼에도 지금 잇는 이유 - 소스를 바꾸는 순간 붙일 곳이 있어야 하고,
+      지금도 쓸 데가 있다. 문장 단위로 보내면 다시보기 자막이 된다.
+
+    :param started_at_ms: 회의 시작 시각(epoch ms). 조각의 발화 시각을 추정하는 기준.
+                          모르면 지금 시각을 쓴다 - 다시보기 위치가 어긋나지만
+                          자막이 아예 없는 것보다는 낫다.
+    """
+    try:
+        env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.env")
+        if os.path.exists(env_path):
+            load_dotenv(env_path)
+
+        url_tpl = os.getenv("CAPTION_INGEST_URL", "").strip()
+        if not url_tpl:
+            return {"ok": False, "detail": "CAPTION_INGEST_URL 미설정"}
+
+        token = os.getenv("INTERNAL_API_TOKEN", "").strip()
+        if not token:
+            return {"ok": False,
+                    "detail": "INTERNAL_API_TOKEN 미설정. /api/v1/internal/** 은 이 헤더 없이는 403 이다."}
+
+        mid = _normalize_meeting_id(meeting_id)
+        if mid is None:
+            return {"ok": False, "detail": f"meetingId 가 없다(값={meeting_id!r})"}
+
+        chunks = _split_into_captions(text)
+        if not chunks:
+            return {"ok": False, "detail": "보낼 자막이 없다"}
+
+        url = url_tpl.replace("{meetingId}", str(mid)).replace("{meeting_id}", str(mid))
+        headers = {"Accept": "application/json", "X-Internal-Token": token}
+        base = started_at_ms if started_at_ms else int(time.time() * 1000)
+
+        sent, failed = 0, []
+        for i, chunk in enumerate(chunks):
+            body = {
+                "text": chunk,
+                "sequence": i,
+                # 실제 발화 시각을 모르므로 균등 분배한다. 이것이 근사라는 사실은
+                # 반환값의 approximate_timing 으로 알린다 - 조용히 정확한 척하지 않는다.
+                "spokenAt": base + i * 3000,
+            }
+            try:
+                r = requests.post(url, headers=headers, json=body, timeout=10)
+                if 200 <= r.status_code < 300:
+                    sent += 1
+                else:
+                    failed.append({"sequence": i, "status": r.status_code,
+                                   "text": (r.text or "")[:120]})
+            except Exception as e:
+                failed.append({"sequence": i, "detail": str(e)[:120]})
+
+        return {
+            "ok": sent > 0 and not failed,
+            "sent": sent,
+            "total": len(chunks),
+            "failed": failed[:5],
+            "approximate_timing": True,
+            "realtime": False,
+        }
+    except Exception as e:
+        return {"ok": False, "detail": f"자막 전송 실패: {e}"}
+
+
 def _normalize_meeting_id(mid):
     """None, 'null', 'None', 'undefined', '', 공백 등을 None으로.
        숫자/숫자문자열만 허용해서 문자열로 반환."""
@@ -1052,6 +1159,14 @@ def merge_audio(class_id: str, body: SttRequest):
                 "summary_ok": False
             })
 
+        # ★ STT 결과를 자막으로도 보낸다. (#113)
+        #   실시간이 아니다 - 녹음이 끝난 뒤 나온 텍스트를 문장 단위로 나눠 보낸다.
+        #   다시보기 자막으로 쓰인다. 실패해도 요약은 계속한다 -
+        #   자막이 없다고 요약까지 버릴 이유가 없다.
+        caption_result = send_captions_to_api(Meeting_id, stt_result.get("text", ""))
+        if not (caption_result or {}).get("ok"):
+            print("[caption] 전송 실패(요약은 계속):", caption_result)
+
         summary_result = summarize_text_auto(transcript_path, os.path.dirname(out_path))
         
         upload_result = None
@@ -1087,6 +1202,7 @@ def merge_audio(class_id: str, body: SttRequest):
             "summary_pdf_path": (summary_result or {}).get("summary_pdf_path"),
             "clean_path": (summary_result or {}).get("clean_path"),
             "summary_detail": (summary_result or {}).get("detail"),
+            "caption_result": caption_result,
             "upload_result": upload_result,
             "cleanup_result": cleanup_result,
         }

--- a/ai/tests/test_caption_ingest_contract.py
+++ b/ai/tests/test_caption_ingest_contract.py
@@ -1,0 +1,143 @@
+"""자막을 백엔드로 보내는 요청이 계약과 맞는지 본다. (#113)
+
+파이프라인의 마지막 빈 칸이었다.
+
+    파이썬 AI   자막 전송 코드 없음          <- 여기
+    백엔드      POST .../captions -> STOMP   O
+    프론트      STOMP 로 듣는다              O
+
+★ 이것은 실시간 자막이 아니다.
+  CLOVA STT 를 녹음이 끝난 뒤 파일 하나로 부르므로 전체 텍스트가 한 덩어리로 나온다.
+  회의가 끝나야 텍스트가 나오는데 실시간일 수 없다.
+  전송 경로를 먼저 잇는 이유는 소스를 바꿀 때 붙일 곳이 있어야 하기 때문이다.
+"""
+import json
+import os
+import sys
+
+import pytest
+import responses
+
+AI_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, AI_DIR)
+
+# 계약을 손으로 적지 않는다. Java 테스트가 읽는 그 파일을 읽는다.
+CONTRACT_PATH = os.path.join(AI_DIR, "..", "contracts", "internal-api.json")
+with open(CONTRACT_PATH, encoding="utf-8") as f:
+    CONTRACT = json.load(f)
+
+CAPTION = CONTRACT["endpoints"]["captionIngest"]
+AUTH_HEADER = CONTRACT["authHeader"]
+JAVA_URL = "http://java:8080" + CAPTION["path"]
+TOKEN = "test-internal-token"
+TARGET = "http://java:8080/api/v1/internal/meetings/77/captions"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("CAPTION_INGEST_URL", JAVA_URL)
+    monkeypatch.setenv("INTERNAL_API_TOKEN", TOKEN)
+
+
+def _bodies():
+    """responses 가 받은 요청들의 JSON 본문."""
+    return [json.loads(c.request.body) for c in responses.calls]
+
+
+@responses.activate
+def _send(text, env_ok=True, started_at=None):
+    import main
+    responses.add(responses.POST, TARGET, json={"ok": True}, status=200)
+    result = main.send_captions_to_api("77", text, started_at_ms=started_at)
+    return result, _bodies(), list(responses.calls)
+
+
+def test_text_is_split_into_chunks(env):
+    """★ 한 덩어리로 보내지 않는다 - 한 화면에 다 안 들어간다."""
+    long_text = "안녕하세요. " * 40
+    result, bodies, _ = _send(long_text)
+
+    assert result["sent"] > 1, "긴 텍스트를 한 번에 보냈다. 자막이 화면을 넘친다"
+    assert all(len(b["text"]) <= 60 for b in bodies), (
+        f"60자를 넘는 조각이 있다: {[len(b['text']) for b in bodies]}")
+
+
+def test_sequence_increases_from_zero(env):
+    """★ sequence 가 순서를 정한다. 빠지거나 뒤섞이면 자막이 뒤엉킨다."""
+    _, bodies, _ = _send("첫 문장이다. 두 번째 문장이다. 세 번째 문장이다.")
+    assert [b["sequence"] for b in bodies] == list(range(len(bodies)))
+
+
+def test_internal_token_header_is_sent(env):
+    """★ X-Internal-Token 이 없으면 Java 가 403 으로 끊는다."""
+    _, _, calls = _send("한 문장.")
+    assert AUTH_HEADER in calls[0].request.headers, (
+        f"인증 헤더가 없다. 보낸 헤더: {sorted(calls[0].request.headers.keys())}")
+    assert calls[0].request.headers[AUTH_HEADER] == TOKEN
+
+
+def test_meeting_id_goes_into_the_path(env):
+    """meetingId 는 경로 변수다. #91 에서 요약 업로드가 같은 이유로 깨져 있었다."""
+    _, _, calls = _send("한 문장.")
+    assert "/meetings/77/captions" in calls[0].request.url
+    assert "{meetingId}" not in calls[0].request.url, "치환되지 않은 채로 나갔다"
+
+
+def test_body_has_the_declared_fields(env):
+    """계약이 선언한 본문 필드를 전부 보낸다."""
+    _, bodies, _ = _send("한 문장.")
+    for field in CAPTION["jsonFields"]:
+        assert field in bodies[0], f"계약의 {field} 가 본문에 없다"
+
+
+def test_timing_is_reported_as_approximate(env):
+    """★ 근사라는 사실을 숨기지 않는다.
+
+    실제 발화 시각을 모르므로 균등 분배한다.
+    조용히 정확한 척하면 다시보기에서 자막이 어긋나도 원인을 못 찾는다.
+    """
+    result, _, _ = _send("첫 문장. 두 번째 문장.")
+    assert result["approximate_timing"] is True
+    assert result["realtime"] is False, "실시간이 아닌데 실시간이라고 보고하면 안 된다"
+
+
+def test_spoken_at_increases(env):
+    """조각의 발화 시각이 순서대로 늘어난다."""
+    _, bodies, _ = _send("첫 문장. 두 번째 문장. 세 번째 문장.", started_at=1_000_000)
+    times = [b["spokenAt"] for b in bodies]
+    assert times == sorted(times)
+    assert times[0] >= 1_000_000
+
+
+def test_missing_token_fails_before_sending(monkeypatch):
+    """토큰이 없으면 보내기 전에 실패한다. 403 을 받고 원인을 찾는 것보다 낫다."""
+    monkeypatch.setenv("CAPTION_INGEST_URL", JAVA_URL)
+    monkeypatch.delenv("INTERNAL_API_TOKEN", raising=False)
+    import main
+    result = main.send_captions_to_api("77", "한 문장.")
+    assert result["ok"] is False
+    assert "INTERNAL_API_TOKEN" in result["detail"]
+
+
+def test_empty_text_is_not_sent(env):
+    """빈 텍스트로 요청을 만들지 않는다. STT 가 아무것도 못 알아들었을 때다."""
+    import main
+    result = main.send_captions_to_api("77", "   ")
+    assert result["ok"] is False
+    assert "자막" in result["detail"]
+
+
+@responses.activate
+def test_partial_failure_is_reported(env):
+    """★ 일부만 실패해도 조용히 성공으로 보고하지 않는다."""
+    import main
+    responses.add(responses.POST, TARGET, json={"ok": True}, status=200)
+    responses.add(responses.POST, TARGET, status=500)
+    responses.add(responses.POST, TARGET, json={"ok": True}, status=200)
+
+    result = main.send_captions_to_api("77", "첫 문장. 두 번째 문장. 세 번째 문장.")
+
+    assert result["ok"] is False, "하나라도 실패하면 ok 가 아니다"
+    assert result["sent"] == 2
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["status"] == 500

--- a/contracts/internal-api.json
+++ b/contracts/internal-api.json
@@ -15,16 +15,34 @@
     "summaryUpload": {
       "method": "POST",
       "path": "/api/v1/internal/meetings/{meetingId}/summary",
-      "pathVariables": ["meetingId"],
-      "multipartFields": ["summary_md", "summary_pdf"],
-      "successStatus": [200, 201],
+      "pathVariables": [
+        "meetingId"
+      ],
+      "multipartFields": [
+        "summary_md",
+        "summary_pdf"
+      ],
+      "successStatus": [
+        200,
+        201
+      ],
       "$note": "201 최초 기록 / 200 재시도로 아무것도 안 바뀜"
     },
     "captionIngest": {
       "method": "POST",
       "path": "/api/v1/internal/meetings/{meetingId}/captions",
-      "pathVariables": ["meetingId"],
-      "successStatus": [200]
+      "pathVariables": [
+        "meetingId"
+      ],
+      "successStatus": [
+        200
+      ],
+      "jsonFields": [
+        "text",
+        "sequence",
+        "spokenAt"
+      ],
+      "$note": "조각 단위다. sequence 는 방 안에서 증가하고 spokenAt 은 발화 시각(epoch ms)이다"
     }
   }
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -164,6 +164,7 @@ services:
     environment:
       # 계약은 contracts/internal-api.json 이다. 경로 변수는 meetingId 다.
       SUMMARY_UPLOAD_URL: http://app:8080/api/v1/internal/meetings/{meetingId}/summary
+      CAPTION_INGEST_URL: http://app:8080/api/v1/internal/meetings/{meetingId}/captions
       INTERNAL_API_TOKEN: ${INTERNAL_API_TOKEN:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       CLOVA_INVOKE_URL: ${CLOVA_INVOKE_URL:-}


### PR DESCRIPTION
Closes #113

파이프라인의 **마지막 빈 칸**이었습니다.

```
파이썬 AI   ❌ 자막 전송 코드 없음          ← 여기
백엔드      ✅ POST .../captions → STOMP   (#65)
프론트      ✅ STOMP 로 듣는다             (#106)
```

## ★ 이것은 실시간 자막이 아닙니다

CLOVA STT 를 **녹음이 끝난 뒤 파일 하나로** 부릅니다.

```python
resp = requests.post(endpoint, files={"media": f}, timeout=600)
text = data.get("text")     # 전체 텍스트 한 덩어리
```

**회의가 끝나야 텍스트가 나오는데 실시간일 수 없습니다.**
실시간으로 하려면 CLOVA **스트리밍 API** 로 바꿔야 하고, 그것은 **기능 추가**입니다.

### 그럼에도 지금 잇는 이유

**소스를 바꾸는 순간 붙일 곳이 있어야 합니다.** 그리고 지금도 쓸 데가 있습니다 —
문장 단위로 보내면 **다시보기 자막**이 됩니다. 실시간은 아니지만 자막이긴 합니다.

## 숨기지 않습니다

```python
return {"ok": ..., "approximate_timing": True, "realtime": False, ...}
```

실제 발화 시각을 모르므로 **균등 분배**합니다.
**조용히 정확한 척하면 다시보기에서 자막이 어긋나도 원인을 못 찾습니다.**

## 일부 실패도 성공으로 보고하지 않습니다

하나라도 실패하면 `ok=False` 이고 `failed` 에 **어느 조각인지** 남깁니다.

## 60자로 자릅니다

한 화면에 다 안 들어가면 읽기 전에 다음 것으로 넘어갑니다.
문장 부호를 우선 경계로 삼고, 긴 문장은 **공백 경계**에서 자릅니다 — 단어 중간에서 끊으면 읽기 어렵습니다.

## ★ 계약 구조가 실제로 작동합니다

검출력을 확인하다 이게 나왔습니다.

| 되돌린 것 | 실패 |
|---|---|
| **계약 파일의 자막 경로 한 줄** | **Java 2개 + 파이썬 3개 동시** |
| 토큰 헤더 제거 | 파이썬 1개 |
| 조각 나누기 제거 | 파이썬 2개 |

#91 에서 만든 구조가 실제로 막습니다 — **한쪽만 바꾸면 반대쪽이 깨집니다.**
AI 연동이 오래 끊겨 있던 이유가 정확히 *"양쪽이 서로를 안 봤다"* 였는데, 이제 못 그럽니다.

## 검증

파이썬 **23개** 통과 (13 → +10).

## 남는 것

**실시간 STT** — CLOVA 스트리밍 API 로의 전환. 별도 설계가 필요합니다.