### PR TITLE
fix: SELinux 가 홈의 스크립트를 실행시켜 주지 않았다

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,9 +132,15 @@ jobs:
             # ★ 유닛 파일을 배포 단위로 둔다 - nginx 설정과 같은 이유다.
             #   서버에 손으로 만들어 두면 재설치할 때 사라지고, 사라진 것을
             #   아무도 모른다. 백업은 특히 그렇다 - 없어도 평소에는 아무 일이 없다.
-            chmod +x scripts/backup-mysql.sh scripts/restore-drill.sh
             sudo install -d -o rocky -g rocky -m 0755 \
                 /var/lib/edumeet/backup /var/lib/edumeet/node-exporter-textfile
+
+            # ★ 스크립트를 홈에서 직접 실행시키지 않는다.
+            #   SELinux 가 Enforcing 이고 /home 아래는 user_home_t 라벨이라
+            #   systemd 가 실행하지 못한다 - 실행 비트가 있어도 203/EXEC 로 죽는다.
+            #   /usr/local/bin 아래로 install 하면 bin_t 를 상속한다.
+            sudo install -m 0755 scripts/backup-mysql.sh  /usr/local/bin/edumeet-backup
+            sudo install -m 0755 scripts/restore-drill.sh /usr/local/bin/edumeet-restore-drill
             sudo install -m 0644 deploy/systemd/edumeet-backup.service       /etc/systemd/system/
             sudo install -m 0644 deploy/systemd/edumeet-backup.timer         /etc/systemd/system/
             sudo install -m 0644 deploy/systemd/edumeet-restore-drill.service /etc/systemd/system/
@@ -162,6 +168,18 @@ jobs:
               fi
               echo "타이머 확인: $t -> 다음 실행 $next"
             done
+
+            # ★ 타이머가 걸린 것과 스크립트가 도는 것은 다른 일이다.
+            #   실제로 백업을 한 번 떠 본다 - 여기서 실패하면 배포가 실패한다.
+            #   이게 없으면 "타이머는 걸렸는데 새벽마다 조용히 실패" 를 며칠 뒤에 안다.
+            #   실제로 SELinux 때문에 그렇게 죽었다(203/EXEC).
+            sudo systemctl start edumeet-backup.service
+            if [ "$(systemctl show edumeet-backup.service -p ExecMainStatus --value)" != "0" ]; then
+              echo "백업이 실패했다"
+              journalctl -u edumeet-backup -n 30 --no-pager
+              exit 1
+            fi
+            echo "백업 실행 확인: $(ls -1 /var/lib/edumeet/backup/edumeet-*.sql.gz | wc -l)개 보관 중"
 
             # ★ --profile observability 를 붙인다. (#83)
             #   prometheus·grafana 는 profiles: [observability] 라

--- a/deploy/systemd/edumeet-backup.service
+++ b/deploy/systemd/edumeet-backup.service
@@ -1,7 +1,13 @@
 # MySQL 백업. (#175)
 #
-# 저장소의 scripts/backup-mysql.sh 를 그대로 부른다 -
+# 저장소의 scripts/backup-mysql.sh 를 배포가 여기에 설치한다 -
 # 로직을 유닛 파일에 적으면 저장소에서 검토되지 않는 코드가 서버에만 생긴다.
+#
+# ★ 홈 디렉터리에서 직접 부르지 않는다.
+#   이 서버는 SELinux 가 Enforcing 이고 /home 아래 파일은 user_home_t 라벨이 붙는다.
+#   systemd 는 그 라벨의 파일을 실행하지 못한다 - 실행 비트가 있어도
+#   "Permission denied" 로 죽는다(status=203/EXEC). 실제로 그렇게 죽었다.
+#   /usr/local/bin 아래에 install 하면 bin_t 를 상속해 정상 실행된다.
 [Unit]
 Description=EduMeet MySQL 백업
 Requires=docker.service
@@ -10,6 +16,6 @@ After=docker.service
 [Service]
 Type=oneshot
 User=rocky
-ExecStart=/home/rocky/edumeet/scripts/backup-mysql.sh
+ExecStart=/usr/local/bin/edumeet-backup
 # 실패해도 타이머는 계속 돈다. 다음 회차에 성공할 수 있고,
 # 실패 자체는 지표(edumeet_backup_success)로 경보가 나간다.

--- a/deploy/systemd/edumeet-restore-drill.service
+++ b/deploy/systemd/edumeet-restore-drill.service
@@ -2,6 +2,9 @@
 #
 # 백업 파일이 쌓이는 것과 그 파일로 DB 를 세울 수 있는 것은 다른 일이다.
 # 확인하는 날이 이미 늦은 날이 되지 않게 정기적으로 세워 본다.
+#
+# ★ 실행 파일은 /usr/local/bin 에 있다. SELinux 가 /home 아래 파일의 실행을 막는다
+#   (edumeet-backup.service 의 주석 참고).
 [Unit]
 Description=EduMeet 백업 복구 훈련
 Requires=docker.service
@@ -10,4 +13,4 @@ After=docker.service
 [Service]
 Type=oneshot
 User=rocky
-ExecStart=/home/rocky/edumeet/scripts/restore-drill.sh
+ExecStart=/usr/local/bin/edumeet-restore-drill

--- a/docs/ops/21-backup.md
+++ b/docs/ops/21-backup.md
@@ -104,6 +104,35 @@ ERROR 1045 (28000): Access denied for user 'root'@'localhost'
 
 기다리는 조건을 **우리가 실제로 할 일**로 바꿨다 — 비밀번호로 붙어 질의해 본다.
 
+### SELinux 가 홈 디렉터리의 스크립트를 실행시켜 주지 않았다
+
+유닛 파일이 저장소의 스크립트를 그대로 부르게 했다. 실행 비트도 있었다.
+
+```
+Failed to locate executable /home/rocky/edumeet/scripts/restore-drill.sh: Permission denied
+edumeet-restore-drill.service: Failed at step EXEC ... status=203/EXEC
+```
+
+이 서버는 SELinux 가 **Enforcing** 이고 `/home` 아래 파일에는 `user_home_t` 라벨이 붙는다.
+systemd 는 그 라벨의 파일을 실행하지 못한다.
+
+```
+unconfined_u:object_r:user_home_t:s0  /home/rocky/edumeet/scripts/restore-drill.sh
+```
+
+nginx 설정·유닛 파일과 같은 방식으로 시스템 경로에 설치하도록 바꿨다.
+`/usr/local/bin` 아래로 `install` 하면 `bin_t` 를 상속한다.
+
+```
+system_u:object_r:bin_t:s0  /usr/local/bin/edumeet-backup
+```
+
+**그리고 배포가 실제로 한 번 떠 본다.** 타이머가 걸린 것과 스크립트가 도는 것은
+다른 일이다. 이 확인이 없었으면 "타이머는 걸렸는데 새벽마다 조용히 실패" 를
+며칠 뒤에나 알았을 것이다 — 이번에는 손으로 돌려 봐서 알았다.
+
+---
+
 ### 배포 확인이 `list-timers` 를 grep 하다 실패했다
 
 타이머를 설치한 뒤 "정말 걸렸나" 를 확인하려고 `systemctl list-timers` 를 grep 했다.
@@ -135,6 +164,11 @@ node-exporter 의 **textfile 수집기**를 쓴다 — 스크립트가 `.prom` �
 경보가 네 개인 이유도 같다. `BackupMetricsMissing` 은 **경보에 대한 경보**다.
 지표 자체가 없으면 `BackupStale` 은 빈 결과를 내고,
 빈 결과는 "정상" 과 구분되지 않는다.
+
+처음엔 그 경보가 백업 지표만 봤다. 배포하고 확인해 보니 훈련 지표가 0개였고,
+그러면 `RestoreDrillStale` 도 똑같이 빈 결과를 낸다 —
+**막으려던 함정을 규칙 하나 옆에 그대로 다시 판 것이다.**
+둘 다 보게 고쳤다.
 
 ### 임계값의 근거
 

--- a/observability/rules/edumeet.yml
+++ b/observability/rules/edumeet.yml
@@ -457,18 +457,25 @@ groups:
       #   백업 스크립트는 실패해도 지표를 쓴다(성공 0). 그러니 지표 자체가
       #   없다는 것은 스크립트가 한 번도 안 돌았거나 textfile 경로가 끊겼다는 뜻이다.
       #   이 경우 BackupStale 은 영원히 안 울린다 - 빈 결과는 "정상" 과 같다.
+      # ★ 훈련 지표도 같이 본다.
+      #
+      #   처음엔 백업 지표만 봤다. 그런데 훈련 지표가 없으면
+      #   RestoreDrillStale 도 똑같이 빈 결과를 낸다 - 훈련이 한 번도
+      #   안 돌아도 조용하다. 막으려던 함정을 규칙 하나 옆에 그대로 다시 팠다.
       - alert: BackupMetricsMissing
         expr: |
           absent(edumeet_backup_last_success_timestamp_seconds)
+            or absent(edumeet_restore_drill_timestamp_seconds)
         for: 30m
         labels:
           severity: warning
           runbook: docs/ops/21-backup.md
         annotations:
-          summary: "백업 지표가 없다 - 백업 경보가 무의미해졌다"
+          summary: "백업 또는 복구 훈련 지표가 없다 - 그쪽 경보가 무의미해졌다"
           description: >-
             타이머가 한 번도 안 돌았거나 node-exporter 의 textfile 경로가 끊겼다.
-            이 상태에서는 BackupStale 이 빈 결과를 내므로 영원히 안 울린다.
+            이 상태에서는 BackupStale·RestoreDrillStale 이 빈 결과를 내므로
+            영원히 안 울린다. 빈 결과는 "정상" 과 구분되지 않는다.
 
       # ────────────────────────────────────────────────────────────────
       # 근거: 복구 훈련은 매주 일요일 05:00 이다. 흩는 폭이 30분이다.


### PR DESCRIPTION
유닛이 저장소 스크립트를 그대로 부르게 했더니 죽었다. 실행 비트는 있었다.

```
Failed to locate executable .../scripts/restore-drill.sh: Permission denied
Failed at step EXEC ... status=203/EXEC
```

이 서버는 SELinux 가 **Enforcing** 이고 `/home` 아래는 `user_home_t` 라벨이라
systemd 가 실행하지 못한다.

nginx 설정·유닛 파일과 같은 방식으로 `/usr/local/bin` 에 install 한다 — `bin_t` 를 상속한다.

**그리고 배포가 백업을 실제로 한 번 떠 본다.** 타이머가 걸린 것과 스크립트가 도는 것은
다른 일이다. 이게 없었으면 "타이머는 걸렸는데 새벽마다 조용히 실패" 를 며칠 뒤에 알았을 것이다.

## 경보에도 같은 구멍이 있었다

`BackupMetricsMissing` 이 백업 지표만 봤다. 배포 후 확인해 보니 훈련 지표가 0개였고,
그러면 `RestoreDrillStale` 도 빈 결과를 낸다 —
**막으려던 함정을 규칙 하나 옆에 그대로 다시 판 것이다.** 둘 다 보게 했다.

## 서버 확인

```
system_u:object_r:bin_t:s0  /usr/local/bin/edumeet-backup
백업 종료코드 0 · 훈련 종료코드 0
★ 복구 확인 - 표 20개의 행 수가 전부 일치. 18초 걸렸다
edumeet_restore_drill_success 1
```