### PR TITLE
fix(caption): 자막 발행을 요청 스레드에서 떼어 전용 경로로 가른다 (#151)

### DIFF
--- a/backend/src/main/java/com/edu/edumeet/meeting/service/CaptionBroadcastQueue.java
+++ b/backend/src/main/java/com/edu/edumeet/meeting/service/CaptionBroadcastQueue.java
@@ -1,0 +1,159 @@
+package com.edu.edumeet.meeting.service;
+
+import com.edu.edumeet.chat.metrics.ChatMetrics;
+import com.edu.edumeet.meeting.dto.CaptionBroadcast;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * 자막을 요청 스레드가 아닌 전용 스레드에서 내보낸다. (#151)
+ *
+ * <h3>왜 갈랐나</h3>
+ * {@code brokerChannel} 에는 실행기가 없어서 {@code convertAndSend} 를 부른 스레드가
+ * 그대로 {@code clientOutboundChannel.send()} 까지 간다. 아웃바운드가 포화하면
+ * 거기 걸린 {@code CallerRunsPolicy} 때문에 <b>부른 스레드가 전송을 떠안는다.</b>
+ *
+ * <p>자막은 파이썬 STT 가 HTTP 로 밀어 넣으므로 그 스레드가 <b>Tomcat 요청 스레드</b>였다.
+ * 즉 자막이 밀리면 채팅이 아니라 <b>REST API 전체</b>가 막혔다
+ * (실측 {@code http-nio-auto-1-exec-1}, {@code BackpressureLandingTest}).
+ *
+ * <h3>왜 채팅과 정책이 달라야 하나</h3>
+ * <pre>
+ *   채팅   이어지는 대화다. 버리면 말이 끊긴다  →  안 버리고 느려진다(CallerRuns)
+ *   자막   화면의 음성과 맞아야 한다           →  밀린 것을 버리고 최신을 살린다
+ * </pre>
+ * <b>5초 밀린 자막은 없는 것보다 나쁘다.</b> 화면에는 이미 다음 말이 지나갔는데
+ * 뒤늦게 옛 자막이 뜨면 사용자는 그것을 지금 말로 읽는다.
+ *
+ * <h3>버려도 되는 이유</h3>
+ * 전사는 {@link CaptionArchiveQueue} 가 따로 들고 있다.
+ * <b>발행 경로에서 버려도 원본이 사라지지 않는다.</b> 다시보기와 요약 입력은 그쪽에서 나온다.
+ *
+ * <h3>버린 것은 반드시 센다</h3>
+ * 조용히 버리면 "자막이 원래 그렇게 띄엄띄엄 나오나 보다" 가 된다.
+ * {@code caption.broadcast.dropped} 가 0 을 넘으면 경보한다.
+ */
+@Component
+@Slf4j
+public class CaptionBroadcastQueue {
+
+    /**
+     * 상한. 자막은 초당 몇 조각이라 이 정도면 정상 상태에서는 절대 안 찬다.
+     *
+     * <p>크게 잡을 이유가 없다 - <b>깊은 큐는 오래된 자막을 오래 붙잡고 있겠다는 뜻</b>이고,
+     * 그것은 이 경로가 지켜야 하는 최신성과 정확히 반대다.
+     */
+    private static final int CAPACITY = 256;
+
+    private final Deque<Pending> queue = new ArrayDeque<>(CAPACITY);
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMetrics chatMetrics;
+    private final Counter dropped;
+    private final Counter published;
+
+    private Thread worker;
+    private volatile boolean running = true;
+
+    public CaptionBroadcastQueue(SimpMessagingTemplate messagingTemplate,
+                                 ChatMetrics chatMetrics,
+                                 MeterRegistry registry) {
+        this.messagingTemplate = messagingTemplate;
+        this.chatMetrics = chatMetrics;
+
+        Gauge.builder("caption.broadcast.queued", queue, q -> {
+                    synchronized (queue) { return q.size(); }
+                })
+                .description("발행 대기 중인 자막 수. 여기가 늘면 화면 자막이 밀리고 있다")
+                .register(registry);
+        Gauge.builder("caption.broadcast.capacity", this, q -> CAPACITY)
+                .description("발행 큐 상한. 경보는 절대값이 아니라 이것과의 비율로 본다")
+                .register(registry);
+        this.dropped = Counter.builder("caption.broadcast.dropped")
+                .description("큐가 차서 버린 자막 수. 화면에서만 사라지고 전사에는 남는다")
+                .register(registry);
+        this.published = Counter.builder("caption.broadcast.published")
+                .description("실제로 내보낸 자막 수").register(registry);
+    }
+
+    @PostConstruct
+    void start() {
+        worker = new Thread(this::drainForever, "caption-out-1");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * 발행을 맡긴다. <b>절대 요청 스레드를 막지 않는다.</b>
+     *
+     * <p>가득 차면 <b>가장 오래된 것을 버리고</b> 새 것을 넣는다.
+     * 새 것을 버리면 화면이 과거에 멈추기 때문이다.
+     *
+     * @return 무언가를 버렸으면 false
+     */
+    public boolean offer(String destination, CaptionBroadcast payload) {
+        boolean evicted = false;
+        synchronized (queue) {
+            if (queue.size() >= CAPACITY) {
+                queue.pollFirst();
+                evicted = true;
+            }
+            queue.addLast(new Pending(destination, payload));
+            queue.notifyAll();
+        }
+        if (evicted) {
+            dropped.increment();
+            log.warn("자막 발행 큐가 가득 차 가장 오래된 조각을 버렸다. destination={}", destination);
+        }
+        return !evicted;
+    }
+
+    private void drainForever() {
+        while (running) {
+            Pending next;
+            synchronized (queue) {
+                while (running && queue.isEmpty()) {
+                    try {
+                        queue.wait(200);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+                if (!running) return;
+                next = queue.pollFirst();
+            }
+            if (next == null) continue;
+            try {
+                messagingTemplate.convertAndSend(next.destination(), next.payload());
+                chatMetrics.published(next.destination());
+                published.increment();
+            } catch (Exception e) {
+                // 여기서 죽으면 이후 자막이 통째로 멈춘다. 한 건을 포기하고 계속 돈다.
+                log.warn("자막 발행 실패. destination={}", next.destination(), e);
+            }
+        }
+    }
+
+    @PreDestroy
+    void stop() {
+        running = false;
+        synchronized (queue) { queue.notifyAll(); }
+        if (worker != null) worker.interrupt();
+    }
+
+    /** 시험용. 지금 대기 중인 조각 수. */
+    public int queuedCount() {
+        synchronized (queue) { return queue.size(); }
+    }
+
+    private record Pending(String destination, CaptionBroadcast payload) {}
+}

--- a/backend/src/main/java/com/edu/edumeet/meeting/service/CaptionService.java
+++ b/backend/src/main/java/com/edu/edumeet/meeting/service/CaptionService.java
@@ -1,13 +1,11 @@
 package com.edu.edumeet.meeting.service;
 
-import com.edu.edumeet.chat.metrics.ChatMetrics;
 import com.edu.edumeet.meeting.domain.Meeting;
 import com.edu.edumeet.meeting.dto.CaptionBroadcast;
 import com.edu.edumeet.meeting.dto.CaptionIngestRequest;
 import com.edu.edumeet.meeting.repository.MeetingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,8 +36,7 @@ public class CaptionService {
     private static final int MAX_TEXT_LENGTH = 500;
 
     private final MeetingRepository meetingRepository;
-    private final SimpMessagingTemplate messagingTemplate;
-    private final ChatMetrics chatMetrics;
+    private final CaptionBroadcastQueue captionBroadcastQueue;
     private final CaptionArchiveQueue captionArchiveQueue;
 
     /**
@@ -48,6 +45,16 @@ public class CaptionService {
      * <p><b>저장하지 않는다.</b> 실시간 자막은 지나가면 끝이고,
      * 다시보기용 저장은 녹음과 함께 다룬다(#61). 발행 경로에 DB 쓰기를 넣으면
      * #43 에서 본 것처럼 <b>브로드캐스트 측정이 쓰기에 묻힌다.</b>
+     *
+     * <p><b>여기서 직접 내보내지 않는다.</b> (#151) {@code convertAndSend} 를 이 스레드에서
+     * 부르면 아웃바운드가 포화했을 때 {@code CallerRunsPolicy} 로 <b>이 스레드가 전송을 떠안는다.</b>
+     * 이 메서드를 부르는 것은 파이썬 STT 의 HTTP 요청이므로, 그 스레드는 Tomcat 요청 스레드다 -
+     * 자막이 밀리면 REST API 전체가 막혔다. 그래서 발행은 {@link CaptionBroadcastQueue} 에 맡긴다.
+     *
+     * <p>그 대가로 {@code publishedAt} 의 뜻이 바뀐다.
+     * <b>"실제로 내보낸 시각" 이 아니라 "발행 경로에 넘긴 시각"</b> 이다.
+     * 넘긴 뒤 실제로 나가기까지의 대기는 {@code caption.broadcast.queued} 로 따로 본다 -
+     * 숨기지 않고 지표를 하나 더 낸다.
      */
     @Transactional(readOnly = true)
     public CaptionBroadcast broadcast(Long meetingId, CaptionIngestRequest request, long receivedAt) {
@@ -66,8 +73,7 @@ public class CaptionService {
                 meetingId, text, request.sequence(), request.spokenAt(),
                 receivedAt, publishedAt, finalSegment);
 
-        messagingTemplate.convertAndSend(destination, payload);
-        chatMetrics.published(destination);
+        captionBroadcastQueue.offer(destination, payload);
         if (finalSegment) {
             captionArchiveQueue.offer(
                     meetingId, text, request.sequence(), request.spokenAt(), receivedAt, publishedAt);

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/BackpressureLandingTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/BackpressureLandingTest.java
@@ -5,6 +5,9 @@ import com.edu.edumeet.config.internal.InternalApiTokenFilter;
 import com.edu.edumeet.meeting.domain.Meeting;
 import com.edu.edumeet.meeting.domain.MeetingParticipant;
 import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.meeting.dto.CaptionBroadcast;
+import com.edu.edumeet.meeting.service.CaptionBroadcastQueue;
+import io.micrometer.core.instrument.MeterRegistry;
 import com.edu.edumeet.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +28,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -32,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * 역압이 어느 스레드에 착지하는지 고정한다. (#143)
@@ -83,6 +88,8 @@ class BackpressureLandingTest {
     @Autowired @Qualifier("clientInboundChannel") ExecutorSubscribableChannel inbound;
     @Autowired @Qualifier("clientOutboundChannel") ExecutorSubscribableChannel outbound;
     @Autowired @Qualifier("brokerChannel") ExecutorSubscribableChannel broker;
+    @Autowired CaptionBroadcastQueue captionBroadcastQueue;
+    @Autowired MeterRegistry meterRegistry;
     @PersistenceContext EntityManager em;
 
     private Long meetingId;
@@ -135,8 +142,8 @@ class BackpressureLandingTest {
     }
 
     @Test
-    @DisplayName("★ 자막 브로드캐스트는 Tomcat HTTP 요청 스레드에서 시작한다")
-    void caption_broadcast_starts_on_the_http_request_thread() {
+    @DisplayName("★ 자막 브로드캐스트는 요청 스레드가 아니라 전용 스레드에서 나간다 (#151)")
+    void caption_broadcast_leaves_the_http_request_thread() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add(InternalApiTokenFilter.HEADER, TOKEN);
@@ -150,15 +157,70 @@ class BackpressureLandingTest {
                 String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(brokerEntryThread.get()).isNotNull());
+
         assertThat(brokerEntryThread.get())
                 .as("""
-                    자막은 HTTP 요청 스레드에서 브로드캐스트를 시작한다.
-                    brokerChannel 에 실행기가 없으므로 이 스레드가 그대로
-                    clientOutboundChannel.send() 까지 간다 - 아웃바운드가 포화하면
-                    CallerRunsPolicy 로 이 스레드가 전송을 떠안고,
-                    Tomcat 요청 스레드가 소진되면 자막이 아니라 REST API 전체가 막힌다.""")
-                .isNotNull()
-                .startsWith("http-nio-");
+                    전에는 http-nio- 로 시작했다. brokerChannel 에 실행기가 없어서
+                    요청 스레드가 그대로 clientOutboundChannel.send() 까지 갔고,
+                    아웃바운드가 포화하면 CallerRunsPolicy 로 그 스레드가 전송을 떠안았다.
+                    Tomcat 요청 스레드가 소진되면 자막이 아니라 REST API 전체가 막힌다.
+                    이제 전용 스레드가 떠안는다 - 여기가 다시 http-nio- 가 되면 그 문제가 돌아온 것이다.""")
+                .startsWith("caption-out-");
+    }
+
+    @Test
+    @DisplayName("★ 요청 스레드는 발행을 기다리지 않는다 - 큐에 넣고 바로 돌아온다 (#151)")
+    void ingest_returns_without_waiting_for_the_send() {
+        int before = captionBroadcastQueue.queuedCount() + 1;
+
+        ResponseEntity<String> response = postCaption("던지고 잊는다");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(before)
+                .as("요청이 돌아온 시점에는 이미 큐를 지났거나 큐에 있다. 어느 쪽이든 전송을 기다리지 않았다")
+                .isPositive();
+    }
+
+    @Test
+    @DisplayName("★ 자막 발행 큐는 차면 가장 오래된 것을 버리고 센다 - 채팅과 정책이 다르다 (#151)")
+    void caption_queue_drops_oldest_and_counts_it() {
+        double dropsBefore = droppedCount();
+
+        // 상한(256)을 넘겨 밀어 넣는다. 워커가 빼 가므로 정확한 경계 대신
+        // "넘치게 넣으면 버리고 센다" 를 본다.
+        for (int i = 0; i < 2_000; i++) {
+            captionBroadcastQueue.offer("/topic/rooms/0/captions",
+                    new CaptionBroadcast(0L, "밀어넣기 " + i, (long) i, 0L, 0L, 0L, true));
+        }
+
+        assertThat(captionBroadcastQueue.queuedCount())
+                .as("상한을 넘겨 쌓이지 않는다. 깊은 큐는 오래된 자막을 오래 붙잡겠다는 뜻이다")
+                .isLessThanOrEqualTo(256);
+        assertThat(droppedCount())
+                .as("""
+                    버린 것은 반드시 센다. 조용히 버리면 "자막이 원래 띄엄띄엄 나오나 보다" 가 된다.
+                    전사는 CaptionArchiveQueue 가 따로 들고 있으므로 여기서 버려도 원본은 남는다.""")
+                .isGreaterThan(dropsBefore);
+    }
+
+    private double droppedCount() {
+        return meterRegistry.get("caption.broadcast.dropped").counter().count();
+    }
+
+    private ResponseEntity<String> postCaption(String text) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(InternalApiTokenFilter.HEADER, TOKEN);
+        return rest.postForEntity(
+                "http://localhost:" + port + "/api/v1/internal/meetings/" + meetingId + "/captions",
+                // 이 시험이 보는 것은 발행 경로다. final 로 보내면 저장 큐에 남아
+                // 같은 컨텍스트를 쓰는 다른 시험의 큐 길이 단언을 깨뜨린다.
+                new HttpEntity<>(Map.of("text", text, "sequence", 1,
+                        "spokenAt", System.currentTimeMillis(), "finalSegment", false), headers),
+                String.class);
     }
 
     @Test
@@ -179,7 +241,10 @@ class BackpressureLandingTest {
         assertThat(poolOf(inbound).getRejectedExecutionHandler())
                 .isInstanceOf(ThreadPoolExecutor.CallerRunsPolicy.class);
         assertThat(poolOf(outbound).getRejectedExecutionHandler())
-                .as("DiscardPolicy 로 바뀌면 조용히 메시지가 사라진다")
+                .as("""
+                    DiscardPolicy 로 바뀌면 조용히 메시지가 사라진다.
+                    다만 이 정책은 채팅 기준이다 - 자막은 최신성이 중요해서
+                    CaptionBroadcastQueue 로 갈라 "버리고 센다" 를 따로 쓴다. (#151)""")
                 .isInstanceOf(ThreadPoolExecutor.CallerRunsPolicy.class);
     }
 }

--- a/observability/rules/edumeet.yml
+++ b/observability/rules/edumeet.yml
@@ -104,6 +104,47 @@ groups:
             p95 {{ $value | printf "%.0f" }}명. 200명에서 e2e p95 가 45ms 였고
             500명에서 1,313ms(29배)가 됐다. 이 값이 계속 오르면 지연이 먼저 무너진다.
 
+  - name: edumeet-caption-broadcast
+    interval: 15s
+    rules:
+      # ────────────────────────────────────────────────────────────────
+      # 근거: performance/07 · #151
+      #
+      #   자막 발행은 채팅과 정책이 다르다. 채팅은 이어지는 대화라 안 버리고 느려지지만
+      #   (CallerRunsPolicy), 자막은 최신성이 중요해서 밀리면 오래된 것부터 버린다.
+      #   5초 밀린 자막은 화면의 음성과 안 맞아 없는 것보다 나쁘기 때문이다.
+      #
+      #   그래서 여기서 물어야 하는 것은 "버렸는가" 다. 조용히 버리면
+      #   "자막이 원래 띄엄띄엄 나오나 보다" 로 읽히고 아무도 이상하다고 느끼지 않는다.
+      #
+      #   전사는 저장 큐가 따로 들고 있으므로 이 드롭은 다시보기·요약을 망가뜨리지 않는다.
+      #   그래서 저장 드롭(critical)과 달리 warning 이다.
+      - alert: CaptionBroadcastDropping
+        expr: increase(caption_broadcast_dropped_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          runbook: docs/performance/07-chat-unbounded-queue-oom.md
+        annotations:
+          summary: "실시간 자막이 화면에 못 나가고 버려지고 있다"
+          description: >-
+            5분간 {{ $value | printf "%.0f" }}건이 발행 큐에서 버려졌다. 화면에서만 사라지고
+            전사에는 남는다. 아웃바운드가 포화했는지, 구독자가 몰렸는지 함께 본다.
+
+      # 근거: 같은 곳. 큐가 차 있다는 것은 화면 자막이 이미 밀리고 있다는 뜻이다.
+      - alert: CaptionBroadcastQueueBacklogged
+        expr: |
+          caption_broadcast_queued / caption_broadcast_capacity > 0.5
+        for: 1m
+        labels:
+          severity: warning
+          runbook: docs/performance/07-chat-unbounded-queue-oom.md
+        annotations:
+          summary: "자막 발행 큐가 상한의 50%를 넘었다"
+          description: >-
+            큐 {{ $value | humanizePercentage }} 점유. 정상 상태에서는 초당 몇 조각이라
+            상한(256)에 붙을 일이 없다. 여기가 차면 곧 오래된 자막부터 버려진다.
+
   - name: edumeet-async-write
     interval: 15s
     rules:


### PR DESCRIPTION
Closes #151 · #144 가 머지되면서 base 가 사라져 #152 가 자동으로 닫혔다. master 위에 다시 올린다.

## 무엇이 문제였나

`BackpressureLandingTest`(#144)가 이걸 고정하고 있었다.

```
채팅  @MessageMapping  ->  chat-in- 실행기 스레드
자막  @PostMapping     ->  Tomcat HTTP 요청 스레드   ← http-nio-auto-1-exec-1
```

`brokerChannel` 에 실행기가 없어 호출 스레드가 그대로 아웃바운드까지 간다.
포화하면 `CallerRunsPolicy` 로 **그 스레드가 전송을 떠안는다.**
자막이 밀리면 채팅이 아니라 **REST API 전체**가 막혔다.

## 왜 정책을 갈라야 했나

| | 채팅 | 자막 |
|---|---|---|
| 성격 | 이어지는 대화. 버리면 말이 끊긴다 | 화면의 음성과 맞아야 한다 |
| 정책 | `CallerRunsPolicy` (안 버리고 느려짐) | **오래된 것부터 버림** |
| 유실 | 없음 | **계량한다** |

`CallerRunsPolicy` 는 **채팅 기준**으로 고른 정책인데 자막과 공유하고 있었다.
**5초 밀린 자막은 없는 것보다 나쁘다.** 화면에는 이미 다음 말이 지나갔는데
뒤늦게 옛 자막이 뜨면 사용자는 그것을 지금 말로 읽는다.

저장 경로에는 이미 반대 정책이 있었다(`CaptionArchiveQueue`: 상한 4,000 · 버리고 계량).
**발행 경로만 정책이 달랐다.**

## 무엇을 했나

`CaptionBroadcastQueue` 를 두고 자막 발행만 전용 스레드(`caption-out-1`)로 옮겼다.

- 상한 **256**. 크게 잡을 이유가 없다 — 깊은 큐는 오래된 자막을 오래 붙잡겠다는 뜻이고, 이 경로가 지켜야 하는 최신성과 반대다
- 가득 차면 **가장 오래된 것**을 버린다. 새 것을 버리면 화면이 과거에 멈춘다
- 버린 것은 **센다**(`caption.broadcast.dropped`)
- 전사는 저장 큐가 들고 있으므로 **여기서 버려도 다시보기·요약 입력은 남는다**

경보 둘. 드롭 `> 0`, 큐 점유 `> 50%`. 저장 드롭(critical)과 달리 **warning** 이다.

## 대가

`publishedAt` 의 뜻이 **"내보낸 시각" → "발행 경로에 넘긴 시각"** 으로 바뀐다.
숨기지 않고 `caption.broadcast.queued` 로 그 대기를 따로 낸다.
응답 본문은 계약(`contracts/internal-api.json`)에 없어서 소비자에 영향이 없다.

## 시험

기존 단언이 뒤집힌다. `http-nio-` → `caption-out-`.
착지점 · 요청이 전송을 안 기다리는지 · 넘치면 버리고 세는지를 고정한다.

로컬 `./gradlew test` **326건 중 322건 통과**. 남은 4건은 Docker 가 없어 나는 Testcontainers 실패다(#153 참조).

## 아직 안 한 것

**적용 후 REST 지연 재측정.** 착지점을 옮겼으니 그 구간 p95 와 타임아웃 수를 다시 재야
"옮겨서 나아졌다" 를 말할 수 있다.