### PR TITLE
fix(build): Docker 29 에서 Testcontainers 가 붙게 API 버전을 못 박는다 (#153)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -109,6 +109,20 @@ tasks.named<Test>("test") {
 
     systemProperty("spring.profiles.active", "test")
 
+    // Testcontainers 가 붙을 Docker API 버전. (#153)
+    //
+    //   Docker 29 는 API 1.40 미만을 거절하는데, Testcontainers 가 쓰는 docker-java 의
+    //   기본값은 1.32 다. 그래서 최신 Docker 가 깔린 곳에서는 시험이 통째로 초기화 실패한다.
+    //
+    //       Docker 19.03  API 1.40
+    //       Docker 20.10  API 1.41   <- 오래된 러너도 커버해야 한다
+    //       Docker 29     API 1.40 이상만 허용
+    //
+    //   1.41 이 두 조건을 동시에 만족하는 값이다. 1.44 로 올리면 오래된 쪽이 깨진다.
+    //   환경변수(DOCKER_API_VERSION)나 ~/.testcontainers.properties 로는 안 먹는다 -
+    //   docker-java 가 읽는 것은 시험 JVM 의 시스템 속성이다.
+    systemProperty("api.version", System.getProperty("api.version") ?: "1.41")
+
     // 테스트 결과 로깅
     testLogging {
         events("passed", "skipped", "failed")


### PR DESCRIPTION
Closes #153

운영 서버(Docker **29.4.2**)에서 Testcontainers 시험이 전부 초기화 실패했다.

```
client version 1.32 is too old. Minimum supported API version is 1.40
```

Docker 29 가 API 1.40 미만을 거절하는데 **docker-java 기본값이 1.32** 다.
소켓 권한 문제가 아니다 — 같은 소켓으로 `docker:cli` 는 정상 동작한다.

CI 러너의 Docker 가 아직 낮아서 지금까지 안 걸렸다. **러너가 29 로 올라가면 백엔드 시험이 통째로 깨진다.**

## 왜 1.41 인가

| Docker | API |
|---|---|
| 19.03 | 1.40 |
| 20.10 | **1.41** |
| 29 | 1.40 이상만 허용 |

**두 조건을 동시에 만족하는 값**이다. 1.44 로 올리면 오래된 러너가 깨진다.

## 안 먹은 방법

- `DOCKER_API_VERSION` 환경변수 — docker-java 는 `api.version` 을 `API_VERSION` 으로 매핑한다
- `~/.testcontainers.properties` 의 `api.version` — Testcontainers 자체 설정 키가 아니라 무시된다

**시험 JVM 의 시스템 속성**이어야 한다. 바깥에서 덮어쓸 수 있게 뒀다.

## 확인

Docker 29.4.2 서버에서 init 스크립트 없이 확인한다(아래).