### PR TITLE
fix(ci): .gitignore 가 재현 스크립트 6개를 먹고 있었다 (#162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,23 @@ jobs:
               - 'ai/caption_normalizer.py'
               - '.github/workflows/ci.yml'
 
+  # ★ 문서가 가리키는 재현 파일이 저장소에 있는지 본다. (#162)
+  #
+  #   두 번 빠졌다. #156 squash 에서 k6 스크립트가 통째로 빠졌고,
+  #   .gitignore 의 *.sh 가 scripts/ 의 재현 스크립트 6개를 먹고 있었다.
+  #   둘 다 로컬에는 파일이 있어서 아무도 눈치채지 못했다.
+  #   재현 경로가 저장소에 없으면 그 측정은 다시 못 돌린다.
+  #
+  #   경로 필터를 안 건다. 이 검사는 30초짜리이고, 무엇을 고쳐도
+  #   문서와 파일의 짝이 깨질 수 있다.
+  doc-refs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: 문서가 가리키는 파일 존재
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/verify-doc-refs.sh
+
   build-and-test:
     needs: changes
     if: needs.changes.outputs.backend == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -239,8 +239,12 @@ upload/
 *.env.*
 *.properties.*
 
+# ★ *.sh 는 임시 실행 스크립트가 딸려 들어오는 것을 막으려는 규칙이다.
+#   그런데 scripts/ 는 문서가 "재현: scripts/..." 로 가리키는 자리라 같이 먹히면 안 된다.
+#   실제로 6개가 조용히 빠져 있었고, 그때마다 예외를 한 줄씩 더하는 식으로 때웠다. (#162)
+#   재현 스크립트가 저장소에 없으면 그 측정은 다시 못 돌린다.
 *.sh
-!scripts/bench-hls-codec-paths.sh
+!scripts/*.sh
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,gradle,windows,macos,visualstudiocode
 ### 개인 작업 메모 — 커밋하지 않는다 ###
 CLAUDE.md

--- a/scripts/measure-prod-cpu-share.sh
+++ b/scripts/measure-prod-cpu-share.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# 부하 창 동안 운영 앱이 2코어를 얼마나 가져가는지 잰다.
+# 운영 앱을 못 내리므로, 대신 그 몫을 숫자로 만들어 한계를 좁힌다.
+set -uo pipefail
+OUT=$HOME/perf160/out; mkdir -p "$OUT"
+CSV="$OUT/prodshare.csv"; : > "$CSV"
+
+( while true; do
+    T=$(date +%s)
+    for C in edumeet-app perf-app; do
+      L=$(docker stats --no-stream --format '{{.CPUPerc}}' "$C" 2>/dev/null) || continue
+      [ -n "$L" ] && echo "$T,$C,$L" >> "$CSV"
+    done
+  done ) &
+SAMPLER=$!
+
+TOXIC=1 "$HOME/perf160/run.sh" after caption-backpressure.js prodshare \
+  -e SUBSCRIBERS=150 -e CAPTION_RATE=45 -e DURATION=90s
+
+kill "$SAMPLER" 2>/dev/null
+echo "SAMPLES $(wc -l < "$CSV")"

--- a/scripts/run-benchmark.sh
+++ b/scripts/run-benchmark.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# 과제 목록 조회 N+1 개선 전/후를 MySQL 에서 측정한다.
+#
+#   ./scripts/run-benchmark.sh
+#
+# 왜 2x2 인가 — 개선은 두 가지였다.
+#
+#   (1) 앱 레벨: 과제마다 제출물을 조회하던 것을 IN 절 한 번으로 묶음
+#   (2) Hibernate: default_batch_fetch_size 로 지연 로딩 컬렉션을 묶음
+#
+# 둘을 동시에 켜고 끄면 어느 쪽이 얼마나 기여했는지 말할 수 없다.
+# (2)는 요청 단위로 못 바꾸는 전역 설정이라 앱을 두 번 띄운다.
+#
+#   nobatch-naive    아무것도 안 함        = 개선 전
+#   nobatch-batch    (1)만
+#   batch100-naive   (2)만
+#   batch100-batch   둘 다                 = 개선 후
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VUS="${VUS:-50}"
+PERF_PORT="${PERF_PORT:-8081}"
+export PERF_PORT
+DURATION="${DURATION:-60s}"
+LOG_DIR="build/benchmark-logs"
+mkdir -p "$LOG_DIR" docs/performance/data
+
+command -v k6 >/dev/null || { echo "k6 가 없다: brew install k6"; exit 1; }
+
+echo "== MySQL/Redis 확인 =="
+docker compose -f docker-compose.perf.yml up -d >/dev/null
+for i in $(seq 1 40); do
+  [ "$(docker inspect --format '{{.State.Health.Status}}' edumeet-perf-mysql 2>/dev/null)" = "healthy" ] && break
+  sleep 2
+done
+
+echo "== 애플리케이션 빌드 =="
+(cd backend && ./gradlew perfBootJar -q)
+# 벤치마크 엔드포인트는 perf 소스셋에만 있다. 운영 jar 에는 없다. (#57)
+JAR=$(ls backend/build/libs/*-perf.jar | head -1)
+echo "   $JAR"
+
+APP_PID=""
+cleanup() { [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+run_measurements() {
+  local bs="$1" tag="$2"
+
+  echo
+  echo "=============================================================="
+  echo " PERF_BATCH_SIZE=$bs  ($tag)"
+  echo "=============================================================="
+
+  PERF_BATCH_SIZE="$bs" java -jar "$JAR" --spring.profiles.active=perf \
+      > "$LOG_DIR/app-$tag.log" 2>&1 &
+  APP_PID=$!
+
+  echo -n "   기동 및 시드 대기"
+  for i in $(seq 1 120); do
+    # 웹 서버는 ApplicationRunner(시드)보다 먼저 뜬다. 200 만 보고 넘어가면
+    # 빈 테이블에 부하를 걸게 되므로 결과 건수까지 확인한다.
+    # set -e + pipefail 이라 curl 실패가 스크립트를 죽인다. 기동 대기 중에는
+    # 실패가 정상이므로 || true 로 막는다.
+    SIZE=$(curl -sI "http://localhost:$PERF_PORT/api/perf/assignments?classId=1&strategy=batch" \
+           2>/dev/null | tr -d '\r' | awk -F': ' '/^X-Result-Size/{print $2}' || true)
+    if [ -n "$SIZE" ] && [ "$SIZE" -gt 0 ] 2>/dev/null; then
+      echo " ok (과제 $SIZE 건)"; break
+    fi
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+      echo " 실패"; tail -30 "$LOG_DIR/app-$tag.log"; exit 1
+    fi
+    echo -n "."; sleep 2
+  done
+
+  # 시드 규모와 요청당 SQL 수를 먼저 찍어둔다. 나중에 수치를 해석할 때 필요하다.
+  for s in naive batch; do
+    local qc
+    qc=$(curl -sI "http://localhost:$PERF_PORT/api/perf/assignments?classId=1&strategy=$s" \
+         | tr -d '\r' | awk -F': ' '/^X-Query-Count/{print $2}' || true)
+    echo "   strategy=$s 요청당 SQL: $qc"
+  done
+
+  for s in naive batch; do
+    echo
+    echo "   --- $tag-$s 워밍업 ---"
+    PERF_BATCH_SIZE="$bs" k6 run -q --no-summary \
+      -e STRATEGY="$s" -e WARMUP=1 k6/assignment-list.js >/dev/null 2>&1 || true
+
+    echo "   --- $tag-$s 측정 ---"
+    PERF_BATCH_SIZE="$bs" k6 run -q \
+      -e STRATEGY="$s" -e LABEL="$tag-$s" -e VUS="$VUS" -e DURATION="$DURATION" \
+      k6/assignment-list.js
+  done
+
+  kill "$APP_PID" 2>/dev/null || true
+  wait "$APP_PID" 2>/dev/null || true
+  APP_PID=""
+  sleep 3
+}
+
+run_measurements "-1"  "nobatch"
+run_measurements "100" "batch100"
+
+echo
+echo "== 완료. 결과: docs/performance/data/k6-*.json =="
+ls -1 docs/performance/data/k6-*.json

--- a/scripts/run-chat-oom.sh
+++ b/scripts/run-chat-oom.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# 무한 큐 OOM 을 재현하고, 큐 제한을 건 뒤 다시 잰다. (#43)
+#
+#   ./scripts/run-chat-oom.sh              # 전/후 둘 다
+#   MODE=before ./scripts/run-chat-oom.sh  # 개선 전만
+#
+# 왜 힙을 512m 으로 조이나
+#   기본 힙이면 OOM 까지 수십 분이 걸린다. 조이면 수 분 안에 같은 현상이 나온다.
+#   조인 것은 "언제 죽는가" 이지 "죽는가" 가 아니다.
+#
+# 왜 구독자를 늘리나
+#   fan-out 이 증폭기다. 발행 1건이 구독자 N명에게 가므로
+#   아웃바운드 큐는 발행 속도의 N배로 쌓인다.
+#   발행 속도를 올리는 것보다 구독자를 늘리는 편이 빠르다.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${MODE:-both}"
+SUBSCRIBERS="${SUBSCRIBERS:-150}"
+PUBLISHERS="${PUBLISHERS:-4}"
+RATE="${RATE:-60}"
+DURATION="${DURATION:-4m}"
+HEAP="${HEAP:-512m}"
+PERF_PORT="${PERF_PORT:-8081}"
+MGMT_PORT="${MGMT_PORT:-9092}"
+
+LOG_DIR="build/chat-oom"
+DATA_DIR="docs/performance/data"
+mkdir -p "$LOG_DIR" "$DATA_DIR"
+
+command -v k6 >/dev/null || { echo "k6 가 없다: brew install k6"; exit 1; }
+
+echo "== 인프라 =="
+docker compose -f docker-compose.perf.yml up -d mysql redis >/dev/null
+for i in $(seq 1 40); do
+  [ "$(docker inspect --format '{{.State.Health.Status}}' edumeet-perf-mysql 2>/dev/null)" = "healthy" ] && break
+  sleep 2
+done
+echo "   mysql ready"
+
+echo "== 빌드 =="
+(cd backend && ./gradlew perfBootJar -q)
+# 벤치마크 엔드포인트는 perf 소스셋에만 있다. 운영 jar 에는 없다. (#57)
+JAR=$(ls backend/build/libs/*-perf.jar | head -1)
+
+APP_PID=""; POLL_PID=""
+cleanup() {
+  [ -n "$POLL_PID" ] && kill "$POLL_PID" 2>/dev/null || true
+  [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# 관측 지표를 1초마다 찍는다. 붕괴는 형태로 봐야 한다 - 마지막 값만 보면 안 보인다.
+poll_metrics() {
+  local out="$1" tmp t=0
+  tmp=$(mktemp)
+  rm -f "$out"
+  while true; do
+    if curl -fsS "http://localhost:$MGMT_PORT/actuator/prometheus" -o "$tmp" 2>/dev/null; then
+      python3 scripts/scrape_to_csv.py "$out" "$t" "$tmp" 2>/dev/null || true
+    fi
+    t=$((t+1)); sleep 1
+  done
+}
+
+run_round() {
+  local tag="$1"; shift
+  local extra_opts="$*"
+
+  echo
+  echo "=============================================================="
+  echo " $tag   힙 ${HEAP} · 구독자 ${SUBSCRIBERS} · 발행 ${PUBLISHERS}x${RATE}/s"
+  echo "=============================================================="
+
+  # shellcheck disable=SC2086
+  java -Xmx"$HEAP" -Xms"$HEAP" \
+       -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="$LOG_DIR/$tag.hprof" \
+       -XX:+ExitOnOutOfMemoryError \
+       $extra_opts \
+       -jar "$JAR" --spring.profiles.active=perf \
+       --server.port="$PERF_PORT" --management.server.port="$MGMT_PORT" \
+       > "$LOG_DIR/app-$tag.log" 2>&1 &
+  APP_PID=$!
+
+  echo -n "   기동 대기"
+  for i in $(seq 1 90); do
+    if curl -fsS "http://localhost:$MGMT_PORT/actuator/health" >/dev/null 2>&1; then
+      echo " ok"; break
+    fi
+    kill -0 "$APP_PID" 2>/dev/null || { echo " 실패"; tail -30 "$LOG_DIR/app-$tag.log"; exit 1; }
+    echo -n "."; sleep 2
+  done
+
+  # 채팅 방과 토큰을 받는다. BROADCAST 는 DB 쓰기가 없어 큐 소진만 본다.
+  local setup
+  setup=$(curl -fsS -X POST "http://localhost:$PERF_PORT/api/perf/chat/setup?type=BROADCAST")
+  local meeting_id token
+  meeting_id=$(echo "$setup" | python3 -c 'import sys,json;print(json.load(sys.stdin)["meetingId"])')
+  token=$(echo "$setup" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+  echo "   meetingId=$meeting_id"
+
+  poll_metrics "$LOG_DIR/metrics-$tag.csv" &
+  POLL_PID=$!
+
+  local started; started=$(date +%s)
+  set +e
+  k6 run -q \
+    -e BASE_URL="ws://localhost:$PERF_PORT" -e TOKEN="$token" -e MEETING_ID="$meeting_id" \
+    -e SUBSCRIBERS="$SUBSCRIBERS" -e PUBLISHERS="$PUBLISHERS" -e RATE="$RATE" -e DURATION="$DURATION" \
+    -e SUMMARY_PATH="$DATA_DIR/chat-oom-$tag.json" \
+    k6/chat-fanout.js 2>&1 | tee "$LOG_DIR/k6-$tag.log"
+  set -e
+  local ended; ended=$(date +%s)
+
+  kill "$POLL_PID" 2>/dev/null || true; POLL_PID=""
+
+  # 앱이 살아 있나. OOM 이면 ExitOnOutOfMemoryError 로 이미 죽었다.
+  local survived="yes"
+  kill -0 "$APP_PID" 2>/dev/null || survived="no"
+
+  echo
+  echo "   경과: $((ended-started))초"
+  echo "   생존: $survived"
+  if [ -f "$LOG_DIR/$tag.hprof" ]; then
+    echo "   힙 덤프: $LOG_DIR/$tag.hprof ($(du -h "$LOG_DIR/$tag.hprof" | cut -f1))"
+  fi
+  grep -c "OutOfMemoryError" "$LOG_DIR/app-$tag.log" 2>/dev/null | xargs echo "   OOM 로그:" || true
+  tail -3 "$LOG_DIR/metrics-$tag.csv" 2>/dev/null | sed 's/^/   /' || true
+
+  kill "$APP_PID" 2>/dev/null || true
+  wait "$APP_PID" 2>/dev/null || true
+  APP_PID=""
+  sleep 3
+}
+
+case "$MODE" in
+  before) run_round before ;;
+  after)  run_round after -Dspring.task.execution.pool.queue-capacity=1000 ;;
+  both)
+    run_round before
+    run_round after -Dspring.task.execution.pool.queue-capacity=1000
+    ;;
+esac
+
+echo
+echo "== 결과 =="
+ls -1 "$LOG_DIR"/metrics-*.csv "$DATA_DIR"/chat-oom-*.json 2>/dev/null | sed 's/^/  /'

--- a/scripts/run-fault-injection.sh
+++ b/scripts/run-fault-injection.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# LiveKit 장애를 주입해 타임아웃과 폴백이 실제로 동작하는지 확인한다.
+#
+#   ./scripts/run-fault-injection.sh
+#
+# 순서가 중요하다 — 막을 장치를 먼저 만들고(#19), 그 장치가 동작함을
+# 증명하는 데 장애 주입을 쓴다. 장치 없이 넣으면 앱이 죽는 것을 증명할 뿐이다.
+#
+#   앱 --> toxiproxy:7881 --[toxic]--> livekit:7880
+#
+# 대조군(legacy=true)은 수정 전 코드(new RestTemplate, 타임아웃 무한)를 탄다.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PERF_PORT="${PERF_PORT:-8081}"; export PERF_PORT
+TOXI="http://localhost:8474"
+APP="http://localhost:$PERF_PORT/api/perf/livekit/room"
+LOG_DIR="build/benchmark-logs"
+OUT="docs/performance/data/fault-injection.json"
+mkdir -p "$LOG_DIR" docs/performance/data
+
+echo "== 컨테이너 기동 =="
+docker compose -f docker-compose.perf.yml up -d >/dev/null
+for i in $(seq 1 40); do
+  curl -sf "$TOXI/version" >/dev/null 2>&1 && break
+  sleep 2
+done
+
+# 프록시를 다시 만든다. 이전 실행의 toxic 이 남아 있으면 결과가 오염된다.
+curl -sf -X DELETE "$TOXI/proxies/livekit" >/dev/null 2>&1 || true
+curl -sf -X POST "$TOXI/proxies" -H 'Content-Type: application/json' \
+  -d '{"name":"livekit","listen":"0.0.0.0:7881","upstream":"livekit:7880","enabled":true}' >/dev/null
+
+echo "== 애플리케이션 빌드 =="
+(cd backend && ./gradlew perfBootJar -q)
+# 벤치마크 엔드포인트는 perf 소스셋에만 있다. 운영 jar 에는 없다. (#57)
+JAR=$(ls backend/build/libs/*-perf.jar | head -1)
+
+APP_PID=""
+cleanup() {
+  curl -sf -X DELETE "$TOXI/proxies/livekit/toxics/latency" >/dev/null 2>&1 || true
+  curl -sf -X DELETE "$TOXI/proxies/livekit/toxics/blackhole" >/dev/null 2>&1 || true
+  curl -sf -X POST "$TOXI/proxies/livekit" -H 'Content-Type: application/json' \
+       -d '{"enabled":true}' >/dev/null 2>&1 || true
+  [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+PERF_BATCH_SIZE=100 java -jar "$JAR" --spring.profiles.active=perf \
+    > "$LOG_DIR/app-fault.log" 2>&1 &
+APP_PID=$!
+
+echo -n "   기동 대기"
+for i in $(seq 1 120); do
+  # 룸이 없으면 404 가 정상이다. -sf 는 404 를 실패로 보므로 상태코드로 판정한다.
+  # curl 은 실패해도 -w 로 000 을 찍는다. || echo 를 덧붙이면 000000 이 되어
+  # 판정이 즉시 통과해버리므로 || true 로만 종료코드를 삼킨다.
+  CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$APP?name=probe" 2>/dev/null || true)
+  if [ -n "$CODE" ] && [ "$CODE" != "000" ]; then echo " ok (HTTP $CODE)"; break; fi
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    echo " 실패"; tail -30 "$LOG_DIR/app-fault.log"; exit 1
+  fi
+  echo -n "."; sleep 2
+done
+
+RESULTS="[]"
+
+# $1 라벨  $2 legacy(true/false)  $3 curl 최대 대기(초)
+probe() {
+  local label="$1" legacy="$2" maxtime="$3"
+  local body http elapsed
+  body=$(curl -s --max-time "$maxtime" -w '\n%{http_code}\n%{time_total}' \
+         "$APP?name=probe&legacy=$legacy" 2>/dev/null || echo -e '\n000\ntimeout')
+  http=$(echo "$body" | tail -2 | head -1)
+  elapsed=$(echo "$body" | tail -1)
+  local outcome
+  outcome=$(echo "$body" | head -1 | sed -n 's/.*"outcome":"\([A-Z_]*\)".*/\1/p')
+  [ "$http" = "000" ] && outcome="클라이언트가 먼저 포기함"
+  printf "   %-22s HTTP %-4s %8ss  %s\n" "$label" "${http:-000}" "$elapsed" "${outcome:-?}"
+  RESULTS=$(python3 -c "
+import json,sys
+r=json.loads(sys.argv[1]); r.append({'case':sys.argv[2],'legacy':sys.argv[3]=='true',
+ 'http':sys.argv[4],'seconds':sys.argv[5],'outcome':sys.argv[6]})
+print(json.dumps(r,ensure_ascii=False))" "$RESULTS" "$label" "$legacy" "${http:-000}" "$elapsed" "${outcome:-?}")
+}
+
+add_latency() {
+  curl -sf -X POST "$TOXI/proxies/livekit/toxics" -H 'Content-Type: application/json' \
+    -d "{\"name\":\"latency\",\"type\":\"latency\",\"stream\":\"downstream\",\"attributes\":{\"latency\":$1,\"jitter\":0}}" >/dev/null
+}
+del_latency() { curl -sf -X DELETE "$TOXI/proxies/livekit/toxics/latency" >/dev/null 2>&1 || true; }
+# 연결은 열어두고 데이터를 한 바이트도 흘리지 않는다. 상대가 "응답하지 않는" 상태다.
+# 지연 주입은 결국 응답이 오지만 이건 오지 않는다. 상한이 없다는 것을 이걸로 보인다.
+add_blackhole() {
+  curl -sf -X POST "$TOXI/proxies/livekit/toxics" -H 'Content-Type: application/json' \
+    -d '{"name":"blackhole","type":"timeout","stream":"upstream","attributes":{"timeout":0}}' >/dev/null
+}
+del_blackhole() { curl -sf -X DELETE "$TOXI/proxies/livekit/toxics/blackhole" >/dev/null 2>&1 || true; }
+set_proxy()   { curl -sf -X POST "$TOXI/proxies/livekit" -H 'Content-Type: application/json' -d "{\"enabled\":$1}" >/dev/null; }
+
+echo
+echo "=============================================================="
+echo " 1. 정상 — LiveKit 이 정상 응답"
+echo "=============================================================="
+probe "수정 후" false 10
+probe "수정 전(대조군)" true 10
+
+echo
+echo "=============================================================="
+echo " 2. 지연 주입 — 응답이 10초 늦게 온다 (read timeout 3초)"
+echo "=============================================================="
+add_latency 10000
+probe "수정 후" false 20
+echo "   (대조군은 무한 대기라 30초에서 클라이언트가 끊는다)"
+probe "수정 전(대조군)" true 30
+del_latency
+
+echo
+echo "=============================================================="
+echo " 3. 연결 불가 — LiveKit 에 아예 닿지 못한다 (connect timeout 2초)"
+echo "=============================================================="
+set_proxy false
+probe "수정 후" false 20
+probe "수정 전(대조군)" true 20
+set_proxy true
+
+echo
+echo "=============================================================="
+echo " 4. 무응답 — 연결은 되지만 한 바이트도 오지 않는다"
+echo "=============================================================="
+add_blackhole
+probe "수정 후" false 20
+echo "   (대조군은 상한이 없다. 30초에서 클라이언트가 먼저 끊는다)"
+probe "수정 전(대조군)" true 30
+del_blackhole
+
+echo
+echo "=============================================================="
+echo " 5. 복구 — 장애가 걷힌 뒤 정상으로 돌아오는가"
+echo "=============================================================="
+probe "수정 후" false 10
+
+echo "$RESULTS" > "$OUT"
+echo
+echo "== 완료: $OUT =="

--- a/scripts/run-lock-determinism.sh
+++ b/scripts/run-lock-determinism.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# 정원 잠금 테스트를 결정론적으로 만든다.
+#
+#   ./scripts/run-lock-determinism.sh
+#
+# 문제 — 잠금 없는 구현의 버그(정원 초과)는 스레드가 "우연히" 겹쳐야 잡힌다.
+# 실행에 따라 초과가 0 이 나올 수 있고, 그러면 테스트가 버그를 놓친다.
+#
+# 해법 — DB 응답에 인위적 지연을 넣어 "센다 -> 비교한다 -> 기록한다" 사이의
+# 창을 넓힌다. 경합이 우연이 아니라 필연이 된다.
+#
+#   앱 --> toxiproxy:13307 --[latency]--> mysql:3306
+#
+# 이건 성능 측정이 아니다. 지연을 넣었으니 당연히 느리다.
+# 재는 것은 "정원을 넘긴 인원이 몇 명인가" 뿐이다.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PERF_PORT="${PERF_PORT:-8081}"; export PERF_PORT
+TOXI="http://localhost:8474"
+CAPACITY="${CAPACITY:-30}"
+ATTEMPTS="${ATTEMPTS:-150}"
+DB_LATENCY_MS="${DB_LATENCY_MS:-20}"
+ROUNDS="${ROUNDS:-3}"
+LOG_DIR="build/benchmark-logs"
+OUT="docs/performance/data/lock-determinism.json"
+mkdir -p "$LOG_DIR" docs/performance/data
+
+command -v k6 >/dev/null || { echo "k6 가 없다: brew install k6"; exit 1; }
+
+echo "== 컨테이너 기동 =="
+docker compose -f docker-compose.perf.yml up -d >/dev/null
+for i in $(seq 1 40); do
+  curl -sf "$TOXI/version" >/dev/null 2>&1 && break
+  sleep 2
+done
+
+echo "== MySQL 프록시 등록 =="
+curl -sf -X DELETE "$TOXI/proxies/mysql" >/dev/null 2>&1 || true
+curl -sf -X POST "$TOXI/proxies" -H 'Content-Type: application/json' \
+  -d '{"name":"mysql","listen":"0.0.0.0:13307","upstream":"mysql:3306","enabled":true}' >/dev/null
+echo "   앱 --> toxiproxy:13307 --> mysql:3306"
+
+echo "== 애플리케이션 빌드 =="
+(cd backend && ./gradlew perfBootJar -q)
+# 벤치마크 엔드포인트는 perf 소스셋에만 있다. 운영 jar 에는 없다. (#57)
+JAR=$(ls backend/build/libs/*-perf.jar | head -1)
+
+APP_PID=""
+cleanup() {
+  curl -sf -X DELETE "$TOXI/proxies/mysql/toxics/dblatency" >/dev/null 2>&1 || true
+  [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# 앱은 프록시를 통해 DB 에 붙는다.
+PERF_DB_PORT=13307 PERF_BATCH_SIZE=100 java -jar "$JAR" --spring.profiles.active=perf \
+    > "$LOG_DIR/app-lock.log" 2>&1 &
+APP_PID=$!
+
+echo -n "   기동 대기"
+for i in $(seq 1 120); do
+  MID=$(curl -sf "http://localhost:$PERF_PORT/api/perf/sessions/seeded" 2>/dev/null \
+        | sed -n 's/.*"meetingId":\([0-9]*\).*/\1/p' || true)
+  [ -n "$MID" ] && { echo " ok (meetingId=$MID)"; break; }
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    echo " 실패"; tail -30 "$LOG_DIR/app-lock.log"; exit 1
+  fi
+  echo -n "."; sleep 2
+done
+[ -n "${MID:-}" ] || { echo "세션을 찾지 못했다"; exit 1; }
+
+add_db_latency() {
+  curl -sf -X POST "$TOXI/proxies/mysql/toxics" -H 'Content-Type: application/json' \
+    -d "{\"name\":\"dblatency\",\"type\":\"latency\",\"stream\":\"downstream\",\"attributes\":{\"latency\":$1,\"jitter\":0}}" >/dev/null
+}
+del_db_latency() { curl -sf -X DELETE "$TOXI/proxies/mysql/toxics/dblatency" >/dev/null 2>&1 || true; }
+
+RESULTS="[]"
+
+# $1 라벨  $2 lock(true/false)
+round() {
+  local label="$1" lock="$2" overflow active
+  k6 run -q --no-summary -e LOCK="$lock" -e LABEL="tmp-$label" -e CAPACITY="$CAPACITY" \
+      -e ATTEMPTS="$ATTEMPTS" k6/session-capacity.js >/dev/null 2>&1 || true
+  local state
+  state=$(curl -sf "http://localhost:$PERF_PORT/api/perf/sessions/state?meetingId=$MID" || echo '{}')
+  active=$(echo "$state" | sed -n 's/.*"active":\([0-9]*\).*/\1/p')
+  overflow=$(echo "$state" | sed -n 's/.*"overflow":\([0-9]*\).*/\1/p')
+  printf "     입장 %-4s 정원 %-4s 초과 %s\n" "${active:-?}" "$CAPACITY" "${overflow:-?}"
+  RESULTS=$(python3 -c "
+import json,sys
+r=json.loads(sys.argv[1]); r.append({'case':sys.argv[2],'lock':sys.argv[3]=='true',
+ 'active':int(sys.argv[4] or 0),'capacity':int(sys.argv[5]),'overflow':int(sys.argv[6] or 0)})
+print(json.dumps(r,ensure_ascii=False))" "$RESULTS" "$label" "$lock" "${active:-0}" "$CAPACITY" "${overflow:-0}")
+}
+
+echo
+echo "=============================================================="
+echo " A. DB 지연 없음 — 경합이 우연에 달렸다"
+echo "=============================================================="
+del_db_latency
+for r in $(seq 1 "$ROUNDS"); do
+  echo "   [${r}회차] 잠금 없음"
+  round "지연없음-잠금없음" false
+done
+
+echo
+echo "=============================================================="
+echo " B. DB 지연 ${DB_LATENCY_MS}ms — 레이스 윈도우를 넓힌다"
+echo "=============================================================="
+add_db_latency "$DB_LATENCY_MS"
+for r in $(seq 1 "$ROUNDS"); do
+  echo "   [${r}회차] 잠금 없음"
+  round "지연${DB_LATENCY_MS}ms-잠금없음" false
+done
+
+echo
+echo "=============================================================="
+echo " C. DB 지연 ${DB_LATENCY_MS}ms + 비관적 잠금 — 지연이 있어도 지켜지는가"
+echo "=============================================================="
+for r in $(seq 1 "$ROUNDS"); do
+  echo "   [${r}회차] 비관적 잠금"
+  round "지연${DB_LATENCY_MS}ms-잠금있음" true
+done
+del_db_latency
+
+rm -f docs/performance/data/k6-session-tmp-*.json
+echo "$RESULTS" > "$OUT"
+echo
+python3 - "$OUT" <<'PY'
+import json, sys, collections
+rows = json.load(open(sys.argv[1]))
+g = collections.OrderedDict()
+for r in rows:
+    g.setdefault(r['case'], []).append(r['overflow'])
+print("== 요약: 회차별 정원 초과 인원 ==")
+for case, overflows in g.items():
+    detected = sum(1 for o in overflows if o > 0)
+    print(f"  {case:<26} {overflows}   버그 검출 {detected}/{len(overflows)}회")
+PY
+echo
+echo "== 완료: $OUT =="

--- a/scripts/run-session-benchmark.sh
+++ b/scripts/run-session-benchmark.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# 세션 정원 제어를 MySQL InnoDB 위에서 검증한다.
+#
+#   ./scripts/run-session-benchmark.sh
+#
+# 이미 JUnit 동시성 테스트가 있지만 H2 위에서 돈다. H2 의 잠금과 InnoDB 의
+# SELECT ... FOR UPDATE 는 동작이 다르다. 운영 DB 에서 다시 확인한다.
+#
+# 잠금 있는 경로와 없는 경로를 같은 조건으로 돌려 잠금이 실제로 무언가를
+# 막고 있음을 보인다.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PERF_PORT="${PERF_PORT:-8081}"
+export PERF_PORT
+CAPACITY="${CAPACITY:-30}"
+ATTEMPTS="${ATTEMPTS:-150}"
+LOG_DIR="build/benchmark-logs"
+mkdir -p "$LOG_DIR" docs/performance/data
+
+command -v k6 >/dev/null || { echo "k6 가 없다: brew install k6"; exit 1; }
+
+docker compose -f docker-compose.perf.yml up -d >/dev/null
+for i in $(seq 1 40); do
+  [ "$(docker inspect --format '{{.State.Health.Status}}' edumeet-perf-mysql 2>/dev/null)" = "healthy" ] && break
+  sleep 2
+done
+
+echo "== 애플리케이션 빌드 =="
+(cd backend && ./gradlew perfBootJar -q)
+# 벤치마크 엔드포인트는 perf 소스셋에만 있다. 운영 jar 에는 없다. (#57)
+JAR=$(ls backend/build/libs/*-perf.jar | head -1)
+
+APP_PID=""
+cleanup() { [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+PERF_BATCH_SIZE=100 java -jar "$JAR" --spring.profiles.active=perf \
+    > "$LOG_DIR/app-session.log" 2>&1 &
+APP_PID=$!
+
+echo -n "   기동 대기"
+for i in $(seq 1 120); do
+  MID=$(curl -sf "http://localhost:$PERF_PORT/api/perf/sessions/seeded" 2>/dev/null \
+        | sed -n 's/.*"meetingId":\([0-9]*\).*/\1/p' || true)
+  if [ -n "$MID" ]; then echo " ok (meetingId=$MID)"; break; fi
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    echo " 실패"; tail -30 "$LOG_DIR/app-session.log"; exit 1
+  fi
+  echo -n "."; sleep 2
+done
+[ -n "${MID:-}" ] || { echo "세션을 찾지 못했다"; exit 1; }
+
+run_case() {
+  local lock="$1" label="$2"
+  echo
+  echo "=============================================================="
+  echo " $label  (lock=$lock, 정원 $CAPACITY, 동시 시도 $ATTEMPTS)"
+  echo "=============================================================="
+
+  k6 run -q -e LOCK="$lock" -e LABEL="$label" -e CAPACITY="$CAPACITY" \
+      -e ATTEMPTS="$ATTEMPTS" k6/session-capacity.js
+
+  # k6 가 끝난 뒤 실제 DB 상태를 읽어 결과에 합친다.
+  local state
+  state=$(curl -sf "http://localhost:$PERF_PORT/api/perf/sessions/state?meetingId=$MID" || echo '{}')
+  python3 - "$label" "$state" <<'PY'
+import json, sys, pathlib
+label, state = sys.argv[1], json.loads(sys.argv[2] or '{}')
+path = pathlib.Path(f"docs/performance/data/k6-session-{label}.json")
+data = json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}
+data.update({
+    "final_active": state.get("active"),
+    "final_limit": state.get("limit"),
+    "overflow": state.get("overflow"),
+    "verdict": "정원 초과" if (state.get("overflow") or 0) > 0 else "정원 준수",
+})
+path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding='utf-8')
+print(f"   최종: 정원 {data.get('final_limit')} / 입장 {data.get('final_active')} "
+      f"/ 초과 {data.get('overflow')} → {data['verdict']}")
+PY
+}
+
+# 잠금 없는 경우를 먼저 돌린다. 잠금 있는 경우가 먼저면 캐시가 덥혀져서
+# 두 번째 회차가 유리해진다.
+run_case false without-lock
+run_case true  with-lock
+
+echo
+echo "== 완료: docs/performance/data/k6-session-*.json =="

--- a/scripts/verify-alerting.sh
+++ b/scripts/verify-alerting.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# 경보가 실제로 사람에게 도달하는지 확인한다. (#139)
+#
+# ★ 왜 이 스크립트가 있는가.
+#
+#   이 저장소는 "선언은 있는데 아무도 안 쓴다" 를 여덟 번 만났다.
+#   경보는 그 함정에 특히 잘 빠진다 - 규칙 파일을 커밋하면 일이 끝난 것처럼 보이는데,
+#   실제로는 네 군데에서 조용히 끊길 수 있다.
+#
+#     ① Prometheus 가 규칙 파일을 아예 안 읽었다 (경로 오타, 마운트 누락)
+#     ② 규칙은 읽었는데 물어보는 지표가 없다 -> 빈 결과. 빈 결과는 "정상" 과 같다
+#     ③ firing 이 됐는데 Alertmanager 로 안 간다 (alerting: 설정 누락)
+#     ④ Alertmanager 가 받았는데 수신자가 없다 -> 조용히 버린다
+#
+#   ①②는 여기서, ③④는 --fire 로 실제 경보를 만들어 확인한다.
+#
+# 사용법 (서버 안에서)
+#   ./scripts/verify-alerting.sh            구조만 확인 (빠름, 안전)
+#   ./scripts/verify-alerting.sh --fire     실제 경보를 하나 쏴서 끝까지 도달하는지 확인
+set -euo pipefail
+
+PROM="${PROM_URL:-http://localhost:9090}"
+ALERTMANAGER="${ALERTMANAGER_URL:-http://localhost:9093}"
+FIRE=0
+[ "${1:-}" = "--fire" ] && FIRE=1
+
+fail=0
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$1"; }
+bad()  { printf "  \033[31m✗\033[0m %s\n" "$1"; fail=1; }
+head() { printf "\n\033[1m%s\033[0m\n" "$1"; }
+
+need() { command -v "$1" >/dev/null || { echo "$1 이 필요하다"; exit 2; }; }
+need curl; need jq
+
+# ── ① 규칙을 실제로 로드했는가 ────────────────────────────────────────
+head "① Prometheus 가 규칙을 로드했는가"
+
+rules_json=$(curl -sf "$PROM/api/v1/rules" || echo '')
+if [ -z "$rules_json" ]; then
+  bad "$PROM/api/v1/rules 에 닿지 못했다"
+else
+  n=$(jq '[.data.groups[].rules[]] | length' <<<"$rules_json")
+  if [ "$n" -gt 0 ]; then ok "규칙 ${n}개 로드됨"; else
+    bad "규칙이 0개다. rule_files 경로와 볼륨 마운트를 본다"
+  fi
+
+  # 파일에 있는 규칙 이름이 전부 로드됐는지 대조한다.
+  # 파일에만 있고 Prometheus 에 없으면 그 규칙은 존재하지 않는 것과 같다.
+  loaded=$(jq -r '[.data.groups[].rules[].name] | sort | .[]' <<<"$rules_json")
+  declared=$(grep -oE '^\s*- alert:\s*\S+' observability/rules/*.yml | awk '{print $NF}' | sort)
+  missing=$(comm -13 <(echo "$loaded") <(echo "$declared") || true)
+  if [ -z "$missing" ]; then ok "파일의 규칙이 전부 로드됨"; else
+    bad "파일에 있는데 로드 안 된 규칙:"; echo "$missing" | sed 's/^/      /'
+  fi
+
+  # 평가 자체가 실패하는 규칙 (문법은 맞는데 런타임 에러)
+  errs=$(jq -r '[.data.groups[].rules[] | select(.health != "ok") | "\(.name): \(.lastError // .health)"] | .[]' <<<"$rules_json")
+  if [ -z "$errs" ]; then ok "평가 오류 없음"; else
+    bad "평가에 실패하는 규칙:"; echo "$errs" | sed 's/^/      /'
+  fi
+fi
+
+# ── ② 규칙이 물어보는 지표가 실제로 있는가 ────────────────────────────
+head "② 규칙이 물어보는 지표가 실제로 나오는가"
+#
+#   없는 지표를 물어보면 Prometheus 는 에러가 아니라 빈 결과를 낸다.
+#   빈 결과는 "정상" 과 구분되지 않으므로, 그 경보는 영원히 안 울린다.
+for metric in chat_channel_queued chat_channel_capacity chat_fanout_recipients_bucket \
+              caption_archive_dropped_total chat_archive_queued caption_archive_queued \
+              chat_sessions_active chat_messages_published_total; do
+  cnt=$(curl -sf --get "$PROM/api/v1/query" --data-urlencode "query=$metric" \
+        | jq '.data.result | length' 2>/dev/null || echo 0)
+  if [ "$cnt" -gt 0 ]; then ok "$metric (시계열 ${cnt}개)"; else
+    bad "$metric 이 없다 - 이 지표를 쓰는 경보는 절대 안 울린다"
+  fi
+done
+
+# ── ③ Alertmanager 가 연결돼 있는가 ───────────────────────────────────
+head "③ Prometheus 가 Alertmanager 를 알고 있는가"
+active=$(curl -sf "$PROM/api/v1/alertmanagers" | jq '.data.activeAlertmanagers | length' 2>/dev/null || echo 0)
+if [ "$active" -gt 0 ]; then ok "Alertmanager ${active}개 연결됨"; else
+  bad "연결된 Alertmanager 가 없다. prometheus.yml 의 alerting: 을 본다"
+fi
+
+# ── ④ 수신자가 실제로 설정돼 있는가 ───────────────────────────────────
+head "④ 경보를 받을 곳이 있는가"
+#
+#   receivers 에 이름만 있고 webhook_configs 등이 없으면 Alertmanager 는
+#   경보를 받아서 조용히 버린다. 이 저장소가 여덟 번 만난 모양 그대로다.
+recv=$(curl -sf "$ALERTMANAGER/api/v2/status" | jq -r '.config.original' 2>/dev/null || echo '')
+if [ -z "$recv" ]; then
+  bad "$ALERTMANAGER 에 닿지 못했다"
+elif grep -qE '(webhook|slack|email|pagerduty|opsgenie|telegram|discord)_configs' <<<"$recv"; then
+  ok "수신자가 설정돼 있다"
+else
+  bad "수신자가 비어 있다 - firing 이 돼도 아무 데도 안 간다. Ansible vault 의 웹훅을 확인한다"
+fi
+
+# ── 실제로 쏴 본다 ────────────────────────────────────────────────────
+if [ "$FIRE" = 1 ]; then
+  head "⑤ 경보를 하나 실제로 보내 본다"
+  #
+  #   규칙을 기다리지 않고 Alertmanager 에 직접 넣는다.
+  #   확인하려는 것은 "규칙이 맞나" 가 아니라 "받은 뒤 나가는가" 이므로 이 경로면 충분하다.
+  now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  end=$(date -u -d '+2 minutes' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null \
+        || date -u -v+2M +%Y-%m-%dT%H:%M:%S.000Z)
+  code=$(curl -s -o /dev/null -w '%{http_code}' -XPOST "$ALERTMANAGER/api/v2/alerts" \
+    -H 'Content-Type: application/json' -d "[{
+      \"labels\": {\"alertname\":\"AlertingPipelineSmokeTest\",\"severity\":\"warning\",\"service\":\"edumeet\"},
+      \"annotations\": {\"summary\":\"경보 경로 점검용. 이 알림이 보이면 경로가 살아 있다\"},
+      \"startsAt\": \"$now\", \"endsAt\": \"$end\"
+    }]")
+  if [ "$code" = "200" ]; then
+    ok "Alertmanager 가 접수했다 (HTTP 200)"
+    echo "      → 실제 알림이 도착했는지는 사람이 확인한다. 2분 뒤 자동 해제된다."
+  else
+    bad "Alertmanager 가 거부했다 (HTTP $code)"
+  fi
+fi
+
+head "결과"
+if [ "$fail" = 0 ]; then
+  ok "경보 경로가 끊긴 곳 없이 이어져 있다"
+else
+  bad "위의 ✗ 를 고치기 전까지 이 경보들은 울리지 않는다"
+  exit 1
+fi

--- a/scripts/verify-doc-refs.sh
+++ b/scripts/verify-doc-refs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# 문서가 "재현" 으로 가리키는 파일이 실제로 저장소에 있는지 본다. (#162)
+#
+# 왜 필요한가
+#   두 번 빠졌다.
+#     #156 squash 에서 k6/caption-backpressure.js 가 통째로 빠졌다
+#     .gitignore 의 *.sh 가 scripts/ 의 재현 스크립트 6개를 먹고 있었다
+#   둘 다 문서는 그대로 그 파일을 가리키고 있었고, 로컬에는 파일이 있어서
+#   아무도 눈치채지 못했다. 재현 경로가 저장소에 없으면 그 측정은 다시 못 돌린다.
+#
+# 왜 재현 경로만 보나
+#   문서에는 "이 선택지는 기각했다" 로 적힌 없는 경로도 있고(contracts/caption-glossary.json),
+#   k6/websockets 처럼 저장소 경로가 아닌 모듈 이름도 있다.
+#   넓게 잡아 오탐이 나면 이 검사부터 무시당한다. 그러면 없느니만 못하다.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+FAIL=0
+while IFS=: read -r doc line ref; do
+  [ -z "${ref:-}" ] && continue
+  if ! git ls-files --error-unmatch "$ref" >/dev/null 2>&1; then
+    echo "없음  $ref   ($doc:$line)"; FAIL=1
+  fi
+done < <(grep -rnoE '`(scripts/[A-Za-z0-9._-]+\.(sh|py)|k6/[A-Za-z0-9._-]+\.js)`' \
+           docs/ CLAUDE.md 2>/dev/null | sed 's/`//g')
+if [ "$FAIL" = 0 ]; then
+  echo "문서가 가리키는 재현 파일이 전부 저장소에 있다"
+fi
+exit "$FAIL"


### PR DESCRIPTION
## 무엇이 문제였나

문서가 `scripts/run-benchmark.sh` 같은 **재현 경로**를 가리키는데, 그 파일들이 저장소에 없었다.

```
.gitignore:242  *.sh
```

`*.sh` 가 전부 먹고 있었다. **로컬에는 파일이 있어서 아무도 눈치채지 못했다.**

| 빠져 있던 것 |
|---|
| `scripts/run-benchmark.sh` |
| `scripts/run-chat-oom.sh` |
| `scripts/run-fault-injection.sh` |
| `scripts/run-lock-determinism.sh` |
| `scripts/run-session-benchmark.sh` |
| `scripts/verify-alerting.sh` |

## 저번과 같은 일이다

**#156 squash 에서 k6 스크립트가 통째로 빠졌던 것과 같은 모양이다.**
그때는 파일 하나를 다시 올리고 끝냈는데, 이번에 보니 원인이 **규칙 쪽**이었다.
예외를 한 줄씩 더하는 식으로 때운 흔적도 있었다 — `!scripts/bench-hls-codec-paths.sh`.

```diff
+# ★ *.sh 는 임시 실행 스크립트가 딸려 들어오는 것을 막으려는 규칙이다.
+#   그런데 scripts/ 는 문서가 "재현: scripts/..." 로 가리키는 자리라 같이 먹히면 안 된다.
 *.sh
-!scripts/bench-hls-codec-paths.sh
+!scripts/*.sh
```

## 다시 안 생기게

CI 에 검사를 붙였다(`scripts/verify-doc-refs.sh`). 문서가 가리키는 재현 파일이
**`git ls-files` 에 있는지** 본다. 로컬 존재가 아니라 저장소 존재를 묻는 것이 핵심이다.

**되돌려서 잡히는 것을 확인했다.**

```
$ git rm --cached scripts/run-benchmark.sh && ./scripts/verify-doc-refs.sh
없음  scripts/run-benchmark.sh   (docs/team-convention.md:336)
종료코드 1
```

### 재현 경로만 보는 이유

문서에는 *"이 선택지는 기각했다"* 로 적힌 없는 경로(`contracts/caption-glossary.json`)도 있고,
`k6/websockets` 처럼 **저장소 경로가 아닌 모듈 이름**도 있다.
넓게 잡으면 오탐이 나고, **오탐이 나면 이 검사부터 무시당한다.**
그래서 `scripts/*.{sh,py}` 와 `k6/*.js` 만 본다.