### PR TITLE
feat(chat): 입장 시 지난 대화를 실제로 꺼낼 수 있게 연결한다 (#170)

### DIFF
--- a/backend/src/main/java/com/edu/edumeet/chat/controller/ChatReplayController.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/controller/ChatReplayController.java
@@ -3,6 +3,8 @@ package com.edu.edumeet.chat.controller;
 import com.edu.edumeet.chat.dto.ChatReplayResponse;
 import com.edu.edumeet.chat.service.ChatService;
 import com.edu.edumeet.member.domain.SecurityMember;
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,6 +44,27 @@ public class ChatReplayController {
      * @param from 구간 시작(포함), 회의 시작 기준 밀리초
      * @param to   구간 끝(제외)
      */
+    /**
+     * 입장 시 보여줄 지난 대화. (#170)
+     *
+     * <pre>
+     *   GET /api/v1/meeting/7/chat/recent
+     * </pre>
+     *
+     * <p><b>{@code /replay} 와 다른 질문이다.</b> 그쪽은 <i>"그때 무슨 얘기 했나"</i> 라
+     * 재생 위치를 받고, 이쪽은 <i>"지금 들어왔는데 방금 무슨 얘기 했나"</i> 라 인자가 없다.
+     *
+     * <p>이 엔드포인트가 없어서 <b>새로고침하면 채팅이 통째로 비었다.</b>
+     * 읽는 코드는 예전부터 있었는데 부르는 곳이 없었다.
+     */
+    @GetMapping("/recent")
+    public ResponseEntity<List<ChatMessageResponse>> recent(
+            @AuthenticationPrincipal SecurityMember member,
+            @PathVariable Long meetingId) {
+
+        return ResponseEntity.ok(chatService.recentMessages(meetingId, member.getEmail()));
+    }
+
     @GetMapping("/replay")
     public ResponseEntity<ChatReplayResponse> replay(
             @AuthenticationPrincipal SecurityMember member,

--- a/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
+++ b/backend/src/main/java/com/edu/edumeet/chat/service/ChatService.java
@@ -77,7 +77,43 @@ public class ChatService {
                 meetingId, senderEmail, trimmed, System.currentTimeMillis());
     }
 
-    /** 입장 시 보여줄 지난 대화. 저장하지 않는 BROADCAST 는 항상 빈 목록이다. */
+    /**
+     * 입장 시 보여줄 지난 대화. (#170)
+     *
+     * <h3>왜 필요한가</h3>
+     * 이 메서드는 오래 전부터 있었는데 <b>아무도 안 불렀다.</b> 컨트롤러도 시험도
+     * 프론트도 안 부르고 주석에서만 언급됐다. 그래서 새로고침하면 채팅이 통째로 비었고,
+     * <b>사용자에게는 그게 고장으로 보인다.</b>
+     *
+     * <p>이 저장소가 반복해 잡은 모양이다 — 만들어 놓고 연결하지 않은 것.
+     * 이번에는 없는 기능을 만든 게 아니라 <b>있는 것을 연결했다.</b>
+     *
+     * <h3>끊긴 동안 놓친 것은 메우지 않는다</h3>
+     * 자막은 재접속 시 놓친 구간을 밀어 준다(#165). <b>채팅은 안 한다.</b>
+     * 성격이 다르기 때문이다.
+     *
+     * <pre>
+     *   자막을 놓치면   강의 내용을 놓친다. 청각장애 학습자에게 3초는 자막 63건이다
+     *   채팅을 놓치면   남의 코멘트를 놓친다. 라이브에서는 원래 그렇다
+     * </pre>
+     *
+     * 라이브 채팅은 <b>들어온 시점부터 보는 것</b>이 표준 동작이다.
+     * 여기서 하는 것은 그 표준에 맞추는 것뿐이다 — 화면이 비어 보이지 않을 만큼만 채운다.
+     *
+     * <h3>BROADCAST 도 나온다</h3>
+     * 예전 주석에 <i>"저장하지 않는 BROADCAST 는 항상 빈 목록"</i> 이라고 적혀 있었는데
+     * <b>#61 이후로 틀린 말이다.</b> 방송 채팅도 저장한다 — 발행 경로가 아니라 큐를 거칠 뿐이다.
+     */
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponse> recentMessages(Long meetingId, String email) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회의입니다: " + meetingId));
+        // 구독과 같은 권한을 본다. 실시간으로 볼 수 있는 것을 조회로 우회하면 안 된다.
+        classAccessChecker.requireMember(meeting.getClassRoom().getId(), email);
+        return recentMessages(meetingId);
+    }
+
+    /** 권한 확인 없이 읽는다. 위 메서드와 시험에서만 쓴다. */
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> recentMessages(Long meetingId) {
         return chatMessageRepository.findRecent(meetingId, PageRequest.of(0, RECENT_LIMIT))

--- a/backend/src/test/java/com/edu/edumeet/integration/chat/RecentChatEndpointTest.java
+++ b/backend/src/test/java/com/edu/edumeet/integration/chat/RecentChatEndpointTest.java
@@ -1,0 +1,157 @@
+package com.edu.edumeet.integration.chat;
+
+import com.edu.edumeet.chat.dto.ChatMessageResponse;
+import com.edu.edumeet.chat.service.ChatService;
+import com.edu.edumeet.classroom.domain.ClassRoom;
+import com.edu.edumeet.meeting.domain.Meeting;
+import com.edu.edumeet.meeting.domain.MeetingParticipant;
+import com.edu.edumeet.meeting.domain.SessionType;
+import com.edu.edumeet.member.domain.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 입장 시 지난 대화를 실제로 꺼낼 수 있는지 고정한다. (#170)
+ *
+ * <h3>왜 이 시험이 생겼나</h3>
+ * {@code ChatService.recentMessages} 는 오래 전부터 있었는데 <b>아무도 안 불렀다.</b>
+ * 컨트롤러도 시험도 프론트도 안 부르고 주석에서만 언급됐다.
+ *
+ * <p>결과는 <i>"채팅이 안 나온다"</i> 가 아니라 <b>"새로고침하면 화면이 빈다"</b> 였다.
+ * 에러가 아니라 빈 화면이라 아무도 고장이라고 느끼지 않는다.
+ * 이 저장소가 반복해 잡은 모양이다 — 만들어 놓고 연결하지 않은 것.
+ *
+ * <p>그래서 <b>메서드가 도는지가 아니라 HTTP 로 닿는지</b>를 본다.
+ * 서비스만 시험하면 이번과 똑같이 "되는데 아무도 못 쓰는" 상태가 다시 만들어진다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("입장 시 지난 대화")
+class RecentChatEndpointTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    @Autowired ChatService chatService;
+    @Autowired com.edu.edumeet.chat.service.ChatArchiveQueue archiveQueue;
+    @Autowired RequestMappingHandlerMapping handlerMapping;
+    @Autowired TransactionTemplate transactionTemplate;
+    @PersistenceContext EntityManager em;
+
+    private Long meetingId;
+    private Long classRoomId;
+    private String member;
+    private String outsider;
+
+    @BeforeEach
+    void setUp() {
+        int n = SEQ.incrementAndGet();
+        member = "recent-chat-" + n + "@test";
+        outsider = "recent-outsider-" + n + "@test";
+        transactionTemplate.executeWithoutResult(s -> {
+            Member owner = Member.builder().email(member).nickname("참가자").password("x").build();
+            em.persist(owner);
+            em.persist(Member.builder().email(outsider).nickname("외부인").password("x").build());
+            ClassRoom room = ClassRoom.builder().member(owner).title("클래스").description("-")
+                    .participantLimit(30).isDeleted(false).build();
+            em.persist(room);
+            Meeting meeting = Meeting.builder().classRoom(room).title("방송").description("-")
+                    .sessionType(SessionType.BROADCAST)
+                    .startTime(LocalDateTime.now().minusMinutes(10)).build();
+            em.persist(meeting);
+            em.persist(MeetingParticipant.join(meeting, member));
+            em.flush();
+            meetingId = meeting.getId();
+            classRoomId = room.getId();
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 만든 것까지만 지운다. 전체를 지우면 같은 컨텍스트의 다른 시험이 깨진다.
+        transactionTemplate.executeWithoutResult(s -> {
+            em.createQuery("DELETE FROM ChatMessage c WHERE c.meeting.id = :id")
+                    .setParameter("id", meetingId).executeUpdate();
+            em.createQuery("DELETE FROM MeetingParticipant p WHERE p.meeting.id = :id")
+                    .setParameter("id", meetingId).executeUpdate();
+            em.createQuery("DELETE FROM Meeting m WHERE m.id = :id")
+                    .setParameter("id", meetingId).executeUpdate();
+            em.createQuery("DELETE FROM ClassRoom c WHERE c.id = :id")
+                    .setParameter("id", classRoomId).executeUpdate();
+            em.createQuery("DELETE FROM Member m WHERE m.email IN (:a, :b)")
+                    .setParameter("a", member).setParameter("b", outsider).executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("★ HTTP 로 닿는 경로가 있다")
+    void 엔드포인트가_실재한다() {
+        boolean exists = handlerMapping.getHandlerMethods().entrySet().stream()
+                .anyMatch(e -> patternsOf(e.getKey()).contains(
+                        "/api/v1/meeting/{meetingId}/chat/recent"));
+
+        assertThat(exists)
+                .as("서비스 메서드만 있고 부르는 곳이 없으면 '되는데 아무도 못 쓰는' 상태다. "
+                        + "실제로 그랬고, 증상은 에러가 아니라 빈 화면이라 아무도 고장이라고 느끼지 않았다")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("방송 채팅도 나온다 - 다만 배치가 넣은 뒤부터다")
+    void 방송도_지난_대화가_나온다() {
+        chatService.handle(meetingId, member, "먼저 한 말");
+        chatService.handle(meetingId, member, "그다음 말");
+
+        // ★ 바로는 안 보인다.
+        //   방송 채팅은 발행 경로에서 저장하지 않는다. 큐에 넣고 배치가 가져간다(#61).
+        //   발행 경로의 DB 쓰기가 브로드캐스트 측정을 가리기 때문이다.
+        //
+        //   그래서 "방금 한 말" 이 지난 대화에 뜨기까지 flush 주기(기본 1초)만큼 늦는다.
+        //   이건 결함이 아니라 그 설계의 대가다. 시험이 그 사실을 그대로 담는다.
+        assertThat(chatService.recentMessages(meetingId, member))
+                .as("발행 직후에는 아직 큐에 있다. 이 지연이 비동기 저장의 대가다")
+                .isEmpty();
+
+        archiveQueue.flush();
+
+        assertThat(chatService.recentMessages(meetingId, member))
+                .extracting(ChatMessageResponse::content)
+                .as("예전 주석은 'BROADCAST 는 항상 빈 목록' 이라고 했는데 #61 이후로 틀린 말이다")
+                .containsExactly("먼저 한 말", "그다음 말");
+    }
+
+    @Test
+    @DisplayName("그 방을 볼 수 없는 사람은 지난 대화도 못 본다")
+    void 외부인은_못_본다() {
+        chatService.handle(meetingId, member, "우리끼리 한 말");
+
+        assertThatThrownBy(() -> chatService.recentMessages(meetingId, outsider))
+                .as("실시간으로 못 보는 것을 조회로 우회할 수 있으면 구독 인가가 의미가 없다")
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> patternsOf(RequestMappingInfo info) {
+        return info.getPathPatternsCondition() != null
+                ? info.getPathPatternsCondition().getPatternValues().stream().toList()
+                : List.of();
+    }
+}

--- a/frontend/src/components/BroadcastChat.vue
+++ b/frontend/src/components/BroadcastChat.vue
@@ -10,6 +10,7 @@
  */
 import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { createRealtimeClient } from '@/features/realtime/stompClient'
+import { fetchRecentChat } from '@/features/chat/recentChatApi'
 
 const props = defineProps({
   meetingId: { type: [Number, String], required: true },
@@ -34,12 +35,27 @@ function push(bucket, item) {
   })
 }
 
-onMounted(() => {
+onMounted(async () => {
   const token = localStorage.getItem('token') || localStorage.getItem('accessToken')
   if (!token) {
     state.value = 'error'
     return
   }
+
+  // 지난 대화를 먼저 채운다. (#170)
+  //
+  // 이게 없으면 새로고침할 때마다 채팅이 통째로 비어서 고장처럼 보인다.
+  // 라이브 채팅은 들어온 시점부터 보는 게 표준이지만, 화면이 완전히 비는 것과
+  // "방금까지 이런 얘기가 오갔다" 가 보이는 것은 다르다.
+  //
+  // ★ 연결보다 먼저 부르되 기다리지 않는다.
+  //   서버가 느리면 실시간 채팅 연결이 그만큼 늦어진다. 지난 대화는 있으면
+  //   좋은 것이고, 실시간은 없으면 못 쓰는 것이다. 급한 쪽을 안 막는다.
+  fetchRecentChat(props.meetingId).then((past) => {
+    // 그 사이 실시간 메시지가 먼저 왔을 수 있다. 지난 것을 앞에 붙인다.
+    if (past.length) messages.value.unshift(...past)
+  })
+
   client = createRealtimeClient({
     baseUrl: import.meta.env.VITE_API_ORIGIN || window.location.origin,
     token,

--- a/frontend/src/features/chat/recentChatApi.js
+++ b/frontend/src/features/chat/recentChatApi.js
@@ -1,0 +1,35 @@
+/**
+ * 입장 시 보여줄 지난 대화. (#170)
+ *
+ * 백엔드 계약
+ *   GET /api/v1/meeting/{meetingId}/chat/recent  →  최근 50건, 오래된 것부터
+ *
+ * ★ 다시보기(/replay)와 다른 질문이다.
+ *   그쪽은 "그때 무슨 얘기 했나" 라 재생 위치를 받고,
+ *   이쪽은 "지금 들어왔는데 방금 무슨 얘기 했나" 라 인자가 없다.
+ *
+ * ★ 끊긴 동안 놓친 것을 메우는 용도가 아니다.
+ *   자막은 재접속 시 놓친 구간을 서버가 밀어 준다. 채팅은 안 한다 -
+ *   자막을 놓치면 강의 내용을 놓치지만, 채팅을 놓치는 건 라이브에서 원래 그렇다.
+ *   여기서 하는 것은 화면이 통째로 비어 보이지 않게 하는 것까지다.
+ */
+import apiClient from '@/utils/apiClient'
+
+/**
+ * 최근 대화를 가져온다.
+ *
+ * 실패해도 던지지 않는다. 지난 대화는 있으면 좋은 것이지 없으면 못 쓰는 것이 아니고,
+ * 여기서 던지면 그것 때문에 실시간 채팅 연결까지 못 하게 된다.
+ *
+ * @param {number|string} meetingId
+ * @returns {Promise<Array>} 오래된 것부터. 실패하면 빈 배열
+ */
+export async function fetchRecentChat(meetingId) {
+  try {
+    const { data } = await apiClient.get(`/meeting/${meetingId}/chat/recent`)
+    return Array.isArray(data) ? data : []
+  } catch (e) {
+    console.warn('지난 대화를 못 가져왔다. 실시간 채팅은 계속한다', e)
+    return []
+  }
+}


### PR DESCRIPTION
## 만들어 놓고 아무도 안 부르고 있었다

`ChatService.recentMessages` 는 오래 전부터 있었다. **컨트롤러도 시험도 프론트도 안 부른다.**
주석에서만 언급된다.

```
데이터        있다 (모든 세션 타입, 큐를 거쳐 배치 저장)
읽는 코드     있다 (최근 50건, 오래된 것부터)
부르는 곳     없다  ← 여기
```

증상이 *"채팅이 안 나온다"* 가 아니라 **"새로고침하면 화면이 빈다"** 였다.
**에러가 아니라 빈 화면이라 아무도 고장이라고 느끼지 않는다.**

이 저장소가 반복해 잡은 모양이다. 그래서 **새 기능을 만든 게 아니라 있는 것을 연결했다.**

## 자막처럼 밀어 주지는 않는다

자막은 재접속 시 놓친 구간을 서버가 밀어 준다(#165). **채팅은 안 한다.**

| | 놓치면 |
|---|---|
| **자막** | **강의 내용을 놓친다.** 3초는 자막 63건이다 |
| 채팅 | 남의 코멘트를 놓친다. 라이브에서는 원래 그렇다 |

라이브 채팅은 **들어온 시점부터 보는 것이 표준**이다(트위치·유튜브도 그렇다).
여기서 하는 것은 화면이 통째로 비어 보이지 않을 만큼까지다.

## 권한을 붙였다

`recentMessages` 에는 권한 확인이 **없었고** `replay` 에는 있었다.
**실시간으로 못 보는 것을 조회로 우회할 수 있으면 구독 인가가 의미가 없다.**

## 낡은 주석을 고쳤다

> *"입장 시 보여줄 지난 대화. 저장하지 않는 BROADCAST 는 항상 빈 목록이다."*

**#61 이후로 틀린 말이다.** 방송 채팅도 저장한다 — 발행 경로가 아니라 큐를 거칠 뿐이다.
(그 근거도 재서 뒤집혔다 — 쓰기는 fan-out 이 아니라 발행량이다.)

다만 **배치가 넣기까지 flush 주기만큼 늦는다.** 결함이 아니라 비동기 저장의 대가라,
시험이 그 사실을 그대로 담는다.

```java
assertThat(recentMessages(...)).isEmpty();   // 발행 직후에는 아직 큐에 있다
archiveQueue.flush();
assertThat(recentMessages(...)).containsExactly("먼저 한 말", "그다음 말");
```

## 시험은 HTTP 로 닿는지를 본다

**서비스만 시험하면 이번과 똑같이 "되는데 아무도 못 쓰는" 상태가 다시 만들어진다.**
`RequestMappingHandlerMapping` 에서 경로가 실재하는지 본다.

`@GetMapping("/recent")` 를 떼면 **그 시험이 깨지는 것을 확인했다.**

## 프론트

연결보다 **먼저 부르되 기다리지 않는다.** 서버가 느리면 실시간 연결이 그만큼 늦어진다.
지난 대화는 있으면 좋은 것이고 실시간은 없으면 못 쓰는 것이다.
실패해도 던지지 않는다 — 그것 때문에 실시간 채팅까지 못 하게 되면 안 된다.