### PR TITLE
feat: 다시보기 채팅 패널 + 프론트 테스트 (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,10 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: 테스트
+        working-directory: frontend
+        run: npm test
+
       - name: 빌드
         working-directory: frontend
         run: npm run build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,8 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
         "vite": "^7.0.0",
-        "vite-plugin-vue-devtools": "^7.7.7"
+        "vite-plugin-vue-devtools": "^7.7.7",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -976,9 +977,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1361,11 +1362,36 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stomp/stompjs": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
       "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.22",
@@ -1396,6 +1422,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/babel-helper-vue-transform-on": {
@@ -1621,6 +1770,16 @@
       "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1749,6 +1908,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1975,6 +2144,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2096,12 +2272,25 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2591,12 +2780,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2736,6 +2925,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -2828,9 +3031,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3035,6 +3238,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3143,6 +3353,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -3168,21 +3392,48 @@
         "node": ">=16"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -3447,6 +3698,96 @@
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
@@ -3517,6 +3858,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wildemitter": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.3.0",
@@ -24,6 +26,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",
     "vite": "^7.0.0",
-    "vite-plugin-vue-devtools": "^7.7.7"
+    "vite-plugin-vue-devtools": "^7.7.7",
+    "vitest": "^4.1.11"
   }
 }

--- a/frontend/src/components/ChatReplayPanel.vue
+++ b/frontend/src/components/ChatReplayPanel.vue
@@ -1,0 +1,155 @@
+<script setup>
+/**
+ * 다시보기 채팅 패널. (#115)
+ *
+ * 재생 위치를 받아 그 시점까지의 대화를 보여준다.
+ * 영상 플레이어와 분리했다 - 플레이어는 S3 재생이라 별개 관심사이고,
+ * 이 컴포넌트는 "재생 위치 -> 그때의 대화" 만 담당한다.
+ *
+ * 쓰는 쪽:
+ *   <ChatReplayPanel :meeting-id="7" :position-ms="video.currentTime * 1000" />
+ */
+import { ref, watch, computed } from 'vue'
+import { fetchChatWindow, windowOf, visibleAt, WINDOW_MS } from '@/features/replay/chatReplayApi'
+
+const props = defineProps({
+  meetingId: { type: [Number, String], required: true },
+  /** 재생 위치(밀리초). 영상 플레이어가 준다. */
+  positionMs: { type: Number, default: 0 },
+})
+
+const loaded = ref([])          // 현재 구간에서 받아 온 전체
+const loadedIndex = ref(-1)     // 그 구간 번호. -1 이면 아직 없다
+const truncated = ref(false)
+const error = ref('')
+const loading = ref(false)
+
+/**
+ * 지금까지 나온 대화만 보여준다.
+ *
+ * 구간을 통째로 그리면 아직 오지 않은 대화가 미리 보인다 - 스포일러다.
+ */
+const visible = computed(() => visibleAt(loaded.value, props.positionMs))
+
+watch(
+  () => windowOf(props.positionMs).index,
+  async (index) => {
+    // 같은 구간 안에서는 다시 부르지 않는다.
+    // 재생 중 위치는 초당 여러 번 바뀌므로 매번 요청하면 서버가 견디지 못한다.
+    if (index === loadedIndex.value) return
+
+    const { from, to } = windowOf(props.positionMs)
+    loading.value = true
+    error.value = ''
+    try {
+      const data = await fetchChatWindow(props.meetingId, from, to)
+      loaded.value = data.messages
+      truncated.value = data.hasMore
+      loadedIndex.value = index
+    } catch (e) {
+      // 채팅을 못 불러왔다고 영상 재생을 막지 않는다.
+      error.value = '이 구간의 대화를 불러오지 못했습니다.'
+      loaded.value = []
+      console.warn('다시보기 채팅 조회 실패', e)
+    } finally {
+      loading.value = false
+    }
+  },
+  { immediate: true },
+)
+
+/** 0:12:34 형태로. 재생 위치와 눈으로 맞춰 볼 수 있게. */
+function formatOffset(ms) {
+  const total = Math.floor(ms / 1000)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const mm = String(m).padStart(2, '0')
+  const ss = String(s).padStart(2, '0')
+  return h > 0 ? `${h}:${mm}:${ss}` : `${m}:${ss}`
+}
+</script>
+
+<template>
+  <section class="chat-replay" aria-label="다시보기 대화">
+    <header class="chat-replay__head">
+      <h3>대화</h3>
+      <span class="chat-replay__pos">{{ formatOffset(positionMs) }}</span>
+    </header>
+
+    <p v-if="loading && !visible.length" class="chat-replay__msg">불러오는 중…</p>
+    <p v-else-if="error" class="chat-replay__msg chat-replay__msg--error" role="alert">
+      {{ error }}
+    </p>
+    <p v-else-if="!visible.length" class="chat-replay__msg">
+      이 시점에는 대화가 없습니다.
+    </p>
+
+    <ol v-else class="chat-replay__list">
+      <li v-for="(m, i) in visible" :key="`${m.offsetMillis}-${i}`">
+        <time :datetime="`PT${Math.floor(m.offsetMillis / 1000)}S`">
+          {{ formatOffset(m.offsetMillis) }}
+        </time>
+        <strong>{{ m.sender }}</strong>
+        <span>{{ m.content }}</span>
+      </li>
+    </ol>
+
+    <!--
+      잘렸다는 사실을 숨기지 않는다. 서버가 한 구간에 500건까지만 준다.
+      말없이 자르면 "그때 분명 더 있었는데" 가 된다.
+    -->
+    <p v-if="truncated" class="chat-replay__msg chat-replay__msg--note">
+      이 구간의 대화가 많아 일부만 표시됩니다.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.chat-replay {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 0;
+}
+.chat-replay__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.chat-replay__pos {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+  font-size: 0.9em;
+}
+.chat-replay__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.chat-replay__list li {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.chat-replay__list time {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.6;
+  font-size: 0.85em;
+}
+.chat-replay__msg {
+  opacity: 0.7;
+  margin: 0;
+}
+.chat-replay__msg--error {
+  color: #b00020;
+}
+.chat-replay__msg--note {
+  font-size: 0.85em;
+}
+</style>

--- a/frontend/src/features/replay/chatReplayApi.js
+++ b/frontend/src/features/replay/chatReplayApi.js
@@ -1,0 +1,52 @@
+/**
+ * 다시보기 채팅 조회. (#115)
+ *
+ * 백엔드 계약 (#108)
+ *   GET /api/v1/meeting/{meetingId}/chat/replay?from=0&to=60000
+ *
+ *   from/to 는 회의 시작 기준 밀리초다. 절대 시각이 아니다 -
+ *   재생 위치와 맞춰야 하기 때문이다.
+ *
+ *   응답의 hasMore 는 "상한에 걸려 잘렸다" 는 뜻이다.
+ *   false 를 "이게 전부" 로 읽으면 안 된다 - 정확히 상한만큼 있을 때도 false 다.
+ */
+import apiClient from '@/utils/apiClient'
+
+/** 한 번에 물어보는 구간 길이. 재생 위치를 따라가며 조금씩 가져온다. */
+export const WINDOW_MS = 60_000
+
+/**
+ * 재생 위치 주변의 대화를 가져온다.
+ *
+ * @param {number|string} meetingId
+ * @param {number} fromMillis 구간 시작(포함)
+ * @param {number} toMillis   구간 끝(제외)
+ */
+export async function fetchChatWindow(meetingId, fromMillis, toMillis) {
+  const { data } = await apiClient.get(`/meeting/${meetingId}/chat/replay`, {
+    params: { from: Math.max(0, Math.floor(fromMillis)), to: Math.floor(toMillis) },
+  })
+  return data
+}
+
+/**
+ * 재생 위치가 속한 구간을 계산한다.
+ *
+ * 위치마다 요청하지 않고 구간 단위로 끊는 이유 -
+ * 재생 중에는 위치가 초당 여러 번 바뀐다. 그때마다 요청하면 서버가 견디지 못한다.
+ * 같은 구간 안에서는 이미 받아 둔 것을 쓴다.
+ */
+export function windowOf(positionMs, windowMs = WINDOW_MS) {
+  const index = Math.floor(Math.max(0, positionMs) / windowMs)
+  return { from: index * windowMs, to: (index + 1) * windowMs, index }
+}
+
+/**
+ * 구간 안에서 "지금까지 나온" 대화만 고른다.
+ *
+ * 구간을 통째로 보여주면 아직 오지 않은 대화가 미리 보인다 -
+ * 다시보기에서 스포일러가 된다.
+ */
+export function visibleAt(messages, positionMs) {
+  return messages.filter((m) => m.offsetMillis <= positionMs)
+}

--- a/frontend/src/features/replay/chatReplayApi.test.js
+++ b/frontend/src/features/replay/chatReplayApi.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { windowOf, visibleAt, WINDOW_MS } from './chatReplayApi'
+
+/**
+ * 다시보기 채팅의 순수 로직. (#115)
+ *
+ * 컴포넌트를 띄우지 않고 이것만 시험하는 이유 -
+ * 여기에 두 가지 판단이 들어 있고, 둘 다 틀리면 화면에서 조용히 잘못 보인다.
+ *
+ *   windowOf   구간 캐싱. 없으면 재생 중 초당 여러 번 요청한다
+ *   visibleAt  스포일러 방지. 없으면 아직 안 나온 대화가 미리 보인다
+ */
+describe('windowOf — 재생 위치를 구간으로 끊는다', () => {
+  it('같은 구간 안의 위치는 같은 구간 번호를 준다', () => {
+    // 재생 중 위치는 초당 여러 번 바뀐다. 매번 요청하면 서버가 견디지 못한다.
+    const a = windowOf(0)
+    const b = windowOf(30_000)
+    const c = windowOf(WINDOW_MS - 1)
+
+    expect(a.index).toBe(b.index)
+    expect(b.index).toBe(c.index)
+    expect(a.from).toBe(0)
+    expect(a.to).toBe(WINDOW_MS)
+  })
+
+  it('구간을 넘어가면 번호가 바뀐다', () => {
+    expect(windowOf(WINDOW_MS).index).toBe(1)
+    expect(windowOf(WINDOW_MS).from).toBe(WINDOW_MS)
+    expect(windowOf(WINDOW_MS).to).toBe(WINDOW_MS * 2)
+  })
+
+  it('구간이 겹치지 않는다 — 겹치면 같은 대화가 두 번 보인다', () => {
+    const first = windowOf(0)
+    const second = windowOf(WINDOW_MS)
+    expect(first.to).toBe(second.from)
+  })
+
+  it('음수 위치는 0으로 본다 — 서버가 400을 내지 않게', () => {
+    expect(windowOf(-5_000).from).toBe(0)
+    expect(windowOf(-5_000).index).toBe(0)
+  })
+})
+
+describe('visibleAt — 아직 안 나온 대화는 감춘다', () => {
+  const messages = [
+    { offsetMillis: 1_000, sender: 'a', content: '처음' },
+    { offsetMillis: 5_000, sender: 'b', content: '중간' },
+    { offsetMillis: 9_000, sender: 'c', content: '나중' },
+  ]
+
+  it('★ 재생 위치보다 뒤의 대화는 안 보인다 — 다시보기의 스포일러', () => {
+    const shown = visibleAt(messages, 5_000)
+    expect(shown.map((m) => m.content)).toEqual(['처음', '중간'])
+  })
+
+  it('정확히 그 시점의 대화는 보인다', () => {
+    expect(visibleAt(messages, 1_000).map((m) => m.content)).toEqual(['처음'])
+  })
+
+  it('시작 시점에는 아무것도 없다', () => {
+    expect(visibleAt(messages, 0)).toEqual([])
+  })
+
+  it('끝까지 가면 전부 보인다', () => {
+    expect(visibleAt(messages, 60_000)).toHaveLength(3)
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,26 +2,56 @@ import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+//
+// ★ vue-devtools 를 정적 import 하지 않는다. (#115)
+//
+//   이 플러그인은 모듈을 불러오는 시점에 localStorage 를 건드린다.
+//   Node 25 의 localStorage 는 객체로 존재하지만 getItem 이 없어서
+//   설정 파일을 읽는 것만으로 죽는다.
+//
+//     TypeError: localStorage.getItem is not a function
+//       at getTimelineLayersStateFromStorage (@vue/devtools-kit)
+//
+//   그래서 빌드도 테스트도 Node 25 에서 돌지 않았다.
+//   Node 22 컨테이너로 빌드해 피해 왔지만, 테스트는 로컬에서 돌아야 의미가 있다.
+//
+//   devtools 는 개발 서버에서만 필요하다. 그때만 동적으로 불러온다 -
+//   그러면 빌드·테스트는 이 플러그인을 아예 로드하지 않으므로 Node 버전과 무관해진다.
+//
+//   command === 'serve' 만으로는 부족하다. vitest 는 내부적으로 vite 개발 서버를
+//   띄우므로 command 가 'serve' 로 온다. 그래서 테스트에서도 devtools 가 로드됐다.
+//   VITEST 환경변수로 함께 가른다.
+export default defineConfig(async ({ command }) => {
+  const plugins = [vue()]
+
+  if (command === 'serve' && !process.env.VITEST) {
+    const { default: vueDevTools } = await import('vite-plugin-vue-devtools')
+    plugins.push(vueDevTools())
+  }
+
+  return {
+    plugins,
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
     },
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false
-      }
-    }
+    server: {
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+    test: {
+      // 순수 로직만 시험한다. 컴포넌트 마운트는 별도 설정이 필요하고
+      // 지금 시험하려는 판단(구간 캐싱·스포일러 방지)은 전부 순수 함수에 있다.
+      include: ['src/**/*.test.js'],
+      environment: 'node',
+    },
   }
 })


### PR DESCRIPTION
Closes #115

## 만들고 안 쓰던 API 를 잇습니다

#108 의 다시보기 조회 API 를 **부르는 곳이 없었습니다.**
이 저장소가 계속 고쳐 온 **바로 그 패턴**입니다.

**영상 플레이어와 분리했습니다.** 플레이어는 S3 재생이라 별개 관심사이고,
이 컴포넌트는 **"재생 위치 → 그때의 대화"** 만 담당합니다.

```vue
<ChatReplayPanel :meeting-id="7" :position-ms="video.currentTime * 1000" />
```

### 두 가지 판단이 순수 함수에 있습니다

| | |
|---|---|
| `windowOf` | **구간 캐싱.** 재생 중 위치는 초당 여러 번 바뀝니다. 매번 요청하면 서버가 견디지 못합니다 |
| `visibleAt` | **스포일러 방지.** 구간을 통째로 그리면 아직 오지 않은 대화가 미리 보입니다 |

`hasMore` 를 화면에 표시합니다 — **말없이 자르면 "그때 분명 더 있었는데" 가 됩니다.**

## 프론트에 테스트가 0개였습니다

```
backend   294개
ai         23개
frontend    0개   ← 러너조차 없었습니다
```

포트폴리오의 주장이 *"모든 수정을 회귀하면 깨지는 테스트로 고정했다"* 인데
**프론트에서 그 주장이 깨지고 있었습니다.**

| 되돌린 것 | 실패 |
|---|---:|
| `visibleAt` 제거 | 3개 |
| 구간을 겹치게 | 3개 |

## ★ Node 25 에서 안 되던 것을 근본에서 고쳤습니다

`vite.config.js` 가 `vite-plugin-vue-devtools` 를 **정적 import** 하는데,
이 플러그인은 **모듈 로드 시점에 `localStorage`** 를 건드립니다.
Node 25 의 `localStorage` 는 객체로 존재하지만 `getItem` 이 없습니다.

```
TypeError: localStorage.getItem is not a function
```

**그동안 Node 22 컨테이너로 빌드해 피해 왔습니다.**
빌드는 그래도 되지만 **테스트는 로컬에서 돌아야 의미가 있습니다.**

devtools 는 개발 서버에서만 필요하므로 **동적 import** 로 바꿨습니다.

> `command === 'serve'` 만으로는 부족했습니다.
> **vitest 가 내부적으로 vite 개발 서버를 띄워서** `command` 가 `serve` 로 옵니다.
> `VITEST` 환경변수로 함께 가릅니다.

이제 **Node 25 에서 빌드도(2.09s) 테스트도(8개)** 됩니다.

## 검증

CI 의 프론트 잡에 테스트 단계를 추가했습니다.