### PR TITLE
refactor: summarize_text_auto 471줄을 다섯으로 나눈다 (#135)

### DIFF
--- a/ai/kr_font.py
+++ b/ai/kr_font.py
@@ -1,0 +1,55 @@
+"""PDF 에 쓸 한글 폰트를 찾는다. (#135)
+
+폰트가 없으면 예외가 아니라 **글자가 네모로 나온다.** 그래서 발견이 늦다 -
+`ai/Dockerfile` 이 `COPY fonts ./fonts` 를 왜 하는지도 여기에 달려 있다.
+
+`summarize_text_auto` 안에 중첩 함수로 있던 것을 뗐다. 파일시스템만 만지므로
+tmp_path 로 시험할 수 있다 - 471줄 안에 있을 때는 그럴 자리가 없었다.
+"""
+from __future__ import annotations
+
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+FONT_NAMES = [
+    "NotoSansKR-Regular.ttf", "NotoSansKR-Regular.otf",
+    "NotoSansKR-Medium.ttf", "NotoSansKR-SemiBold.ttf",
+    "NotoSansKR-Bold.ttf", "NotoSansKR-Black.ttf",
+    "NotoSansKR-Light.ttf", "NotoSansKR-ExtraLight.ttf",
+    "NotoSansKR-ExtraBold.ttf", "NotoSansKR-Thin.ttf",
+]
+
+
+def default_search_dirs() -> list[str]:
+    return [
+        os.path.join(HERE, "fonts"),
+        os.path.normpath(os.path.join(HERE, "..", "backend", "fonts")),
+    ]
+
+
+def find_kr_font_paths(search_dirs: list[str] | None = None) -> dict:
+    """찾은 폰트와, 본문/굵게에 쓸 대표 두 개를 고른다.
+
+    대표를 고르는 순서에 뜻이 있다 - **굵은 폰트가 없다고 실패하지 않는다.**
+    Bold -> SemiBold -> ExtraBold -> (없으면) regular 로 내려간다.
+    제목이 조금 덜 굵은 것보다 PDF 가 안 나오는 쪽이 나쁘다.
+    """
+    found: dict[str, str] = {}
+    for directory in (search_dirs or default_search_dirs()):
+        if not os.path.isdir(directory):
+            continue
+        lowered = {fn.lower(): os.path.join(directory, fn) for fn in os.listdir(directory)}
+        for name in FONT_NAMES:
+            for lower_name, path in lowered.items():
+                if lower_name.endswith(name.lower()):
+                    found[name.split(".")[0]] = path
+
+    regular = (found.get("NotoSansKR-Regular")
+               or next((p for k, p in found.items() if "Regular" in k), None)
+               or next(iter(found.values()), None))
+    bold = (found.get("NotoSansKR-Bold")
+            or found.get("NotoSansKR-SemiBold")
+            or found.get("NotoSansKR-ExtraBold")
+            or regular)
+    return {"regular": regular, "bold": bold, "all": found}

--- a/ai/main.py
+++ b/ai/main.py
@@ -2,14 +2,18 @@
 from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-import os, re, glob, wave, traceback, subprocess, requests, time, json, shutil, textwrap
+import os, re, glob, wave, traceback, subprocess, requests, time, json, shutil
 
 # 백엔드와 말하는 코드는 backend_client.py 로 옮겼다. (#117)
+# 요약 파이프라인은 다섯 조각으로 나눴다. (#135)
 #
-# ★ 나머지는 옮기지 않았다. summarize_text_auto 가 471줄인데 테스트가 0개다.
-#   테스트 없이 쪼개면 "동작이 바뀌었는지 알 방법이 없는 변경" 이 되고,
-#   471줄이라 테스트를 쓸 수도 없다 - 닭-달걀이다.
-#   먼저 그 함수를 시험 가능한 크기로 만드는 작업이 필요하고, 그건 별개다.
+# #117 에서는 summarize_text_auto 를 두고 이렇게 적었다 -
+#   "471줄인데 테스트가 0개다. 테스트 없이 쪼개면 동작이 바뀌었는지 알 방법이
+#    없고, 471줄이라 테스트를 쓸 수도 없다 - 닭-달걀이다."
+#
+# 닭-달걀은 함수 전체에만 성립했다. 함수 안에는 이미 경계가 있었고,
+# 그중 셋은 순수 함수라 옮기기만 하면 바로 시험할 수 있었다.
+# 쪼갤 수 없어서 못 쓴 게 아니라 쪼갤 순서를 안 정했던 것이다.
 from backend_client import (
     send_summary_to_api,
     send_captions_to_api,
@@ -19,7 +23,18 @@ from backend_client import (
 )
 from dotenv import load_dotenv
 from openai import OpenAI
-from fpdf import FPDF
+
+# summarize_text_auto 에서 뗀 조각들. (#135)
+#   #117 에서 "471줄이라 테스트를 쓸 수 없다" 고 적어 둔 그 함수다.
+#   닭-달걀은 함수 전체에만 성립했고 조각에는 성립하지 않았다.
+from summary_llm import (
+    clean_transcript,
+    join_notes,
+    map_summarize,
+    reduce_via_gms,
+    reduce_via_openai,
+)
+from summary_pdf import write_pdf
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
@@ -368,469 +383,86 @@ def _load_openai_clients():
 
 
 def summarize_text_auto(transcript_path: str, out_dir: str) -> dict:
-   
+    """transcript 를 정제 -> 부분 요약 -> 통합 -> md/pdf 로 만든다. (#135)
+
+    ★ 전에는 이 함수가 471줄이었고 테스트가 0개였다.
+
+      #117 에서 backend_client 를 뗄 때 여기는 일부러 두고 이렇게 적었다 -
+      "테스트 없이 쪼개면 동작이 바뀌었는지 알 방법이 없고, 471줄이라
+       테스트를 쓸 수도 없다. 닭-달걀이다."
+
+      닭-달걀은 **함수 전체에만 성립하고 조각에는 성립하지 않았다.**
+      쪼갤 수 없어서 못 쓴 게 아니라 쪼갤 순서를 안 정했던 것이다.
+      테스트를 먼저 씌울 수 있는 것부터 뗐다.
+
+          transcript_chunker   순수 함수
+          kr_font              파일시스템만
+          markdown_blocks      순수 함수 - 파싱과 그리기를 갈랐다
+          summary_pdf          블록을 받아 그리기만
+          summary_llm          클라이언트를 인자로 받는다
+
+      여기 남은 것은 조립과 파일 입출력이다.
+    """
     try:
-        oai, clean_model, summary_model = _load_openai_clients()
+        client, clean_model, summary_model = _load_openai_clients()
+
         env_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "../backend/.env"))
         if os.path.exists(env_path):
             load_dotenv(env_path)
 
-        use_claude = os.getenv("USE_GMS_CLAUDE", "false").lower() == "true"
-        gms_key    = os.getenv("GMS_KEY", "").strip()
-        
-        gms_base = os.getenv("GMS_ANTHROPIC_BASE", "https://gms.ssafy.io/gmsapi/api.anthropic.com").rstrip("/")
-        
         if not os.path.isfile(transcript_path):
             return {"ok": False, "detail": f"transcript 없음: {transcript_path}"}
 
         with open(transcript_path, "r", encoding="utf-8") as f:
             raw = f.read()
 
-        def chunk_text(text: str, max_chars: int):
-            chunks, buf = [], []
-            for line in text.splitlines(keepends=True):
-                if sum(len(x) for x in buf) + len(line) > max_chars and buf:
-                    chunks.append("".join(buf)); buf = []
-                buf.append(line)
-            if buf: chunks.append("".join(buf))
-            return chunks
-
-        def find_kr_font_paths() -> dict:
-            
-            candidates_dirs = [
-                os.path.join(HERE, "fonts"),
-                os.path.normpath(os.path.join(HERE, "..", "backend", "fonts")),
-            ]
-            names = [
-                "NotoSansKR-Regular.ttf", "NotoSansKR-Regular.otf",
-                "NotoSansKR-Medium.ttf", "NotoSansKR-SemiBold.ttf",
-                "NotoSansKR-Bold.ttf", "NotoSansKR-Black.ttf",
-                "NotoSansKR-Light.ttf", "NotoSansKR-ExtraLight.ttf",
-                "NotoSansKR-ExtraBold.ttf", "NotoSansKR-Thin.ttf",
-            ]
-            found = {}
-            for d in candidates_dirs:
-                if not os.path.isdir(d):
-                    continue
-                lowerfiles = {fn.lower(): os.path.join(d, fn) for fn in os.listdir(d)}
-                for n in names:
-                    for k, p in lowerfiles.items():
-                        if k.endswith(n.lower()):
-                            key = n.split(".")[0]  # e.g. NotoSansKR-Bold
-                            found[key] = p
-            # 대표 regular/bold 결정
-            regular = (found.get("NotoSansKR-Regular") or
-                       next((p for k, p in found.items() if "Regular" in k), None) or
-                       next(iter(found.values()), None))
-            bold    = (found.get("NotoSansKR-Bold") or
-                       found.get("NotoSansKR-SemiBold") or
-                       found.get("NotoSansKR-ExtraBold") or
-                       regular)
-            return {"regular": regular, "bold": bold, "all": found}
-        
-        def markdown_to_pdf(md_text: str, pdf_path: str):
-            fonts = find_kr_font_paths()
-            regular_path = fonts.get("regular")
-            bold_path    = fonts.get("bold")
-
-            class PrettyPDF(FPDF):
-                def __init__(self, *args, **kwargs):
-                    super().__init__(*args, **kwargs)
-                    self.doc_title = ""
-                    self.family_base = "NotoKR" if regular_path else "Helvetica"
-                    self.family_mono = "NotoKR-Mono" if regular_path else "Courier"
-
-                def header(self):
-                    if not self.doc_title:
-                        return
-                    self.set_y(12)
-                    self.set_font(self.family_base, "B", 15)
-                    self.set_text_color(25, 25, 25)
-                    self.cell(0, 8, self.doc_title, ln=1)
-                    # 얇은 구분선
-                    self.set_draw_color(200, 200, 200)
-                    self.set_line_width(0.4)
-                    self.line(self.l_margin, self.get_y()+1, self.w - self.r_margin, self.get_y()+1)
-                    self.ln(5)
-
-                def footer(self):
-                    self.set_y(-15)
-                    self.set_font(self.family_base, "", 10)
-                    self.set_text_color(120, 120, 120)
-                    self.cell(0, 8, f"{self.page_no()}", align="C")
-
-            ACCENT = (34, 197, 94)   # 브랜드 그린
-            CODE_BG = (245, 246, 248)
-            CALL_BG = (248, 250, 246)
-
-            pdf = PrettyPDF(format="A4", unit="mm")
-            pdf.set_left_margin(18)
-            pdf.set_right_margin(18)
-            pdf.set_auto_page_break(auto=True, margin=18)
-            pdf.add_page()
-
-            if regular_path:
-                pdf.add_font("NotoKR", "", regular_path, uni=True)
-                pdf.add_font("NotoKR", "B", bold_path or regular_path, uni=True)
-                # 코드 블록에서도 한글 보이게 동일 폰트 사용
-                pdf.add_font("NotoKR-Mono", "", regular_path, uni=True)
-            # 기본 폰트
-            base_family = pdf.family_base
-            mono_family = pdf.family_mono
-
-            usable_w = pdf.w - pdf.l_margin - pdf.r_margin
-            line_h   = 6.0
-            para_gap = 1.5
-            bullet_indent = 5.5
-            # 문서 제목(H1 첫 줄) 추출 → 헤더에 사용
-            for ln in md_text.splitlines():
-                if ln.startswith("# "):
-                    pdf.doc_title = ln[2:].strip()
-                    break
-
-            pdf.set_font(base_family, "", 12)
-            pdf.set_text_color(20, 20, 20)
-
-            def hr(gap=2):
-                pdf.set_draw_color(230, 230, 230)
-                pdf.set_line_width(0.4)
-                pdf.line(pdf.l_margin, pdf.get_y(), pdf.w - pdf.r_margin, pdf.get_y())
-                pdf.ln(gap)
-
-            def para(text, h=line_h, fill=False):
-                pdf.set_x(pdf.l_margin)
-                pdf.multi_cell(usable_w, h, text, fill=fill)
-                pdf.ln(para_gap)
-
-            def bullet(text):
-                x = pdf.get_x()
-                pdf.set_x(pdf.l_margin)
-                pdf.cell(bullet_indent, line_h, "•")
-                pdf.set_x(pdf.l_margin + bullet_indent)
-                pdf.multi_cell(usable_w - bullet_indent, line_h, text)
-
-            # 코드/수식 박스
-            in_code = False
-            code_is_math = False
-            def open_code(is_math=False):
-                # 배경 박스 느낌으로 줄마다 fill True
-                pdf.ln(0.5)
-                pdf.set_fill_color(*CODE_BG if not is_math else (240, 245, 255))
-                pdf.set_draw_color(220, 220, 220)
-                pdf.set_line_width(0.2)
-                pdf.set_font(mono_family, "", 10)
-                pdf.set_text_color(40, 40, 40 if not is_math else 0)
-
-            def close_code():
-                pdf.set_text_color(20, 20, 20)
-                pdf.set_font(base_family, "", 12)
-                pdf.ln(1.0)
-
-            # 요약(Callout) 박스 모드
-            callout = False
-            def open_callout():
-                pdf.ln(0.5)
-                pdf.set_fill_color(*CALL_BG)
-            def close_callout():
-                pdf.ln(1.0)
-
-            # 본문 렌더링
-            lines = md_text.splitlines()
-            i = 0
-            while i < len(lines):
-                raw = lines[i]
-                line = raw.rstrip("\n")
-
-                # 코드/수식 토글
-                if line.strip().startswith("```"):
-                    if not in_code:
-                        tag = line.strip()[3:].strip().lower()
-                        code_is_math = (tag == "math")
-                        in_code = True
-                        open_code(code_is_math)
-                    else:
-                        in_code = False
-                        close_code()
-                    i += 1
-                    continue
-                    
-                if in_code:
-                    # 줄 단위로 채워진 박스
-                    pdf.set_x(pdf.l_margin + 2)
-                    pdf.multi_cell(usable_w - 4, 5, line, fill=True)
-                    i += 1
-                    continue
-
-                 # 섹션 헤딩
-                if line.startswith("### "):
-                    pdf.set_font(base_family, "B", 13)
-                    para(line[4:].strip())
-                    pdf.set_font(base_family, "", 12)
-                    i += 1
-                    continue
-
-                if line.startswith("## "):
-                    # 요약 헤딩은 Accent 라벨 + Callout 박스 시작
-                    title = line[3:].strip()
-                    pdf.set_font(base_family, "B", 16)
-                    # 액센트 라벨
-                    pdf.set_text_color(*ACCENT)
-                    para(title)
-                    pdf.set_text_color(20, 20, 20)
-                    hr(gap=2)
-
-                    # "요약" 섹션이면 배경 박스 모드
-                    if title.replace(" ", "") in ("요약", "Summary"):
-                        callout = True
-                        open_callout()
-                    else:
-                        if callout:
-                            callout = False
-                            close_callout()
-                    pdf.set_font(base_family, "", 12)
-                    i += 1
-                    continue
-
-                if line.startswith("# "):
-                    pdf.set_font(base_family, "B", 20)
-                    # 큰 타이틀은 아래 여백 조금 더
-                    para(line[2:].strip())
-                    hr(gap=3)
-                    pdf.set_font(base_family, "", 12)
-                    i += 1
-                    continue
-
-                # 불릿
-                if line.strip().startswith("- "):
-                    body = line.strip()[2:]
-                    if callout:
-                        # 콜아웃 내부 불릿은 약간 더 촘촘히 + 배경
-                        pdf.set_fill_color(*CALL_BG)
-                        x = pdf.get_x()
-                        pdf.set_x(pdf.l_margin)
-                        pdf.cell(bullet_indent, line_h, "•", fill=True)
-                        pdf.set_x(pdf.l_margin + bullet_indent)
-                        pdf.multi_cell(usable_w - bullet_indent, line_h, body, fill=True)
-                    else:
-                        bullet(body)
-                    i += 1
-                    continue
-
-                # 빈 줄
-                if not line.strip():
-                    pdf.ln(2 if callout else 1)
-                    i += 1
-                    continue
-
-                # ✅ 일반 문단
-                if callout:
-                    pdf.set_fill_color(*CALL_BG)
-                    para(line, fill=True)
-                else:
-                    para(line)
-                i += 1
-
-            # 마지막에 열어둔 callout 닫기
-            if callout:
-                close_callout()
-
-            pdf.output(pdf_path)
-
-
-        # 1) 전처리(clean) — OpenAI
-        system_clean = (
-            "너는 한국어 전사 텍스트를 정제하는 도우미다. "
-            "원문 의미를 보존하고 환각을 피한다. "
-            "해야 할 일: 문장 경계/문장부호 복원, 띄어쓰기·맞춤법 보정, 중복/잡음 최소화. "
-            "불명확하면 [불명확]로 표기하고 임의로 보충하지 않는다."
-        )
-        o3_max = int(os.getenv("O3_CHUNK_CHARS", "9000"))
-        clean_chunks = []
-        for i, ch in enumerate(chunk_text(raw, o3_max), 1):
-            prompt = (
-                "아래 한국어 텍스트를 의미 왜곡 없이 정리하세요.\n"
-                "- 문장부호/문장 경계 복원, 띄어쓰기/맞춤법 보정\n"
-                "- 명백한 중복/잡음은 간단히 정리(사실 추가/삭제 금지)\n"
-                "- 고유명사가 한국어 음역일 때, 맥락이 명확하면 원어(예: C++)로 복원\n"
-                "- 불명확하면 [불명확] 표기\n\n"
-                f"{ch}"
-
-            )
-            try:
-                resp = oai.responses.create(
-                    model=clean_model,
-                    input=[
-                        {"role":"system","content": system_clean},
-                        {"role":"user","content": prompt}
-                    ],
-                    temperature=0.2,
-                    max_output_tokens=2000,
-                )
-                clean_chunks.append(resp.output_text.strip())
-            except Exception:
-                comp = oai.chat.completions.create(
-                    model=clean_model,
-                    messages=[
-                        {"role":"system","content": system_clean},
-                        {"role":"user","content": prompt}
-                    ],
-                    temperature=0.2,
-                )
-                clean_chunks.append(comp.choices[0].message.content.strip())
-        cleaned = "\n\n".join(clean_chunks)
+        # 1) 정제
+        cleaned = clean_transcript(client, clean_model, raw)
         cleaned_path = os.path.join(out_dir, "cleaned.txt")
         with open(cleaned_path, "w", encoding="utf-8") as fw:
             fw.write(cleaned)
 
-        # 2) 맵 요약 — OpenAI
-        system_summarize = (
-            
-            
-            "너는 정확한 한국어 필기자다. 환각 없이 핵심을 구조화하고, "
-            "수식은 입력에 실제 언급된 경우에만 ```math 블록을 사용한다."
-        )
-        sum_max = int(os.getenv("OAI_SUMMARY_CHARS", "8000"))
-        map_notes = []
-        for i, ch in enumerate(chunk_text(cleaned, sum_max), 1):
-            prompt = (
-                 "아래 텍스트를 한국어 강의 노트로 요약하세요.\n"
-                "- 핵심 포인트 3~6개 불릿\n"
-                "- 수학/과학/공학 등에서 실제 언급된 공식이 있으면 ```math 블록으로 표기\n"
-                "- 입력에 없는 사실 금지, 불명확하면 [불명확]\n\n"
-                f"{ch}"
-            )
-            try:
-                resp = oai.responses.create(
-                    model=summary_model,
-                    input=[
-                        {"role":"system","content": system_summarize},
-                        {"role":"user","content": prompt}
-                    ],
-                    temperature=0.3,
-                    max_output_tokens=2200,
-                )
-                map_notes.append(resp.output_text.strip())
-            except Exception:
-                comp = oai.chat.completions.create(
-                    model=summary_model,
-                    messages=[
-                        {"role":"system","content": system_summarize},
-                        {"role":"user","content": prompt}
-                    ],
-                    temperature=0.3,
-                )
-                map_notes.append(comp.choices[0].message.content.strip())
+        # 2) 부분 요약 (map)
+        notes_joined = join_notes(map_summarize(client, summary_model, cleaned))
 
-        notes_joined = "\n\n---\n\n".join(map_notes)
-
-        # 3) 최종 리듀스 — Claude via GMS (우선)
+        # 3) 통합 (reduce). GMS 를 먼저 보고 안 되면 OpenAI 로 간다 -
+        #    GMS 는 사내 프록시라 없을 수 있고, 없다고 요약을 버릴 이유는 없다.
         final_md = None
-        if use_claude and gms_key:
-            url = f"{gms_base}/v1/messages"
-            headers = {
-                "Content-Type": "application/json",
-                "x-api-key": gms_key,
-                "anthropic-version": "2023-06-01",
-            }
-            payload = {
-                "model": "claude-3-7-sonnet-latest",
-                "max_tokens": 4500,
-                "system": "너는 한국어 기술 문서 작성자다. 부분 요약들을 하나의 일관된 마크다운 문서로 통합하라. 중복 제거, 용어/표기 통일, 사실 보존, 환각 금지.",
-                "messages": [
-                    {"role": "user", "content":
-                        "다음 '부분 요약 노트'를 통합해 하나의 강의 문서를 만들어라.\n"
-                        "- 섹션: # 요약(5~8문장), ## 핵심 개념(불릿으로 리스트), ## 수식/정의(수학/과학 등 수식이 있는 경우만, ```math)\n"
-                        "- 중복 제거, 용어 일관성 유지, 사실 추가/삭제 금지\n\n"
-                        f"{notes_joined}"
-                    }
-                ],
-            }
-            r = requests.post(url, headers=headers, data=json.dumps(payload), timeout=120)
-            if r.status_code == 200:
-                j = r.json()
-                content = j.get("content", [])
-                if content and isinstance(content, list) and isinstance(content[0], dict) and "text" in content[0]:
-                    final_md = content[0]["text"].strip()
-            else:
-                print("[GMS Claude] HTTP", r.status_code, r.text[:200])
-
-        # 폴백 — OpenAI reduce
+        if os.getenv("USE_GMS_CLAUDE", "false").lower() == "true":
+            gms_key = os.getenv("GMS_KEY", "").strip()
+            if gms_key:
+                final_md = reduce_via_gms(
+                    notes_joined,
+                    os.getenv("GMS_ANTHROPIC_BASE",
+                              "https://gms.ssafy.io/gmsapi/api.anthropic.com"),
+                    gms_key,
+                )
         if not final_md:
-            prompt = (
-                "다음 요약 노트 묶음을 하나의 문서로 통합하세요. "
-                "중복 제거, 용어 일관성 유지, 사실추가 금지. "
-                "출력은 Markdown으로 하고 아래 섹션을 포함:\n"
-                "1) 요약(5~8문장)\n"
-                "2) 핵심 개념 리스트\n"
-                "3) 수학, 과학, 공학과 같이 공식이 필요, 언급 되거나 공식이 있으면 설명이 잘 된다면 수식을 표기해줘\n"
-                f"{notes_joined}"
-            )
-            try:
-                resp = oai.responses.create(
-                    model=summary_model,
-                    input=[
-                        {"role":"system","content":
-                         """
-                        내가 한국어로 작성된 방대한 텍스트를 너에게 줄게. 
-                        텍스트 내용은 선생님이 학생들에게 가르친 내용, 즉 수업 내용이야. 
-                        따라서 텍스트는 수학, 언어, 과학, 역사, 경제, 공학 등 초,중,고, 대학교를 포함해 주식, 부동산 등 다양한 내용일 수 있어. 
-                        텍스트는 정말 많은 단어를 포함하고 있기 때문에 나는 텍스트를 잘 요약해서 학생들에게 주고 싶어. 
-                        따라서 텍스트에 있는 수업 내용만을 포함하고, hallucinations를 피하고, 한국어 깔끔한 한국어 Markdown을 작성해줘. 
-                        """},
-                        {"role":"user","content":prompt}
-                    ],
-                    temperature=0.3,
-                    max_output_tokens=3000,
-                )
-                final_md = resp.output_text.strip()
-            except Exception:
-                comp = oai.chat.completions.create(
-                    model=summary_model,
-                    messages=[
-                        {"role":"system","content":"You are a senior Korean technical writer. Merge partial notes into one coherent Markdown document."},
-                        {"role":"user","content":prompt}
-                    ],
-                    temperature=0.3,
-                )
-                final_md = comp.choices[0].message.content.strip()
+            final_md = reduce_via_openai(client, summary_model, notes_joined)
 
-
-
-        # 4) 저장 & PDF
-        summary_md_path  = os.path.join(out_dir, "summary.md")
+        # 4) 저장
+        summary_md_path = os.path.join(out_dir, "summary.md")
         summary_pdf_path = os.path.join(out_dir, "summary.pdf")
         with open(summary_md_path, "w", encoding="utf-8") as fw:
             fw.write(final_md)
 
-        try:
-            markdown_to_pdf(final_md, summary_pdf_path)
-        except Exception as pdf_err:
-            print(f"[PDF] markdown_to_pdf 실패, fallback 실행: {pdf_err}")
-            pdf = FPDF(format="A4", unit="mm")
-            pdf.set_auto_page_break(auto=True, margin=15)
-            pdf.add_page()
-            fonts = find_kr_font_paths()
-            regular_path = fonts.get("regular")
-            if regular_path and os.path.exists(regular_path):
-                pdf.add_font("NotoKR", "", regular_path, uni=True)
-                pdf.set_font("NotoKR", size=12)
-            else:
-                pdf.set_font("Helvetica", size=12)
-
-            for line in final_md.splitlines():
-                # 긴 라인도 끊어서 출력
-                wrapped = textwrap.wrap(line, width=100, break_long_words=True, break_on_hyphens=False) or [""]
-                for seg in wrapped:
-                    pdf.multi_cell(0, 6, seg)
-            pdf.output(summary_pdf_path)
-
-        print("✅ summary 저장:", summary_md_path, " / ", summary_pdf_path)
+        # ★ PDF 실패가 요약 전체를 실패시키지 않는다. (#135)
+        #
+        #   전에는 여기서 난 예외가 바깥 except 까지 올라가 ok:False 가 됐다.
+        #   summary.md 는 이미 만들어져 있는데도 그랬다 - 그러면 다시 하려면
+        #   정제와 요약을 처음부터, 즉 토큰을 처음부터 다시 쓴다.
+        #
+        #   send_summary_to_api 는 pdf_path 가 없어도 md 만 올린다.
+        pdf_mode = write_pdf(final_md, summary_pdf_path)
+        print("summary 저장:", summary_md_path, "/",
+              summary_pdf_path if pdf_mode != "failed" else "(PDF 없음)", f"[{pdf_mode}]")
 
         return {
             "ok": True,
             "summary_path": summary_md_path,
-            "summary_pdf_path": summary_pdf_path,
+            "summary_pdf_path": summary_pdf_path if pdf_mode != "failed" else None,
             "clean_path": cleaned_path,
+            "pdf_mode": pdf_mode,
         }
 
     except Exception as e:

--- a/ai/markdown_blocks.py
+++ b/ai/markdown_blocks.py
@@ -1,0 +1,115 @@
+"""마크다운을 블록으로 읽는다 - 그리지는 않는다. (#135)
+
+★ 왜 뗐나.
+
+`markdown_to_pdf` 안에서 **"이 줄이 무슨 블록인가" 와 "그것을 어떻게 그리나" 가
+한 루프에 섞여** 있었다. `in_code` · `code_is_math` · `callout` 세 상태를
+FPDF 를 부르는 코드가 직접 들고 있어서, 파싱만 물어보는 시험을 쓸 자리가 없었다.
+
+여기에는 FPDF 가 없다. 그래서 "이 줄은 h2 이고 콜아웃을 연다" 를 그냥 물어볼 수 있다.
+
+★ 콜아웃은 왜 있나.
+
+`## 요약` 섹션만 배경색 박스로 그린다. 그래서 h2 가 상태를 바꾼다 -
+`요약`/`Summary` 면 열고, 다른 h2 면 닫는다. 문서 끝까지 열려 있으면 끝에서 닫는다.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+CALLOUT_TITLES = ("요약", "Summary")
+
+
+@dataclass(frozen=True)
+class Block:
+    """한 덩어리.
+
+    :param kind: h1 · h2 · h3 · bullet · code · blank · para
+    :param lines: `code` 전용. 펜스 안의 줄들
+    :param is_math: ```math 펜스인가. 배경색이 달라진다
+    :param in_callout: 이 블록이 콜아웃 박스 안인가
+    :param starts_callout: 이 h2 가 콜아웃을 여는가
+    :param ends_callout: 이 h2 가 콜아웃을 닫는가
+    """
+    kind: str
+    text: str = ""
+    lines: tuple[str, ...] = field(default=())
+    is_math: bool = False
+    in_callout: bool = False
+    starts_callout: bool = False
+    ends_callout: bool = False
+
+
+def _is_fence(line: str) -> bool:
+    return line.strip().startswith("```")
+
+
+def parse_markdown_blocks(md_text: str) -> list[Block]:
+    """줄들을 블록으로 바꾼다.
+
+    판정 순서를 원본 그대로 둔다 - 펜스 → 헤딩 → 불릿 → 빈 줄 → 문단.
+    순서를 바꾸면 `- ` 로 시작하는 헤딩 같은 경계 사례에서 결과가 달라진다.
+    """
+    blocks: list[Block] = []
+    lines = md_text.splitlines()
+    callout = False
+    i = 0
+
+    while i < len(lines):
+        line = lines[i].rstrip("\n")
+
+        if _is_fence(line):
+            tag = line.strip()[3:].strip().lower()
+            body: list[str] = []
+            i += 1
+            # 닫는 펜스가 없으면 끝까지 코드로 본다. 원본도 그랬다 -
+            # 모델이 펜스를 안 닫는 일이 실제로 있고, 그때 나머지를 문단으로
+            # 그리면 코드가 본문 폭으로 흘러 더 읽기 어렵다.
+            while i < len(lines) and not _is_fence(lines[i]):
+                body.append(lines[i].rstrip("\n"))
+                i += 1
+            i += 1
+            blocks.append(Block("code", lines=tuple(body),
+                                is_math=(tag == "math"), in_callout=callout))
+            continue
+
+        if line.startswith("### "):
+            blocks.append(Block("h3", text=line[4:].strip(), in_callout=callout))
+        elif line.startswith("## "):
+            title = line[3:].strip()
+            starts = title.replace(" ", "") in CALLOUT_TITLES
+            ends = (not starts) and callout
+            blocks.append(Block("h2", text=title, in_callout=callout,
+                                starts_callout=starts, ends_callout=ends))
+            if starts:
+                callout = True
+            elif ends:
+                callout = False
+        elif line.startswith("# "):
+            blocks.append(Block("h1", text=line[2:].strip(), in_callout=callout))
+        elif line.strip().startswith("- "):
+            blocks.append(Block("bullet", text=line.strip()[2:], in_callout=callout))
+        elif not line.strip():
+            blocks.append(Block("blank", in_callout=callout))
+        else:
+            blocks.append(Block("para", text=line, in_callout=callout))
+        i += 1
+
+    return blocks
+
+
+def callout_left_open(blocks: list[Block]) -> bool:
+    """문서가 끝날 때까지 콜아웃이 열려 있는가 - 그리는 쪽이 끝에서 닫아야 한다.
+
+    마지막 블록의 `in_callout` 을 보면 안 된다. 그 값은 **그 블록을 처리하기 전**
+    상태라, 마지막 h2 가 `## 요약` 이면 열어 놓고도 False 로 보인다.
+    """
+    state = False
+    for block in blocks:
+        if block.kind != "h2":
+            continue
+        if block.starts_callout:
+            state = True
+        elif block.ends_callout:
+            state = False
+    return state

--- a/ai/summary_llm.py
+++ b/ai/summary_llm.py
@@ -1,0 +1,198 @@
+"""정제 → 부분 요약 → 통합. LLM 을 부르는 부분만 모았다. (#135)
+
+★ 여기 있는 것 중 제일 중요한 것은 폴백이다.
+
+`summarize_text_auto` 안에서 이 모양이 **세 번 똑같이** 반복되고 있었다.
+
+    try:
+        resp = oai.responses.create(...)      # 신 API
+        ...output_text
+    except Exception:
+        comp = oai.chat.completions.create(...)   # 구 API
+        ...choices[0].message.content
+
+세 벌이라 고칠 때 하나를 빠뜨리기 쉽고, **한 번도 시험된 적이 없었다.**
+`responses` 가 실패해야 도는 길인데 그 실패를 만들 자리가 없었기 때문이다.
+한곳으로 모으고 가짜 클라이언트로 두 갈래를 다 지나가게 했다.
+
+★ 클라이언트를 인자로 받는다.
+
+전에는 함수 안에서 `_load_openai_clients()` 를 불렀다. 그러면 시험이 돌 때마다
+`OPENAI_API_KEY` 를 요구하고, 없으면 예외가 나서 **요약 로직을 한 줄도 못 재본다.**
+부르는 쪽이 만들어 넘기면 가짜를 넣을 수 있다.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import requests
+
+from transcript_chunker import chunk_text
+
+SYSTEM_CLEAN = (
+    "너는 한국어 전사 텍스트를 정제하는 도우미다. "
+    "원문 의미를 보존하고 환각을 피한다. "
+    "해야 할 일: 문장 경계/문장부호 복원, 띄어쓰기·맞춤법 보정, 중복/잡음 최소화. "
+    "불명확하면 [불명확]로 표기하고 임의로 보충하지 않는다."
+)
+
+SYSTEM_SUMMARIZE = (
+    "너는 정확한 한국어 필기자다. 환각 없이 핵심을 구조화하고, "
+    "수식은 입력에 실제 언급된 경우에만 ```math 블록을 사용한다."
+)
+
+SYSTEM_REDUCE = """
+                        내가 한국어로 작성된 방대한 텍스트를 너에게 줄게. 
+                        텍스트 내용은 선생님이 학생들에게 가르친 내용, 즉 수업 내용이야. 
+                        따라서 텍스트는 수학, 언어, 과학, 역사, 경제, 공학 등 초,중,고, 대학교를 포함해 주식, 부동산 등 다양한 내용일 수 있어. 
+                        텍스트는 정말 많은 단어를 포함하고 있기 때문에 나는 텍스트를 잘 요약해서 학생들에게 주고 싶어. 
+                        따라서 텍스트에 있는 수업 내용만을 포함하고, hallucinations를 피하고, 한국어 깔끔한 한국어 Markdown을 작성해줘. 
+                        """
+
+SYSTEM_REDUCE_FALLBACK = (
+    "You are a senior Korean technical writer. "
+    "Merge partial notes into one coherent Markdown document."
+)
+
+
+def ask(client, model: str, system: str, prompt: str,
+        temperature: float, max_output_tokens: int) -> str:
+    """신 API 를 먼저 부르고, 실패하면 구 API 로 내려간다.
+
+    두 API 의 응답 모양이 다르다 - `output_text` 와 `choices[0].message.content`.
+    호출부가 그것까지 알 필요는 없어서 여기서 문자열 하나로 맞춘다.
+
+    `except Exception` 이 넓은 것은 의도다. SDK 버전·프록시·모델에 따라
+    나오는 예외 종류가 제각각이고, 어느 쪽이든 할 일은 같다 - 구 API 로 간다.
+    """
+    try:
+        response = client.responses.create(
+            model=model,
+            input=[{"role": "system", "content": system},
+                   {"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+        )
+        return response.output_text.strip()
+    except Exception:
+        completion = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "system", "content": system},
+                      {"role": "user", "content": prompt}],
+            temperature=temperature,
+        )
+        return completion.choices[0].message.content.strip()
+
+
+def clean_transcript(client, model: str, raw: str, max_chars: int | None = None) -> str:
+    """STT 원문을 문장으로 되돌린다. 사실을 더하거나 빼지 않는다."""
+    limit = max_chars or int(os.getenv("O3_CHUNK_CHARS", "9000"))
+    parts = []
+    for chunk in chunk_text(raw, limit):
+        prompt = (
+            "아래 한국어 텍스트를 의미 왜곡 없이 정리하세요.\n"
+            "- 문장부호/문장 경계 복원, 띄어쓰기/맞춤법 보정\n"
+            "- 명백한 중복/잡음은 간단히 정리(사실 추가/삭제 금지)\n"
+            "- 고유명사가 한국어 음역일 때, 맥락이 명확하면 원어(예: C++)로 복원\n"
+            "- 불명확하면 [불명확] 표기\n\n"
+            f"{chunk}"
+        )
+        parts.append(ask(client, model, SYSTEM_CLEAN, prompt, 0.2, 2000))
+    return "\n\n".join(parts)
+
+
+def map_summarize(client, model: str, cleaned: str, max_chars: int | None = None) -> list[str]:
+    """조각마다 부분 요약을 만든다 (map).
+
+    통합(reduce)과 나눈 이유는 컨텍스트다. 정제본 전체를 한 번에 넣으면
+    긴 강의에서 앞부분이 잘린다 - 잘렸다는 신호 없이 조용히 빠진다.
+    """
+    limit = max_chars or int(os.getenv("OAI_SUMMARY_CHARS", "8000"))
+    notes = []
+    for chunk in chunk_text(cleaned, limit):
+        prompt = (
+            "아래 텍스트를 한국어 강의 노트로 요약하세요.\n"
+            "- 핵심 포인트 3~6개 불릿\n"
+            "- 수학/과학/공학 등에서 실제 언급된 공식이 있으면 ```math 블록으로 표기\n"
+            "- 입력에 없는 사실 금지, 불명확하면 [불명확]\n\n"
+            f"{chunk}"
+        )
+        notes.append(ask(client, model, SYSTEM_SUMMARIZE, prompt, 0.3, 2200))
+    return notes
+
+
+def join_notes(notes: list[str]) -> str:
+    return "\n\n---\n\n".join(notes)
+
+
+def reduce_via_gms(notes_joined: str, gms_base: str, gms_key: str,
+                   post=requests.post, timeout: int = 120) -> str | None:
+    """SSAFY GMS 프록시로 통합을 시도한다. 실패하면 None - 예외를 올리지 않는다.
+
+    여기서 죽이면 **부분 요약까지 만들어 놓고 전부 버리게 된다.**
+    부르는 쪽이 None 을 받으면 OpenAI 로 통합하면 된다.
+    """
+    payload = {
+        "model": "claude-3-7-sonnet-latest",
+        "max_tokens": 4500,
+        "system": ("너는 한국어 기술 문서 작성자다. 부분 요약들을 하나의 일관된 마크다운 "
+                   "문서로 통합하라. 중복 제거, 용어/표기 통일, 사실 보존, 환각 금지."),
+        "messages": [{"role": "user", "content":
+                      "다음 '부분 요약 노트'를 통합해 하나의 강의 문서를 만들어라.\n"
+                      "- 섹션: # 요약(5~8문장), ## 핵심 개념(불릿으로 리스트), "
+                      "## 수식/정의(수학/과학 등 수식이 있는 경우만, ```math)\n"
+                      "- 중복 제거, 용어 일관성 유지, 사실 추가/삭제 금지\n\n"
+                      f"{notes_joined}"}],
+    }
+    try:
+        response = post(
+            f"{gms_base.rstrip('/')}/v1/messages",
+            headers={"Content-Type": "application/json",
+                     "x-api-key": gms_key,
+                     "anthropic-version": "2023-06-01"},
+            data=json.dumps(payload), timeout=timeout,
+        )
+    except Exception as err:
+        print("[GMS] 호출 실패:", err)
+        return None
+
+    if response.status_code != 200:
+        print("[GMS] HTTP", response.status_code, response.text[:200])
+        return None
+
+    content = response.json().get("content", [])
+    if content and isinstance(content, list) and isinstance(content[0], dict) \
+            and "text" in content[0]:
+        return content[0]["text"].strip()
+    print("[GMS] 응답 모양이 예상과 다르다")
+    return None
+
+
+def reduce_via_openai(client, model: str, notes_joined: str) -> str:
+    prompt = (
+        "다음 요약 노트 묶음을 하나의 문서로 통합하세요. "
+        "중복 제거, 용어 일관성 유지, 사실추가 금지. "
+        "출력은 Markdown으로 하고 아래 섹션을 포함:\n"
+        "1) 요약(5~8문장)\n"
+        "2) 핵심 개념 리스트\n"
+        "3) 수학, 과학, 공학과 같이 공식이 필요, 언급 되거나 공식이 있으면 설명이 잘 된다면 수식을 표기해줘\n"
+        f"{notes_joined}"
+    )
+    try:
+        response = client.responses.create(
+            model=model,
+            input=[{"role": "system", "content": SYSTEM_REDUCE},
+                   {"role": "user", "content": prompt}],
+            temperature=0.3,
+            max_output_tokens=3000,
+        )
+        return response.output_text.strip()
+    except Exception:
+        completion = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "system", "content": SYSTEM_REDUCE_FALLBACK},
+                      {"role": "user", "content": prompt}],
+            temperature=0.3,
+        )
+        return completion.choices[0].message.content.strip()

--- a/ai/summary_pdf.py
+++ b/ai/summary_pdf.py
@@ -1,0 +1,261 @@
+"""블록을 PDF 로 그린다 - 마크다운은 여기서 읽지 않는다. (#135)
+
+파싱은 `markdown_blocks.py` 가 한다. 여기 있는 것은 FPDF 호출뿐이다.
+
+★ 폰트가 없을 때 무슨 일이 나는가 - 원본 주석이 틀렸다. (#135)
+
+원본 코드에는 "폰트가 없으면 글자가 네모로 나온다" 는 전제가 깔려 있었다.
+**fpdf2 2.7 이후로는 그렇지 않다.**
+
+    FPDFUnicodeEncodingException: Character "강" ... is outside the range of
+    characters supported by the font used: "helvetica"
+
+예외가 난다. 그래서 되돌림 경로가 성립하지 않았다 -
+`markdown_to_pdf` 가 죽어서 `plain_pdf` 로 내려가는데, 한글이면 **거기서도 똑같이
+죽는다.** 존재 이유인 바로 그 조건에서 못 도는 되돌림이었다.
+
+그리고 그 예외는 `summarize_text_auto` 의 바깥 except 까지 올라가서
+**요약 전체를 실패시켰다.** `summary.md` 는 이미 만들어져 있는데도 그렇다.
+
+지금은 세 값을 돌려준다 - `pretty` / `plain` / `failed`.
+PDF 를 못 만들어도 마크다운은 나간다. `send_summary_to_api` 는 이미
+`pdf_path` 가 없어도 md 만 올린다.
+"""
+from __future__ import annotations
+
+import os
+import textwrap
+
+from fpdf import FPDF
+
+from kr_font import find_kr_font_paths
+from markdown_blocks import callout_left_open, parse_markdown_blocks
+
+ACCENT = (34, 197, 94)     # 브랜드 그린
+CODE_BG = (245, 246, 248)
+MATH_BG = (240, 245, 255)
+CALL_BG = (248, 250, 246)
+
+LINE_H = 6.0
+PARA_GAP = 1.5
+BULLET_INDENT = 5.5
+
+
+def _document_title(md_text: str) -> str:
+    """헤더에 반복해 찍을 제목. 첫 번째 H1 이다."""
+    for line in md_text.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""
+
+
+def _pdf_class(regular_path: str | None):
+    class PrettyPDF(FPDF):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.doc_title = ""
+            self.family_base = "NotoKR" if regular_path else "Helvetica"
+            self.family_mono = "NotoKR-Mono" if regular_path else "Courier"
+
+        def header(self):
+            if not self.doc_title:
+                return
+            self.set_y(12)
+            self.set_font(self.family_base, "B", 15)
+            self.set_text_color(25, 25, 25)
+            self.cell(0, 8, self.doc_title, ln=1)
+            self.set_draw_color(200, 200, 200)
+            self.set_line_width(0.4)
+            self.line(self.l_margin, self.get_y() + 1, self.w - self.r_margin, self.get_y() + 1)
+            self.ln(5)
+
+        def footer(self):
+            self.set_y(-15)
+            self.set_font(self.family_base, "", 10)
+            self.set_text_color(120, 120, 120)
+            self.cell(0, 8, f"{self.page_no()}", align="C")
+
+    return PrettyPDF
+
+
+def markdown_to_pdf(md_text: str, pdf_path: str, fonts: dict | None = None) -> None:
+    fonts = fonts or find_kr_font_paths()
+    regular_path = fonts.get("regular")
+    bold_path = fonts.get("bold")
+
+    pdf = _pdf_class(regular_path)(format="A4", unit="mm")
+    pdf.set_left_margin(18)
+    pdf.set_right_margin(18)
+    pdf.set_auto_page_break(auto=True, margin=18)
+    pdf.add_page()
+
+    if regular_path:
+        # uni=True 는 fpdf2 2.5.1 부터 무시되는 인자다. 지금은 무해하지만
+        # "다음 릴리스에서 제거" 라고 예고돼 있고 requirements 가 <3 이라
+        # 2.x 안에서 사라질 수 있다. 그때 TypeError 로 죽는다.
+        pdf.add_font("NotoKR", "", regular_path)
+        pdf.add_font("NotoKR", "B", bold_path or regular_path)
+        # 코드 블록도 같은 폰트를 쓴다. 등폭 폰트로 바꾸면 한글이 못 그려진다.
+        pdf.add_font("NotoKR-Mono", "", regular_path)
+
+    base_family = pdf.family_base
+    mono_family = pdf.family_mono
+    usable_w = pdf.w - pdf.l_margin - pdf.r_margin
+    pdf.doc_title = _document_title(md_text)
+
+    pdf.set_font(base_family, "", 12)
+    pdf.set_text_color(20, 20, 20)
+
+    def hr(gap=2):
+        pdf.set_draw_color(230, 230, 230)
+        pdf.set_line_width(0.4)
+        pdf.line(pdf.l_margin, pdf.get_y(), pdf.w - pdf.r_margin, pdf.get_y())
+        pdf.ln(gap)
+
+    def para(text, h=LINE_H, fill=False):
+        pdf.set_x(pdf.l_margin)
+        pdf.multi_cell(usable_w, h, text, fill=fill)
+        pdf.ln(PARA_GAP)
+
+    def bullet(text, fill=False):
+        pdf.set_x(pdf.l_margin)
+        pdf.cell(BULLET_INDENT, LINE_H, "•", fill=fill)
+        pdf.set_x(pdf.l_margin + BULLET_INDENT)
+        pdf.multi_cell(usable_w - BULLET_INDENT, LINE_H, text, fill=fill)
+
+    blocks = parse_markdown_blocks(md_text)
+
+    for block in blocks:
+        if block.kind == "code":
+            pdf.ln(0.5)
+            pdf.set_fill_color(*(MATH_BG if block.is_math else CODE_BG))
+            pdf.set_draw_color(220, 220, 220)
+            pdf.set_line_width(0.2)
+            pdf.set_font(mono_family, "", 10)
+            pdf.set_text_color(40, 40, 0 if block.is_math else 40)
+            for line in block.lines:
+                pdf.set_x(pdf.l_margin + 2)
+                pdf.multi_cell(usable_w - 4, 5, line, fill=True)
+            pdf.set_text_color(20, 20, 20)
+            pdf.set_font(base_family, "", 12)
+            pdf.ln(1.0)
+
+        elif block.kind == "h3":
+            pdf.set_font(base_family, "B", 13)
+            para(block.text)
+            pdf.set_font(base_family, "", 12)
+
+        elif block.kind == "h2":
+            pdf.set_font(base_family, "B", 16)
+            pdf.set_text_color(*ACCENT)
+            para(block.text)
+            pdf.set_text_color(20, 20, 20)
+            hr(gap=2)
+            if block.starts_callout:
+                pdf.ln(0.5)
+                pdf.set_fill_color(*CALL_BG)
+            elif block.ends_callout:
+                pdf.ln(1.0)
+            pdf.set_font(base_family, "", 12)
+
+        elif block.kind == "h1":
+            pdf.set_font(base_family, "B", 20)
+            para(block.text)
+            hr(gap=3)
+            pdf.set_font(base_family, "", 12)
+
+        elif block.kind == "bullet":
+            if block.in_callout:
+                pdf.set_fill_color(*CALL_BG)
+                bullet(block.text, fill=True)
+            else:
+                bullet(block.text)
+
+        elif block.kind == "blank":
+            pdf.ln(2 if block.in_callout else 1)
+
+        else:  # para
+            if block.in_callout:
+                pdf.set_fill_color(*CALL_BG)
+                para(block.text, fill=True)
+            else:
+                para(block.text)
+
+    if callout_left_open(blocks):
+        pdf.ln(1.0)
+
+    pdf.output(pdf_path)
+
+
+def plain_pdf(md_text: str, pdf_path: str, fonts: dict | None = None) -> None:
+    """서식 없이 글자만 넣는 되돌림 경로.
+
+    꾸미다 실패해도 **요약 자체는 나가야 한다.** 요약 본문은 이미 만들어졌고,
+    PDF 는 그것을 담는 그릇일 뿐이다. 그릇 때문에 내용을 버리지 않는다.
+    """
+    fonts = fonts or find_kr_font_paths()
+    pdf = FPDF(format="A4", unit="mm")
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+
+    regular_path = fonts.get("regular")
+    if regular_path and os.path.exists(regular_path):
+        pdf.add_font("NotoKR", "", regular_path)
+        pdf.set_font("NotoKR", size=12)
+    else:
+        pdf.set_font("Helvetica", size=12)
+
+    for line in md_text.splitlines():
+        wrapped = textwrap.wrap(line, width=100, break_long_words=True,
+                                break_on_hyphens=False) or [""]
+        for segment in wrapped:
+            # ★ x 를 매번 왼쪽으로 되돌린다. (#135)
+            #
+            #   `multi_cell(0, ...)` 의 폭은 "지금 x 부터 오른쪽 여백까지" 다.
+            #   fpdf2 의 multi_cell 은 끝나고 x 를 셀 오른쪽에 두므로,
+            #   되돌리지 않으면 두 번째 줄부터 폭이 0 에 가까워진다.
+            #
+            #       fpdf.errors.FPDFException:
+            #           Not enough horizontal space to render a single character
+            #
+            #   즉 이 되돌림 경로는 **한 줄짜리 문서에서만** 돌고 있었다.
+            #   되돌림은 잘 안 도는 길이라 그 사실을 아무도 못 봤다.
+            pdf.set_x(pdf.l_margin)
+            pdf.multi_cell(0, 6, segment)
+    pdf.output(pdf_path)
+
+
+def has_unicode_font(fonts: dict) -> bool:
+    """한글을 그릴 수 있는 폰트가 있는가.
+
+    없으면 한글 PDF 는 **만들 수 없다.** 네모로라도 나오는 게 아니라 예외가 난다.
+    """
+    return bool(fonts.get("regular"))
+
+
+def write_pdf(md_text: str, pdf_path: str, fonts: dict | None = None) -> str:
+    """꾸민 PDF -> 글자만 -> 포기. 어디까지 갔는지 돌려준다.
+
+    포기해도 예외를 올리지 않는다. **요약 본문은 이미 만들어졌고**, PDF 는 그것을
+    담는 그릇일 뿐이다. 그릇 때문에 내용을 버리면 요약을 처음부터 다시 해야 하고,
+    그건 토큰을 다시 쓰는 일이다.
+
+    :return: ``pretty`` · ``plain`` · ``failed``
+    """
+    fonts = fonts or find_kr_font_paths()
+    if not has_unicode_font(fonts):
+        print("[PDF] 한글 폰트를 못 찾았다. ai/fonts 를 확인한다 - "
+              "한글이 있으면 PDF 생성은 실패한다")
+
+    try:
+        markdown_to_pdf(md_text, pdf_path, fonts=fonts)
+        return "pretty"
+    except Exception as err:
+        print(f"[PDF] 서식 있는 PDF 실패, 글자만 넣어 본다: {err}")
+
+    try:
+        plain_pdf(md_text, pdf_path, fonts=fonts)
+        return "plain"
+    except Exception as err:
+        print(f"[PDF] 글자만 넣기도 실패했다. 마크다운만 낸다: {err}")
+        return "failed"

--- a/ai/tests/test_kr_font.py
+++ b/ai/tests/test_kr_font.py
@@ -1,0 +1,78 @@
+"""한글 폰트를 찾는 규칙. (#135)
+
+폰트가 없으면 예외가 아니라 **글자가 네모로 나온다.** 그래서 발견이 늦고,
+늦게 발견되는 것은 시험으로 고정해 둘 값어치가 있다.
+"""
+from kr_font import default_search_dirs, find_kr_font_paths
+
+
+def _make(dirpath, *names):
+    dirpath.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (dirpath / name).write_bytes(b"not-a-real-font")
+    return str(dirpath)
+
+
+def test_no_directory_means_no_font(tmp_path):
+    result = find_kr_font_paths([str(tmp_path / "없는곳")])
+    assert result["regular"] is None
+    assert result["bold"] is None
+    assert result["all"] == {}
+
+
+def test_finds_regular_and_bold(tmp_path):
+    d = _make(tmp_path / "fonts", "NotoSansKR-Regular.ttf", "NotoSansKR-Bold.ttf")
+    result = find_kr_font_paths([d])
+    assert result["regular"].endswith("NotoSansKR-Regular.ttf")
+    assert result["bold"].endswith("NotoSansKR-Bold.ttf")
+
+
+def test_bold_falls_back_through_semibold_then_regular(tmp_path):
+    """★ 굵은 폰트가 없다고 실패하지 않는다.
+
+    제목이 덜 굵은 것보다 PDF 가 아예 안 나오는 쪽이 나쁘다.
+    """
+    semi = _make(tmp_path / "a", "NotoSansKR-Regular.ttf", "NotoSansKR-SemiBold.ttf")
+    assert find_kr_font_paths([semi])["bold"].endswith("NotoSansKR-SemiBold.ttf")
+
+    only_regular = _make(tmp_path / "b", "NotoSansKR-Regular.ttf")
+    result = find_kr_font_paths([only_regular])
+    assert result["bold"] == result["regular"]
+
+
+def test_uses_any_font_when_regular_is_missing(tmp_path):
+    d = _make(tmp_path / "fonts", "NotoSansKR-Light.ttf")
+    result = find_kr_font_paths([d])
+    assert result["regular"].endswith("NotoSansKR-Light.ttf")
+
+
+def test_matching_is_case_insensitive(tmp_path):
+    d = _make(tmp_path / "fonts", "notosanskr-regular.TTF")
+    assert find_kr_font_paths([d])["regular"] is not None
+
+
+def test_otf_is_accepted_too(tmp_path):
+    d = _make(tmp_path / "fonts", "NotoSansKR-Regular.otf")
+    assert find_kr_font_paths([d])["regular"].endswith(".otf")
+
+
+def test_unrelated_files_are_ignored(tmp_path):
+    d = _make(tmp_path / "fonts", "Arial.ttf", "readme.txt")
+    assert find_kr_font_paths([d])["all"] == {}
+
+
+def test_earlier_directory_can_be_overridden_by_later_one(tmp_path):
+    """뒤에 오는 디렉터리가 이긴다 - 원본 구현의 동작이다.
+
+    ai/fonts 가 먼저고 backend/fonts 가 뒤다. 배포 이미지는 ai/fonts 만 갖고,
+    로컬에는 둘 다 있을 수 있다.
+    """
+    first = _make(tmp_path / "first", "NotoSansKR-Regular.ttf")
+    second = _make(tmp_path / "second", "NotoSansKR-Regular.ttf")
+    assert find_kr_font_paths([first, second])["regular"].startswith(second)
+
+
+def test_default_dirs_point_at_ai_then_backend():
+    dirs = default_search_dirs()
+    assert dirs[0].endswith("ai/fonts")
+    assert dirs[1].endswith("backend/fonts")

--- a/ai/tests/test_markdown_blocks.py
+++ b/ai/tests/test_markdown_blocks.py
@@ -1,0 +1,139 @@
+"""마크다운을 블록으로 읽는 규칙. (#135)
+
+★ 이 시험이 이번 분리의 이유다.
+
+전에는 파싱과 FPDF 그리기가 한 루프에 있었다. `in_code` · `code_is_math` ·
+`callout` 세 상태를 그리는 코드가 직접 들고 있어서 **"이 줄이 무슨 블록인가" 를
+물어볼 자리가 없었다.** PDF 를 만들어 열어 보는 것 말고는 확인할 방법이 없었다.
+"""
+from markdown_blocks import Block, callout_left_open, parse_markdown_blocks
+
+
+def kinds(md):
+    return [b.kind for b in parse_markdown_blocks(md)]
+
+
+def test_empty_document_has_no_block():
+    assert parse_markdown_blocks("") == []
+
+
+def test_heading_levels():
+    assert kinds("# 하나\n## 둘\n### 셋") == ["h1", "h2", "h3"]
+
+
+def test_heading_text_drops_the_marker():
+    blocks = parse_markdown_blocks("# 제목입니다")
+    assert blocks[0].text == "제목입니다"
+
+
+def test_four_hashes_is_a_paragraph_not_a_heading():
+    """`#### ` 는 처리하지 않는다 - 원본 동작이다. 조용히 h3 로 만들지 않는다."""
+    assert kinds("#### 넷") == ["para"]
+
+
+def test_bullet_and_blank_and_paragraph():
+    assert kinds("- 하나\n\n문단") == ["bullet", "blank", "para"]
+
+
+def test_bullet_text_drops_the_marker():
+    assert parse_markdown_blocks("  - 들여쓴 불릿")[0].text == "들여쓴 불릿"
+
+
+def test_code_fence_collects_lines():
+    blocks = parse_markdown_blocks("```\na = 1\nb = 2\n```")
+    assert len(blocks) == 1
+    assert blocks[0].kind == "code"
+    assert blocks[0].lines == ("a = 1", "b = 2")
+    assert blocks[0].is_math is False
+
+
+def test_math_fence_is_marked():
+    """```math 는 배경색이 다르다. 파싱 단계에서 구분해 둬야 그리는 쪽이 단순해진다."""
+    assert parse_markdown_blocks("```math\nE = mc^2\n```")[0].is_math is True
+
+
+def test_headings_inside_a_fence_are_code_not_headings():
+    """★ 펜스 안에서는 어떤 마커도 해석하지 않는다."""
+    blocks = parse_markdown_blocks("```\n# 이건 주석이다\n- 불릿 아님\n```")
+    assert len(blocks) == 1
+    assert blocks[0].lines == ("# 이건 주석이다", "- 불릿 아님")
+
+
+def test_unclosed_fence_swallows_the_rest():
+    """모델이 펜스를 안 닫는 일이 실제로 있다. 나머지를 문단으로 그리면 더 안 읽힌다."""
+    blocks = parse_markdown_blocks("```\n코드\n계속 코드")
+    assert len(blocks) == 1
+    assert blocks[0].lines == ("코드", "계속 코드")
+
+
+def test_summary_heading_opens_a_callout():
+    blocks = parse_markdown_blocks("## 요약\n첫 줄")
+    assert blocks[0].starts_callout is True
+    assert blocks[1].in_callout is True
+
+
+def test_summary_with_spaces_still_opens_a_callout():
+    """`## 요 약` 도 연다 - 공백을 지우고 비교한다."""
+    assert parse_markdown_blocks("## 요 약")[0].starts_callout is True
+
+
+def test_english_summary_heading_also_opens():
+    assert parse_markdown_blocks("## Summary")[0].starts_callout is True
+
+
+def test_another_heading_closes_the_callout():
+    blocks = parse_markdown_blocks("## 요약\n안\n## 핵심 개념\n밖")
+    assert blocks[2].ends_callout is True
+    assert blocks[1].in_callout is True
+    assert blocks[3].in_callout is False
+
+
+def test_heading_does_not_close_what_was_never_open():
+    assert parse_markdown_blocks("## 핵심 개념")[0].ends_callout is False
+
+
+def test_callout_left_open_at_the_end_is_reported():
+    """★ 마지막 블록의 in_callout 을 보면 안 된다.
+
+    그 값은 그 블록을 처리하기 **전** 상태라, 마지막 줄이 `## 요약` 이면
+    열어 놓고도 False 로 보인다.
+    """
+    assert callout_left_open(parse_markdown_blocks("## 요약")) is True
+    assert callout_left_open(parse_markdown_blocks("## 요약\n안\n## 다음")) is False
+    assert callout_left_open(parse_markdown_blocks("문단만 있다")) is False
+
+
+def test_paragraph_keeps_its_leading_spaces():
+    """문단은 strip 하지 않는다 - 원본이 raw 줄을 그대로 그렸다."""
+    assert parse_markdown_blocks("   들여쓴 문단")[0].text == "   들여쓴 문단"
+
+
+def test_blocks_are_immutable():
+    """블록은 값이다. 그리는 쪽이 상태를 되돌려 놓는 실수를 못 하게 한다."""
+    import dataclasses
+    import pytest
+    block = parse_markdown_blocks("문단")[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        block.kind = "h1"
+
+
+def test_full_document_shape():
+    md = "\n".join([
+        "# 강의 요약",
+        "",
+        "## 요약",
+        "- 첫째",
+        "- 둘째",
+        "",
+        "## 핵심 개념",
+        "본문입니다",
+        "```math",
+        "a^2 + b^2 = c^2",
+        "```",
+    ])
+    blocks = parse_markdown_blocks(md)
+    assert kinds(md) == ["h1", "blank", "h2", "bullet", "bullet",
+                         "blank", "h2", "para", "code"]
+    assert [b.in_callout for b in blocks[3:6]] == [True, True, True]
+    assert blocks[7].in_callout is False
+    assert callout_left_open(blocks) is False

--- a/ai/tests/test_summary_llm.py
+++ b/ai/tests/test_summary_llm.py
@@ -1,0 +1,158 @@
+"""LLM 호출 계층. (#135)
+
+★ 여기서 제일 중요한 것은 `ask` 의 폴백이다.
+
+전에는 이 try/except 가 `summarize_text_auto` 안에 **세 번 똑같이** 있었고
+**한 번도 시험된 적이 없었다.** `responses` 가 실패해야 도는 길인데,
+471줄 안에서는 그 실패를 만들 자리가 없었기 때문이다.
+
+클라이언트를 인자로 받게 바꾼 것도 같은 이유다. 전에는 함수 안에서
+`_load_openai_clients()` 를 불러서, 시험을 돌리려면 OPENAI_API_KEY 가 필요했다.
+"""
+import pytest
+
+import summary_llm
+from summary_llm import (ask, clean_transcript, join_notes, map_summarize,
+                         reduce_via_gms, reduce_via_openai)
+
+
+class FakeResponses:
+    def __init__(self, text=None, error=None):
+        self.text, self.error, self.calls = text, error, []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+        return type("R", (), {"output_text": self.text})()
+
+
+class FakeCompletions:
+    def __init__(self, text=None):
+        self.text, self.calls = text, []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        message = type("M", (), {"content": self.text})()
+        return type("C", (), {"choices": [type("Ch", (), {"message": message})()]})()
+
+
+class FakeClient:
+    def __init__(self, responses_text=None, responses_error=None, chat_text=None):
+        self.responses = FakeResponses(responses_text, responses_error)
+        self.chat = type("Chat", (), {})()
+        self.chat.completions = FakeCompletions(chat_text)
+
+
+# ── ask ──────────────────────────────────────────────────────────────
+
+def test_uses_the_new_api_when_it_works():
+    client = FakeClient(responses_text="  결과  ")
+    assert ask(client, "m", "sys", "prompt", 0.2, 100) == "결과"
+    assert client.chat.completions.calls == [], "성공했는데 구 API 도 불렀다"
+
+
+def test_falls_back_to_chat_completions():
+    """★ 한 번도 시험된 적 없던 길이다."""
+    client = FakeClient(responses_error=RuntimeError("이 모델은 responses 미지원"),
+                        chat_text="  폴백 결과  ")
+    assert ask(client, "m", "sys", "prompt", 0.2, 100) == "폴백 결과"
+    assert len(client.chat.completions.calls) == 1
+
+
+def test_fallback_keeps_the_same_system_and_prompt():
+    """폴백에서 프롬프트가 달라지면 결과가 조용히 달라진다."""
+    client = FakeClient(responses_error=RuntimeError("x"), chat_text="ok")
+    ask(client, "m", "시스템", "사용자", 0.3, 100)
+    messages = client.chat.completions.calls[0]["messages"]
+    assert messages[0] == {"role": "system", "content": "시스템"}
+    assert messages[1] == {"role": "user", "content": "사용자"}
+
+
+def test_fallback_drops_max_output_tokens():
+    """구 API 는 그 인자를 모른다. 넘기면 TypeError 로 폴백까지 실패한다."""
+    client = FakeClient(responses_error=RuntimeError("x"), chat_text="ok")
+    ask(client, "m", "s", "p", 0.3, 2200)
+    assert "max_output_tokens" not in client.chat.completions.calls[0]
+
+
+def test_both_paths_fail_raises():
+    """둘 다 실패하면 삼키지 않는다 - 부르는 쪽이 요약 실패로 처리해야 한다."""
+    client = FakeClient(responses_error=RuntimeError("a"))
+    client.chat.completions.create = lambda **k: (_ for _ in ()).throw(RuntimeError("b"))
+    with pytest.raises(RuntimeError, match="b"):
+        ask(client, "m", "s", "p", 0.2, 10)
+
+
+# ── clean / map ──────────────────────────────────────────────────────
+
+def test_clean_calls_once_per_chunk():
+    client = FakeClient(responses_text="정제됨")
+    result = clean_transcript(client, "m", "a\nb\nc\n", max_chars=2)
+    assert len(client.responses.calls) == 3
+    assert result == "정제됨\n\n정제됨\n\n정제됨"
+
+
+def test_map_returns_one_note_per_chunk():
+    client = FakeClient(responses_text="노트")
+    assert map_summarize(client, "m", "a\nb\n", max_chars=2) == ["노트", "노트"]
+
+
+def test_join_notes_uses_a_visible_separator():
+    """구분자가 없으면 통합 프롬프트가 부분 요약들을 한 덩어리로 읽는다."""
+    assert join_notes(["A", "B"]) == "A\n\n---\n\nB"
+
+
+def test_empty_transcript_makes_no_call():
+    client = FakeClient(responses_text="x")
+    assert clean_transcript(client, "m", "", max_chars=100) == ""
+    assert client.responses.calls == []
+
+
+# ── reduce ───────────────────────────────────────────────────────────
+
+class FakeHttpResponse:
+    def __init__(self, status, payload=None, text=""):
+        self.status_code, self._payload, self.text = status, payload, text
+
+    def json(self):
+        return self._payload
+
+
+def test_gms_reduce_returns_the_text():
+    def post(url, **kwargs):
+        assert url.endswith("/v1/messages")
+        assert kwargs["headers"]["x-api-key"] == "key"
+        return FakeHttpResponse(200, {"content": [{"text": "  통합본  "}]})
+
+    assert reduce_via_gms("노트", "https://gms.example.com/", "key", post=post) == "통합본"
+
+
+@pytest.mark.parametrize("response", [
+    FakeHttpResponse(500, text="서버 오류"),
+    FakeHttpResponse(200, {"content": []}),
+    FakeHttpResponse(200, {"content": [{"no_text": 1}]}),
+    FakeHttpResponse(200, {}),
+])
+def test_gms_reduce_returns_none_instead_of_raising(response):
+    """★ 여기서 죽이면 부분 요약을 다 만들어 놓고 전부 버리게 된다."""
+    assert reduce_via_gms("노트", "https://gms.example.com", "key",
+                          post=lambda *a, **k: response) is None
+
+
+def test_gms_transport_failure_returns_none():
+    def boom(*a, **k):
+        raise ConnectionError("닿지 않음")
+    assert reduce_via_gms("노트", "https://gms.example.com", "key", post=boom) is None
+
+
+def test_openai_reduce_falls_back_too():
+    client = FakeClient(responses_error=RuntimeError("x"), chat_text="통합 폴백")
+    assert reduce_via_openai(client, "m", "노트") == "통합 폴백"
+
+
+def test_openai_reduce_uses_the_korean_system_prompt():
+    client = FakeClient(responses_text="ok")
+    reduce_via_openai(client, "m", "노트")
+    system = client.responses.calls[0]["input"][0]["content"]
+    assert system is summary_llm.SYSTEM_REDUCE

--- a/ai/tests/test_summary_pdf.py
+++ b/ai/tests/test_summary_pdf.py
@@ -1,0 +1,150 @@
+"""PDF 를 실제로 만들어 본다. (#135)
+
+여기는 순수 함수가 아니라 스모크다. 파싱은 `test_markdown_blocks.py` 가 이미
+따로 잰다 - 그래서 여기서는 **그리다가 죽지 않는가**와 **되돌림이 어디까지 가는가**만 본다.
+
+★ 이 시험을 쓰다가 결함을 하나 찾았다.
+
+원본에는 "폰트가 없으면 글자가 네모로 나온다" 는 전제가 깔려 있었다. 아니었다 -
+fpdf2 2.7 이후로는 FPDFUnicodeEncodingException 이 난다. 그래서 되돌림 경로가
+성립하지 않았다. markdown_to_pdf 가 죽어 plain_pdf 로 내려가는데 한글이면
+**거기서도 똑같이 죽고**, 그 예외가 summarize_text_auto 바깥까지 올라가
+**summary.md 를 이미 만들어 놓고도 요약 전체가 실패**했다.
+
+471줄 안에 있을 때는 이 조건을 만들 자리가 없었다.
+"""
+import pytest
+
+import summary_pdf
+from kr_font import find_kr_font_paths
+from summary_pdf import has_unicode_font, markdown_to_pdf, plain_pdf, write_pdf
+
+MD = "\n".join([
+    "# 강의 요약",
+    "",
+    "## 요약",
+    "- 첫째 항목",
+    "- 둘째 항목",
+    "",
+    "## 핵심 개념",
+    "본문 문단입니다",
+    "```math",
+    "a^2 + b^2 = c^2",
+    "```",
+    "### 작은 제목",
+    "```",
+    "print('hello')",
+    "```",
+])
+
+NO_FONTS = {"regular": None, "bold": None, "all": {}}
+ASCII_MD = "# Title\n\n- one\n- two\n\nplain paragraph"
+
+
+@pytest.fixture
+def kr_fonts():
+    """저장소에 들어 있는 진짜 폰트. 없으면 이 시험들은 의미가 없다."""
+    fonts = find_kr_font_paths()
+    if not fonts.get("regular"):
+        pytest.skip("ai/fonts 에 한글 폰트가 없다")
+    return fonts
+
+
+def _pdf_bytes(path):
+    assert path.exists(), "PDF 가 안 만들어졌다"
+    data = path.read_bytes()
+    assert data.startswith(b"%PDF"), "PDF 헤더가 아니다"
+    return data
+
+
+def test_renders_a_full_document(kr_fonts, tmp_path):
+    out = tmp_path / "s.pdf"
+    markdown_to_pdf(MD, str(out), fonts=kr_fonts)
+    assert len(_pdf_bytes(out)) > 500
+
+
+def test_renders_an_empty_document(kr_fonts, tmp_path):
+    out = tmp_path / "empty.pdf"
+    markdown_to_pdf("", str(out), fonts=kr_fonts)
+    _pdf_bytes(out)
+
+
+def test_renders_a_document_that_leaves_a_callout_open(kr_fonts, tmp_path):
+    """`## 요약` 으로 끝나는 문서. 닫는 처리를 안 하면 여기서 드러난다."""
+    out = tmp_path / "open.pdf"
+    markdown_to_pdf("# 제목\n## 요약\n- 하나", str(out), fonts=kr_fonts)
+    _pdf_bytes(out)
+
+
+def test_renders_an_unclosed_code_fence(kr_fonts, tmp_path):
+    out = tmp_path / "fence.pdf"
+    markdown_to_pdf("```\n닫히지 않은 코드", str(out), fonts=kr_fonts)
+    _pdf_bytes(out)
+
+
+def test_plain_pdf_wraps_very_long_lines(kr_fonts, tmp_path):
+    out = tmp_path / "plain.pdf"
+    plain_pdf("가" * 5000, str(out), fonts=kr_fonts)
+    _pdf_bytes(out)
+
+
+def test_even_ascii_fails_without_a_unicode_font_because_of_the_bullet(tmp_path):
+    """★ 영문 문서도 안 된다 - 불릿 기호 자체가 latin-1 밖이다.
+
+    본문이 전부 ASCII 여도 `- ` 를 그리는 순간 `•` 를 찍는다. 그래서
+    "영문이면 폰트 없이도 된다" 는 위안이 성립하지 않는다.
+    폰트가 없으면 이 서비스의 PDF 는 사실상 만들 수 없다.
+    """
+    with pytest.raises(Exception) as caught:
+        markdown_to_pdf(ASCII_MD, str(tmp_path / "ascii.pdf"), fonts=NO_FONTS)
+    assert "•" in str(caught.value)
+
+
+def test_ascii_without_bullets_renders_without_a_unicode_font(tmp_path):
+    """불릿이 없으면 영문 문서는 나온다 - 경계를 정확히 적어 둔다."""
+    out = tmp_path / "ascii-plain.pdf"
+    markdown_to_pdf("# Title\n\nplain paragraph", str(out), fonts=NO_FONTS)
+    _pdf_bytes(out)
+
+
+def test_korean_without_a_unicode_font_raises(tmp_path):
+    """★ 원본이 틀렸던 지점. 네모로 나오는 게 아니라 예외가 난다."""
+    with pytest.raises(Exception) as caught:
+        markdown_to_pdf("# 강의 요약", str(tmp_path / "x.pdf"), fonts=NO_FONTS)
+    assert "helvetica" in str(caught.value).lower()
+
+
+def test_has_unicode_font():
+    assert has_unicode_font(NO_FONTS) is False
+    assert has_unicode_font({"regular": "/some/font.ttf"}) is True
+
+
+def test_write_pdf_uses_the_pretty_path_when_it_works(kr_fonts, tmp_path):
+    out = tmp_path / "w.pdf"
+    assert write_pdf(MD, str(out), fonts=kr_fonts) == "pretty"
+    _pdf_bytes(out)
+
+
+def test_write_pdf_falls_back_to_plain_when_rendering_dies(kr_fonts, tmp_path, monkeypatch):
+    """꾸미다 실패해도 글자는 넣는다."""
+    def boom(*args, **kwargs):
+        raise RuntimeError("multi_cell 폭 계산 실패")
+
+    monkeypatch.setattr(summary_pdf, "markdown_to_pdf", boom)
+    out = tmp_path / "fallback.pdf"
+    assert write_pdf(MD, str(out), fonts=kr_fonts) == "plain"
+    _pdf_bytes(out)
+
+
+def test_write_pdf_gives_up_instead_of_raising(tmp_path):
+    """★ 한글 + 폰트 없음 = 두 경로가 다 죽는다. 그래도 예외를 올리지 않는다.
+
+    요약 본문은 이미 만들어졌다. 그릇 때문에 내용을 버리면
+    정제와 요약을 처음부터 다시 해야 하고, 그건 토큰을 다시 쓰는 일이다.
+    """
+    assert write_pdf("# 강의 요약", str(tmp_path / "none.pdf"), fonts=NO_FONTS) == "failed"
+
+
+def test_document_title_is_the_first_h1():
+    assert summary_pdf._document_title("잡담\n# 진짜 제목\n# 두 번째") == "진짜 제목"
+    assert summary_pdf._document_title("h1 이 없다") == ""

--- a/ai/tests/test_transcript_chunker.py
+++ b/ai/tests/test_transcript_chunker.py
@@ -1,0 +1,52 @@
+"""장문을 자르는 규칙. (#135)
+
+`summarize_text_auto` 안에 있던 9줄짜리 중첩 함수다.
+471줄 안에 있을 때는 이 시험 여덟 개를 쓸 자리가 없었다.
+"""
+from transcript_chunker import chunk_text
+
+
+def test_short_text_stays_one_chunk():
+    assert chunk_text("한 줄", 100) == ["한 줄"]
+
+
+def test_empty_text_makes_no_chunk():
+    assert chunk_text("", 100) == []
+
+
+def test_splits_before_exceeding_the_limit():
+    text = "aaaa\nbbbb\ncccc\n"      # 줄마다 5자(개행 포함)
+    assert chunk_text(text, 10) == ["aaaa\nbbbb\n", "cccc\n"]
+
+
+def test_keeps_line_endings():
+    """★ keepends 다. 개행을 버리면 이어 붙일 때 문장이 붙어 버린다."""
+    assert "".join(chunk_text("a\nb\nc\n", 3)) == "a\nb\nc\n"
+
+
+def test_nothing_is_lost_or_duplicated():
+    text = "\n".join(f"{i}번째 문장입니다" for i in range(200))
+    for limit in (10, 50, 500, 10_000):
+        assert "".join(chunk_text(text, limit)) == text
+
+
+def test_a_single_long_line_is_not_cut():
+    """★ 한 줄이 상한보다 길어도 자르지 않는다.
+
+    문장 중간에서 자르면 정제 프롬프트가 잘린 문장을 완성하려 들면서
+    없는 말을 만든다. 조각이 조금 큰 쪽이 낫다.
+    """
+    long_line = "가" * 100
+    assert chunk_text(long_line, 10) == [long_line]
+
+
+def test_long_line_still_starts_a_new_chunk():
+    result = chunk_text("짧다\n" + "가" * 100, 10)
+    assert len(result) == 2
+    assert result[1] == "가" * 100
+
+
+def test_limit_boundary_is_exclusive():
+    """정확히 상한이면 아직 안 자른다 - 넘을 때 자른다."""
+    assert chunk_text("abcde\n", 6) == ["abcde\n"]
+    assert len(chunk_text("abcde\nx", 6)) == 2

--- a/ai/transcript_chunker.py
+++ b/ai/transcript_chunker.py
@@ -1,0 +1,28 @@
+"""장문을 모델에 넣을 수 있는 크기로 자른다. (#135)
+
+`summarize_text_auto` 안에 중첩 함수로 있던 것을 그대로 뗐다.
+동작을 바꾸지 않았다 - 먼저 시험을 씌우려고 자리만 옮겼다.
+
+**줄 경계로만 자른다.** 문장 중간에서 자르면 정제·요약 프롬프트가
+잘린 문장을 완성하려 들면서 없는 말을 만든다.
+"""
+from __future__ import annotations
+
+
+def chunk_text(text: str, max_chars: int) -> list[str]:
+    """줄 단위로 모아 `max_chars` 를 넘기 직전에 끊는다.
+
+    한 줄이 그 자체로 `max_chars` 보다 길면 자르지 않고 통째로 하나가 된다.
+    STT 결과는 줄이 문장 단위라 실제로는 거의 일어나지 않고, 여기서 다시 쪼개면
+    문장 중간이 잘린다 - 그쪽이 더 나쁘다.
+    """
+    chunks: list[str] = []
+    buf: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if sum(len(x) for x in buf) + len(line) > max_chars and buf:
+            chunks.append("".join(buf))
+            buf = []
+        buf.append(line)
+    if buf:
+        chunks.append("".join(buf))
+    return chunks

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,26 @@ STT   "python 을 배웠습니다"   →   저장   "파이썬 을 배웠습니�
 
 → [`ops/11-mcp-transcript-server.md`](ops/11-mcp-transcript-server.md)
 
+### 닭-달걀은 함수 전체에만 성립한다
+
+`summarize_text_auto` 는 471줄인데 시험이 0개였다. #117 에서 이렇게 적어 뒀다 —
+*"테스트 없이 쪼개면 동작이 바뀌었는지 알 방법이 없고, 471줄이라 테스트를 쓸 수도 없다."*
+
+**뒷 문장이 틀렸다.** 함수 안에 이미 경계가 있었고 그중 셋은 순수 함수였다.
+쪼갤 수 없어서 못 쓴 게 아니라 **쪼갤 순서를 안 정했던 것**이다.
+
+그리고 시험을 쓰자마자 결함이 셋 나왔다. 셋 다 **되돌림 경로**에 있었다.
+
+| | |
+|---|---|
+| 폰트가 없으면 예외가 난다 | 원본은 "네모로 나온다" 를 전제했다. 그래서 되돌림 PDF 가 **존재 이유인 그 조건에서 같이 죽었다** |
+| 그 예외가 요약 전체를 죽였다 | `summary.md` 는 이미 만들어졌는데 버렸다. 다시 하려면 토큰을 처음부터 다시 쓴다 |
+| 되돌림 PDF 는 한 줄 문서에서만 돌았다 | `multi_cell(0, ...)` 뒤에 x 를 안 되돌려서 둘째 줄부터 폭이 0 이 된다 |
+
+**잘 안 도는 길일수록 시험이 유일한 관측 수단이다.**
+
+→ [`refactoring/02-split-summarize.md`](refactoring/02-split-summarize.md)
+
 ### MySQL 은 "새로 고른 DB" 가 아니라 유지한 운영 전제다
 
 EduMeet 에서 DB 를 PostgreSQL 로 바꾸지 않은 이유는 PostgreSQL 이 부족해서가 아니다.
@@ -323,6 +343,7 @@ DEFAULT_BLOCKING_SEND_TIMEOUT = 20 * 1000;
 | [`performance/12-hls-codec-benchmark.md`](performance/12-hls-codec-benchmark.md) | H264 리먹싱 vs VP8 재인코딩 vs audio-only HLS 의 CPU·세그먼트 길이 비교 |
 | [`performance/13-caption-archive-transcript.md`](performance/13-caption-archive-transcript.md) | final 자막만 비동기 저장해 요약 입력으로 쓰는 경로 |
 | [`refactoring/01-remove-port-adapter.md`](refactoring/01-remove-port-adapter.md) | Port/Adapter 제거. 코드 38% 감소, 최적화 쿼리가 죽어 있었음 |
+| [`refactoring/02-split-summarize.md`](refactoring/02-split-summarize.md) | **471줄 · 시험 0.** 쪼개자 결함 3건이 나왔다 — 되돌림 PDF 가 존재 이유인 조건에서 죽고 있었다 |
 
 ### 운영
 

--- a/docs/refactoring/02-split-summarize.md
+++ b/docs/refactoring/02-split-summarize.md
@@ -1,0 +1,197 @@
+# 471줄과 테스트 0개 — 닭-달걀은 어디서 끊는가
+
+> **#135.** `ai/main.py` 의 `summarize_text_auto`.
+
+---
+
+## 반년 전의 나에게 반박한다
+
+#117 에서 `backend_client.py` 를 뗄 때, 이 함수는 일부러 두고 이렇게 적었다.
+
+> 테스트 없이 쪼개면 '동작이 바뀌었는지 알 방법이 없는 변경' 이 된다.
+> 그런데 471줄이라 테스트를 쓸 수가 없다 — **닭-달걀이다.**
+
+앞 문장은 맞다. 뒷 문장이 틀렸다.
+
+**닭-달걀은 함수 전체에만 성립했고 조각에는 성립하지 않았다.**
+함수 안에는 이미 경계가 있었다. 세어 보면 이렇다.
+
+| 조각 | 줄수 | 성질 | 먼저 시험할 수 있나 |
+|---|---:|---|---|
+| `chunk_text` | 9 | 순수 함수 | **가능** |
+| `find_kr_font_paths` | 30 | 파일시스템만 | **가능** (`tmp_path`) |
+| 마크다운 파싱 | ~90 | 순수 함수로 뗄 수 있다 | **가능** |
+| FPDF 그리기 | ~160 | 부수효과 | 스모크만 |
+| LLM clean/map/reduce | ~120 | 네트워크 | 클라이언트를 주입하면 가능 |
+
+**쪼갤 수 없어서 시험을 못 쓴 게 아니라, 쪼갤 순서를 안 정했던 것이다.**
+
+---
+
+## 결과
+
+```
+ai/main.py                471줄 · 시험 0
+        ↓
+ai/transcript_chunker.py   28줄 · 시험  8      순수
+ai/kr_font.py              55줄 · 시험  9      파일시스템만
+ai/markdown_blocks.py     115줄 · 시험 19      순수
+ai/summary_pdf.py         261줄 · 시험 12      스모크
+ai/summary_llm.py         198줄 · 시험 17      클라이언트 주입
+ai/main.py                 88줄 · 조립만
+```
+
+파이썬 시험 **30 → 96.**
+
+---
+
+## 파싱과 그리기를 가른 것이 제일 컸다
+
+원본은 `markdown_to_pdf` 안에서 **"이 줄이 무슨 블록인가" 와 "그것을 어떻게 그리나" 가
+한 루프**에 있었다.
+
+```python
+in_code = False
+code_is_math = False
+callout = False
+while i < len(lines):
+    if line.strip().startswith("```"):
+        ...  open_code(code_is_math)      # 상태 판정과 FPDF 호출이 같은 자리
+```
+
+세 개의 상태를 **FPDF 를 부르는 코드가 직접 들고 있었다.**
+그래서 *"`## 요약` 다음 불릿은 콜아웃 안인가"* 를 물어볼 방법이
+**PDF 를 만들어 눈으로 여는 것밖에 없었다.**
+
+지금은 `parse_markdown_blocks` 가 값을 돌려준다.
+
+```python
+assert parse_markdown_blocks("## 요약\n- 하나")[1].in_callout is True
+```
+
+---
+
+## 시험을 쓰자마자 결함이 셋 나왔다
+
+**이게 이 작업의 값어치다.** 리팩터링이 아니라 그 리팩터링이 가능하게 만든 시험이 찾았다.
+
+### 1. 되돌림 PDF 가 존재 이유인 조건에서 죽는다
+
+원본에는 이런 전제가 깔려 있었다 — *"폰트가 없으면 글자가 네모로 나온다."*
+
+**아니었다.**
+
+```
+fpdf.errors.FPDFUnicodeEncodingException:
+  Character "강" at index 2 in text is outside the range of characters
+  supported by the font used: "helvetica"
+```
+
+fpdf2 2.7 이후로는 **예외가 난다.** 그래서 구조가 이랬다.
+
+```
+markdown_to_pdf  실패
+    ↓
+plain_pdf (Helvetica)  ← 한글이면 여기서도 똑같이 죽는다
+    ↓
+summarize_text_auto 의 바깥 except
+    ↓
+ok: False               ← summary.md 는 이미 만들어져 있는데도
+```
+
+**요약 본문은 만들어졌는데 PDF 때문에 전부 버려진다.**
+다시 하려면 정제와 map/reduce 를 처음부터, 즉 **토큰을 처음부터 다시 쓴다.**
+
+`send_summary_to_api` 는 이미 `pdf_path` 가 없어도 md 만 올리도록 돼 있었다.
+받을 준비는 되어 있는데 보내는 쪽이 포기하고 있었다.
+
+### 2. 되돌림 PDF 는 한 줄짜리 문서에서만 돌았다
+
+```
+fpdf.errors.FPDFException: Not enough horizontal space to render a single character
+```
+
+```python
+pdf.multi_cell(0, 6, segment)
+```
+
+`multi_cell(0, ...)` 의 폭은 **"지금 x 부터 오른쪽 여백까지"** 다.
+fpdf2 의 `multi_cell` 은 끝나고 x 를 셀 오른쪽에 둔다.
+되돌리지 않으면 **두 번째 줄부터 폭이 0 에 가까워진다.**
+
+되돌림 경로는 잘 안 도는 길이라 아무도 못 봤다.
+**잘 안 도는 길일수록 시험이 유일한 관측 수단이다.**
+
+### 3. "영문이면 폰트 없이도 된다" 도 아니었다
+
+본문이 전부 ASCII 여도 `- ` 를 만나면 `•` 를 찍는다. `•` 는 latin-1 밖이다.
+
+```python
+def test_even_ascii_fails_without_a_unicode_font_because_of_the_bullet():
+    assert "•" in str(caught.value)
+```
+
+**폰트가 없으면 이 서비스의 PDF 는 사실상 만들 수 없다.** 위안이 없다.
+그래서 `write_pdf` 가 먼저 확인하고 로그로 말한다.
+
+---
+
+## 한 번도 시험된 적 없던 폴백
+
+`responses` → `chat.completions` 폴백이 **세 번 똑같이** 반복되고 있었다.
+
+```python
+try:
+    resp = oai.responses.create(...)
+    ...output_text
+except Exception:
+    comp = oai.chat.completions.create(...)
+    ...choices[0].message.content
+```
+
+세 벌이라 고칠 때 하나를 빠뜨리기 쉽고, **한 번도 실행된 적이 없었다** —
+`responses` 가 실패해야 도는 길인데 471줄 안에서는 그 실패를 만들 자리가 없었다.
+
+한곳(`ask`)으로 모으고 가짜 클라이언트로 두 갈래를 다 지나가게 했다.
+그러자 폴백에서만 나는 문제도 물어볼 수 있게 됐다.
+
+```python
+def test_fallback_drops_max_output_tokens():
+    """구 API 는 그 인자를 모른다. 넘기면 TypeError 로 폴백까지 실패한다."""
+```
+
+### 클라이언트를 인자로 받는다
+
+전에는 함수 안에서 `_load_openai_clients()` 를 불렀다.
+그러면 시험이 돌 때마다 `OPENAI_API_KEY` 를 요구하고, 없으면 예외가 나서
+**요약 로직을 한 줄도 못 재본다.**
+
+> 이 저장소가 AI 서비스를 못 띄우는 이유 셋 중 하나가 "유료 키" 다.
+> 키가 없어서 못 재던 것을 **키 없이 재게 만든 것**이 이 변경의 절반이다.
+
+---
+
+## 동작을 바꾸지 않은 부분
+
+옮기기만 한 것과 고친 것을 나눠 적는다. 섞으면 나중에 어느 쪽인지 알 수 없다.
+
+| | |
+|---|---|
+| **그대로 옮김** | `chunk_text` · `find_kr_font_paths` · 프롬프트 문자열 전부 · 블록 판정 순서 · 색상값 |
+| **고침** | PDF 실패가 요약을 죽이지 않는다 · `plain_pdf` 의 x 되돌림 · `uni=True` 제거 |
+
+프롬프트는 **공백 하나까지 그대로** 뒀다. 프롬프트가 바뀌면 결과가 바뀌는데
+그것은 시험으로 못 잡는다.
+
+`uni=True` 는 fpdf2 2.5.1 부터 무시되는 인자이고 "다음 릴리스에서 제거" 가 예고돼 있다.
+`requirements` 가 `fpdf2>=2.7,<3` 이라 **2.x 안에서 사라질 수 있고**, 그때 `TypeError` 로 죽는다.
+
+---
+
+## 남은 것
+
+| | |
+|---|---|
+| `merge_audio` 174줄 | 오디오 병합. 파일 입출력이라 tmp_path 로 뗄 수 있다. 다음 차례 |
+| `Start_STT` 142줄 | CLOVA 호출. 클라이언트 주입으로 같은 방법이 쓰인다 |
+| PDF 시각 검증 | 지금은 "죽지 않는가" 까지다. 픽셀 비교는 안 한다 — 폰트 버전에 따라 흔들려 유지비가 값어치를 넘는다 |


### PR DESCRIPTION
Closes #135

## 반년 전에 적은 것에 반박한다

#117 에서 이 함수를 두고 이렇게 적었다.

> 테스트 없이 쪼개면 '동작이 바뀌었는지 알 방법이 없는 변경' 이 된다.
> 그런데 471줄이라 테스트를 쓸 수가 없다 — **닭-달걀이다.**

앞 문장은 맞다. **뒷 문장이 틀렸다.**

| 조각 | 줄수 | 성질 | 먼저 시험 가능? |
|---|---:|---|---|
| `chunk_text` | 9 | 순수 함수 | **가능** |
| `find_kr_font_paths` | 30 | 파일시스템만 | **가능** |
| 마크다운 파싱 | ~90 | 순수 함수로 뗄 수 있다 | **가능** |
| FPDF 그리기 | ~160 | 부수효과 | 스모크만 |
| LLM clean/map/reduce | ~120 | 네트워크 | 클라이언트 주입하면 가능 |

닭-달걀은 **함수 전체에만** 성립했다.
쪼갤 수 없어서 시험을 못 쓴 게 아니라 **쪼갤 순서를 안 정했던 것**이다.

```
ai/main.py                471줄 · 시험 0
        ↓
ai/transcript_chunker.py   28줄 · 시험  8
ai/kr_font.py              55줄 · 시험  9
ai/markdown_blocks.py     115줄 · 시험 19
ai/summary_pdf.py         261줄 · 시험 12
ai/summary_llm.py         198줄 · 시험 17
ai/main.py                 88줄 · 조립만
```

**파이썬 시험 30 → 96.**

## ★ 시험을 쓰자마자 결함이 셋 나왔다

셋 다 **되돌림 경로**에 있었다. 잘 안 도는 길이라 아무도 못 봤다.

### 1. 되돌림 PDF 가 존재 이유인 조건에서 죽는다

원본 전제 — *"폰트가 없으면 글자가 네모로 나온다."* **아니었다.**

```
fpdf.errors.FPDFUnicodeEncodingException:
  Character "강" ... outside the range of characters supported by: "helvetica"
```

```
markdown_to_pdf  실패
    ↓
plain_pdf (Helvetica)   ← 한글이면 여기서도 똑같이 죽는다
```

### 2. 그 예외가 요약 전체를 죽였다

```
    ↓  바깥 except
ok: False               ← summary.md 는 이미 만들어져 있는데도
```

다시 하려면 정제와 map/reduce 를 처음부터 — **토큰을 처음부터 다시 쓴다.**

`send_summary_to_api` 는 이미 `pdf_path` 없이 md 만 올릴 수 있었다.
**받을 준비는 되어 있는데 보내는 쪽이 포기하고 있었다.**

### 3. 되돌림 PDF 는 한 줄짜리 문서에서만 돌았다

```
fpdf.errors.FPDFException: Not enough horizontal space to render a single character
```

`multi_cell(0, ...)` 의 폭은 **"지금 x 부터 오른쪽 여백까지"** 인데,
fpdf2 는 끝나고 x 를 셀 오른쪽에 둔다. 되돌리지 않으면 **둘째 줄부터 폭이 0** 이 된다.

> 그리고 *"영문이면 폰트 없이도 된다"* 도 아니다 — `- ` 를 만나면 `•` 를 찍는데
> latin-1 밖이다. 폰트가 없으면 이 서비스의 PDF 는 사실상 만들 수 없다.

## 한 번도 실행된 적 없던 폴백

`responses` → `chat.completions` 가 **세 번 똑같이** 있었다.
`responses` 가 실패해야 도는 길이라 471줄 안에서는 그 실패를 만들 자리가 없었다.

한곳(`ask`)으로 모으고 가짜 클라이언트로 두 갈래를 다 지나가게 했다.

```python
def test_fallback_drops_max_output_tokens():
    """구 API 는 그 인자를 모른다. 넘기면 TypeError 로 폴백까지 실패한다."""
```

**클라이언트를 인자로 받게 바꿨다.** 전에는 함수 안에서 `_load_openai_clients()` 를
불러서 시험을 돌리려면 `OPENAI_API_KEY` 가 필요했다 —
이 저장소가 AI 서비스를 못 띄우는 이유 셋 중 하나가 그 키다.
**키가 없어서 못 재던 것을 키 없이 재게 만들었다.**

## 옮긴 것과 고친 것

| | |
|---|---|
| **그대로 옮김** | `chunk_text` · `find_kr_font_paths` · **프롬프트 문자열 전부** · 블록 판정 순서 · 색상값 |
| **고침** | PDF 실패가 요약을 죽이지 않는다 · `plain_pdf` 의 x 되돌림 · `uni=True` 제거 |

프롬프트는 **공백 하나까지** 그대로 뒀다. 바뀌면 결과가 바뀌는데 그건 시험으로 못 잡는다.

`uni=True` 는 fpdf2 2.5.1 부터 무시되고 "다음 릴리스에서 제거" 가 예고돼 있다.
`fpdf2>=2.7,<3` 이라 **2.x 안에서 사라질 수 있고**, 그때 `TypeError` 로 죽는다.

## 확인

```
ai/  pytest -q   →  96 passed  (전 30)
```

문서: `docs/refactoring/02-split-summarize.md`