### PR TITLE
fix: 존재하지 않는 사용자를 위한 위험한 CORS 기본값 (#179)

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -1,7 +1,6 @@
 # main.py
 from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
 import os, re, glob, wave, traceback, subprocess, requests, time, json, shutil
 
 # 백엔드와 말하는 코드는 backend_client.py 로 옮겼다. (#117)
@@ -48,11 +47,29 @@ from summary_llm import (
 )
 from summary_pdf import write_pdf
 app = FastAPI()
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"], allow_credentials=True,
-    allow_methods=["*"], allow_headers=["*"],
-)
+
+# ★ CORS 미들웨어를 두지 않는다. (#179)
+#
+#   있었다. 그리고 위험한 조합이었다 -
+#
+#       allow_origins=["*"], allow_credentials=True
+#
+#   Starlette 은 이 조합에서 쿠키가 붙은 요청에 대해 **요청이 보낸 origin 을
+#   그대로 되돌려 준다**(cors.py 의 allow_all_origins and has_cookie).
+#   즉 아무 사이트나 이 API 를 인증된 채로 부를 수 있다는 뜻이다.
+#
+#   그런데 지웠지 고치지 않은 이유는 따로 있다 - **브라우저가 여기 닿을 수 없다.**
+#
+#       프론트 코드      이 서비스를 부르는 곳이 없다
+#       nginx            이 서비스로 보내는 location 이 없다
+#       compose          expose 만 한다. 호스트 포트를 열지 않는다
+#
+#   부르는 것은 백엔드뿐이고 서버 간 호출에는 CORS 가 관여하지 않는다.
+#   즉 이 설정은 **존재하지 않는 사용자를 위한 것**이었다.
+#   존재하지 않는 사용자를 위해 위험한 기본값을 들고 있을 이유가 없다.
+#
+#   브라우저가 정말 필요해지면 그때 origin 을 명시해서 넣는다.
+#   와일드카드로 다시 넣는 것은 tests/test_no_wildcard_cors.py 가 막는다.
 
 
 @app.middleware("http")

--- a/ai/tests/test_no_wildcard_cors.py
+++ b/ai/tests/test_no_wildcard_cors.py
@@ -1,0 +1,97 @@
+"""아무 사이트나 인증된 채로 부를 수 있는 CORS 설정을 막는다. (#179)
+
+★ 무엇이 위험한가
+
+  ``allow_origins=["*"]`` 와 ``allow_credentials=True`` 를 같이 쓰면
+  Starlette 은 쿠키가 붙은 요청에 대해 **요청이 보낸 origin 을 그대로
+  되돌려 준다**. 브라우저 입장에서는 "이 사이트는 허용됨" 이 되므로
+  아무 사이트나 이 API 를 인증된 채로 부를 수 있다.
+
+  ``*`` 를 쓰면 자격증명이 안 실린다고 알고 있는 사람이 많은데,
+  그건 브라우저가 ``Access-Control-Allow-Origin: *`` 를 받았을 때의 이야기다.
+  Starlette 은 이 조합에서 ``*`` 를 보내지 않고 origin 을 되돌려 준다.
+
+★ 왜 "지금은 CORS 자체가 없다" 로 끝내지 않는가
+
+  지금 이 서비스는 브라우저가 닿을 수 없다. 그래서 미들웨어를 지웠다.
+  하지만 나중에 브라우저가 필요해지면 누군가 다시 넣을 것이고,
+  가장 먼저 붙여 보는 값이 ``*`` 다 - 그게 제일 빨리 동작하기 때문이다.
+
+  그 순간을 막는다. 이 시험은 CORS 를 못 쓰게 하는 것이 아니라
+  **와일드카드와 자격증명을 같이 쓰는 것**만 막는다.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+AI_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _cors_calls(tree: ast.AST):
+    """add_middleware(CORSMiddleware, ...) 호출을 찾는다."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_middleware"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        name = first.id if isinstance(first, ast.Name) else getattr(first, "attr", None)
+        if name == "CORSMiddleware":
+            yield node
+
+
+def _keyword(call: ast.Call, name: str):
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def test_no_wildcard_origin_with_credentials():
+    offenders = []
+
+    for path in sorted(AI_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for call in _cors_calls(tree):
+            origins = _keyword(call, "allow_origins")
+            creds = _keyword(call, "allow_credentials")
+
+            wildcard = isinstance(origins, ast.List) and any(
+                isinstance(e, ast.Constant) and e.value == "*" for e in origins.elts
+            )
+            credentialed = isinstance(creds, ast.Constant) and creds.value is True
+
+            if wildcard and credentialed:
+                offenders.append(f"{path.name}:{call.lineno}")
+
+    assert not offenders, (
+        "allow_origins=['*'] 와 allow_credentials=True 를 같이 쓰고 있다: "
+        f"{offenders}\n"
+        "Starlette 은 이 조합에서 요청이 보낸 origin 을 그대로 되돌려 준다.\n"
+        "아무 사이트나 이 API 를 인증된 채로 부를 수 있다는 뜻이다.\n"
+        "허용할 origin 을 명시하거나, 자격증명이 필요 없으면 "
+        "allow_credentials 를 빼라."
+    )
+
+
+def test_the_rule_actually_matches():
+    """안 잡히는 규칙은 없는 것과 같다."""
+    bad = ast.parse(
+        "app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_credentials=True)"
+    )
+    calls = list(_cors_calls(bad))
+    assert calls, "CORSMiddleware 호출 자체를 못 찾으면 이 시험은 늘 초록이다"
+
+    good = ast.parse(
+        "app.add_middleware(CORSMiddleware, "
+        "allow_origins=['https://studywithtymee.com'], allow_credentials=True)"
+    )
+    origins = _keyword(list(_cors_calls(good))[0], "allow_origins")
+    assert not any(
+        isinstance(e, ast.Constant) and e.value == "*" for e in origins.elts
+    ), "명시한 origin 까지 잡으면 고칠 방법이 없어진다"

--- a/docs/ops/23-cors-for-nobody.md
+++ b/docs/ops/23-cors-for-nobody.md
@@ -1,0 +1,69 @@
+# 23. 존재하지 않는 사용자를 위한 위험한 기본값 (#179)
+
+파이썬 AI 서비스에 이 설정이 있었다.
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"], allow_credentials=True,
+    allow_methods=["*"], allow_headers=["*"],
+)
+```
+
+---
+
+## 이 조합이 왜 위험한가
+
+`*` 를 쓰면 자격증명이 안 실린다고 알고 있는 사람이 많다.
+그건 브라우저가 `Access-Control-Allow-Origin: *` 를 **받았을 때**의 이야기다.
+
+Starlette 은 이 조합에서 `*` 를 보내지 않는다.
+
+```python
+# starlette/middleware/cors.py
+if self.allow_all_origins and has_cookie:
+    self.allow_explicit_origin(headers, origin)
+```
+
+쿠키가 붙은 요청에 대해 **요청이 보낸 origin 을 그대로 되돌려 준다.**
+브라우저 입장에서는 "이 사이트는 허용됨" 이 된다 —
+즉 **아무 사이트나 이 API 를 인증된 채로 부를 수 있다.**
+
+---
+
+## 고치지 않고 지웠다
+
+고치려면 허용할 origin 을 적으면 된다. 그런데 적을 origin 이 없었다.
+
+| | |
+|---|---|
+| 프론트 코드 | 이 서비스를 부르는 곳이 **없다** |
+| nginx | 이 서비스로 보내는 `location` 이 **없다** |
+| compose | `expose` 만 한다. 호스트 포트를 **안 연다** |
+
+부르는 것은 백엔드뿐이고, **서버 간 호출에는 CORS 가 관여하지 않는다.**
+브라우저가 보내는 `Origin` 헤더를 보고 브라우저에게 답하는 규칙이기 때문이다.
+
+이 설정은 **존재하지 않는 사용자를 위한 것**이었다.
+존재하지 않는 사용자를 위해 위험한 기본값을 들고 있을 이유가 없다.
+
+[`07-declared-but-unused.md`](07-declared-but-unused.md) 의 뒤집힌 모양이다 —
+지금까지는 "선언은 있는데 안 쓴다" 였는데, 이건 **"쓰는 사람이 없는데 문은 열려 있다"** 다.
+
+---
+
+## 지우고 나서 문을 잠갔다
+
+지우는 것만으로는 끝이 아니다. 나중에 브라우저가 정말 필요해지면 누군가 다시 넣을 것이고,
+**가장 먼저 붙여 보는 값이 `*` 다** — 그게 제일 빨리 동작하기 때문이다.
+
+`tests/test_no_wildcard_cors.py` 가 그 순간을 막는다.
+CORS 를 못 쓰게 하는 것이 아니라 **와일드카드와 자격증명을 같이 쓰는 것**만 막는다.
+
+```
+allow_origins=['*'] + allow_credentials=True     -> 빨강
+allow_origins=['https://...'] + credentials      -> 초록
+```
+
+규칙을 넣고 **위반을 심어 실제로 빨개지는지 먼저 확인했다.**
+안 잡히는 규칙은 없는 것보다 나쁘다 — 있다고 믿게 만들기 때문이다.


### PR DESCRIPTION
파이썬 AI 서비스에 이 설정이 있었다.

```python
allow_origins=["*"], allow_credentials=True
```

## 이 조합이 왜 위험한가

`*` 를 쓰면 자격증명이 안 실린다고 알기 쉽다. 그건 브라우저가
`Access-Control-Allow-Origin: *` 를 **받았을 때**의 이야기다.

Starlette 은 이 조합에서 `*` 를 보내지 않는다.

```python
# starlette/middleware/cors.py
if self.allow_all_origins and has_cookie:
    self.allow_explicit_origin(headers, origin)
```

쿠키가 붙은 요청에 **요청이 보낸 origin 을 그대로 되돌려 준다.**
브라우저에게는 "이 사이트는 허용됨" 이 된다 — 아무 사이트나 이 API 를 인증된 채로 부를 수 있다.

## 고치지 않고 지웠다

고치려면 허용할 origin 을 적으면 된다. **적을 origin 이 없었다.**

| | |
|---|---|
| 프론트 코드 | 이 서비스를 부르는 곳이 없다 |
| nginx | 이 서비스로 보내는 `location` 이 없다 |
| compose | `expose` 만 한다. 호스트 포트를 안 연다 |

부르는 것은 백엔드뿐이고 **서버 간 호출에는 CORS 가 관여하지 않는다.**
이 설정은 **존재하지 않는 사용자를 위한 것**이었다.

`07-declared-but-unused.md` 의 뒤집힌 모양이다 — 지금까지는 "선언은 있는데 안 쓴다" 였는데,
이건 **"쓰는 사람이 없는데 문은 열려 있다"** 다.

## 지우고 나서 문을 잠갔다

나중에 브라우저가 필요해지면 누군가 다시 넣을 텐데, **가장 먼저 붙여 보는 값이 `*`** 다.
`test_no_wildcard_cors.py` 는 CORS 를 못 쓰게 하는 게 아니라
**와일드카드와 자격증명을 같이 쓰는 것**만 막는다.

```
allow_origins=['*'] + allow_credentials=True     -> 빨강
allow_origins=['https://...'] + credentials      -> 초록
```

위반을 심어 실제로 빨개지는지 먼저 확인했다. 파이썬 시험 105 → 107, 전부 통과.

기록: `docs/ops/23-cors-for-nobody.md`